### PR TITLE
poolRegistry Refactor: Add poolId to VenusPool Struct

### DIFF
--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -43,6 +43,7 @@ contract PoolRegistry is OwnableUpgradeable {
      * @dev Struct for a Venus interest rate pool.
      */
     struct VenusPool {
+        uint256 poolId;
         string name;
         address creator;
         address comptroller;
@@ -152,14 +153,17 @@ contract PoolRegistry is OwnableUpgradeable {
             "RegistryPool: Pool already exists in the directory."
         );
         require(bytes(name).length <= 100, "No pool name supplied.");
+
+        _numberOfPools++;
+        
         VenusPool memory pool = VenusPool(
+            _numberOfPools,
             name,
             msg.sender,
             comptroller,
             block.number,
             block.timestamp
         );
-        _numberOfPools++;
 
         _poolsByID[_numberOfPools] = pool;
         _poolByComptroller[comptroller] = pool;

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -175,12 +175,14 @@ describe("PoolRegistry: Tests", async function () {
     const pool1 = await poolRegistry.getPoolByComptroller(
       comptroller1Proxy.address
     );
-    expect(pool1[0]).equal("Pool 1");
+    expect(pool1[0]).equal(1);
+    expect(pool1[1]).equal("Pool 1");
 
     const pool2 = await poolRegistry.getPoolByComptroller(
       comptroller2Proxy.address
     );
-    expect(pool2[0]).equal("Pool 2");
+    expect(pool2[0]).equal(2);
+    expect(pool2[1]).equal("Pool 2");
   });
 
   it("Deploy Mock Tokens", async function () {


### PR DESCRIPTION
## context
This is to get access to PoolId when a lookup of VenusPool is done from mapping

## Description
- Add poolId to VenusPool Struct
- set poolId in the struct in the body of _registerPool function call
- numberOfPools storage is incremented followed the numberOfPools value set as poolId
- Add assertions on poolId property in PoolRegistry.ts unitTest

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
