### PR TITLE
refactor: replace index with comptroller address to identify pool

### DIFF
--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -136,7 +136,7 @@ contract PoolRegistry is OwnableUpgradeable {
     /**
      * @dev Emitted when a pool name is set.
      */
-    event PoolNameSet(uint256 index, string name);
+    event PoolNameSet(address comptroller, string name);
 
     /**
      * @dev Adds a new Venus pool to the directory (without checking msg.sender).
@@ -246,7 +246,7 @@ contract PoolRegistry is OwnableUpgradeable {
         require(msg.sender == _comptroller.admin() || msg.sender == owner());
 
         _poolsByID[poolId].name = name;
-        emit PoolNameSet(poolId, name);
+        emit PoolNameSet(address(_comptroller), name);
     }
 
     /**


### PR DESCRIPTION
## Description

Updates PoolNameSet event to send comptroller address instead of pool index

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
