### PR TITLE
PoolRegistry: mapping for comptroller to poolIndex

### DIFF
--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -88,9 +88,9 @@ contract PoolRegistry is OwnableUpgradeable {
     uint256 private _numberOfPools;
 
     /**
-     * @dev Maps comptroller address to Venus pool.
-     */
-    mapping(address => VenusPool) private _poolByComptroller;
+    * @dev Maps comptroller address to Venus pool Index.
+    */
+    mapping(address => uint256) private _poolByComptroller;
 
     /**
      * @dev Maps Ethereum accounts to arrays of Venus pool Comptroller proxy contract addresses.
@@ -146,12 +146,12 @@ contract PoolRegistry is OwnableUpgradeable {
         internal
         returns (uint256)
     {
-        VenusPool memory venusPool = _poolByComptroller[comptroller];
-
-        require(
-            venusPool.creator == address(0),
+        VenusPool memory venusPool = _poolsByID[_poolByComptroller[comptroller]];
+        
+        require(venusPool.creator == address(0),
             "RegistryPool: Pool already exists in the directory."
         );
+        
         require(bytes(name).length <= 100, "No pool name supplied.");
 
         _numberOfPools++;
@@ -166,7 +166,7 @@ contract PoolRegistry is OwnableUpgradeable {
         );
 
         _poolsByID[_numberOfPools] = pool;
-        _poolByComptroller[comptroller] = pool;
+        _poolByComptroller[comptroller] = _numberOfPools;
 
         emit PoolRegistered(_numberOfPools, pool);
         return _numberOfPools;
@@ -281,13 +281,24 @@ contract PoolRegistry is OwnableUpgradeable {
 
     /**
      * @param comptroller The Comptroller implementation address.
-     * @notice Returns Venus pool Unitroller (Comptroller proxy) contract addresses.
+     * @notice Returns Venus pool.
      */
-
     function getPoolByComptroller(address comptroller)
         external
         view
         returns (VenusPool memory)
+    {
+        return _poolsByID[_poolByComptroller[comptroller]];
+    }
+
+    /**
+     * @param comptroller The Comptroller implementation address.
+     * @notice Returns poolID.
+     */
+    function getPoolIDByComptroller(address comptroller)
+        external
+        view
+        returns (uint256)
     {
         return _poolByComptroller[comptroller];
     }

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -170,7 +170,7 @@ describe("PoolRegistry: Tests", async function () {
     expect(pool.name).equal("Pool 2");
   });
 
-  // Get all pool by the comptroller address.
+  // Get pool by the comptroller address.
   it("Get pool by comptroller", async function () {
     const pool1 = await poolRegistry.getPoolByComptroller(
       comptroller1Proxy.address
@@ -183,6 +183,19 @@ describe("PoolRegistry: Tests", async function () {
     );
     expect(pool2[0]).equal(2);
     expect(pool2[1]).equal("Pool 2");
+  });
+
+  // Get poolID by the comptroller address.
+  it("Get poolID by comptroller", async function () {
+    const poolIndex1 = await poolRegistry.getPoolIDByComptroller(
+      comptroller1Proxy.address
+    );
+    expect(poolIndex1).equal(1);
+
+    const poolIndex2 = await poolRegistry.getPoolIDByComptroller(
+      comptroller2Proxy.address
+    );
+    expect(poolIndex2).equal(2);
   });
 
   it("Deploy Mock Tokens", async function () {


### PR DESCRIPTION
## Description

- Update existing mapping of comptroller -> VenusPool to comptroller -> poolIndex
- VenusPool Lookup can be done via Pool Array and poolIndex
- Fix Unit tests

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
