### PR TITLE
Copy contracts to resolve build info conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ secrets.json
 
 # Build
 dist
+
+contracts/oracle/*

--- a/copy_contracts.sh
+++ b/copy_contracts.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+# For convience we are going to copy contracts locally
+
+rm -rf ./contracts/oracle
+mkdir -p ./contracts/oracle
+cp -rf ./node_modules/@venusprotocol/oracle/contracts/ ./contracts/oracle

--- a/deploy/001-deploy-pool-registry.ts
+++ b/deploy/001-deploy-pool-registry.ts
@@ -3,7 +3,6 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { DeployResult } from "hardhat-deploy/dist/types";
 import { ethers } from "hardhat";
 import { convertToUnit } from "../helpers/utils";
-import { MockToken } from "../typechain";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
@@ -76,7 +75,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   });
   
   
-  const BUSD: MockToken = await ethers.getContract("MockBUSD");
+  const BUSD = await ethers.getContract("MockBUSD");
 
   await deploy('Shortfall', {
     from: deployer,

--- a/deploy/002-deploy-pools.ts
+++ b/deploy/002-deploy-pools.ts
@@ -3,10 +3,6 @@ import { DeployFunction } from "hardhat-deploy/types";
 import { DeployResult } from "hardhat-deploy/dist/types";
 import { ethers } from "hardhat";
 import { convertToUnit } from "../helpers/utils";
-import { MockToken } from "../typechain";
-import { AccessControlManager } from "../typechain/AccessControlManager";
-import { VBep20Immutable } from "../typechain/VBep20Immutable";
-import { PoolRegistry } from "../typechain/PoolRegistry";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts }: any = hre;
@@ -23,7 +19,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     autoMine: true, // speed up deployment on local network (ganache, hardhat), no effect on live networks
   });
 
-  const wBTC: MockToken = await ethers.getContract("MockBTC");
+  const wBTC = await ethers.getContract("MockBTC");
 
   await deploy("MockDAI", {
     from: deployer,
@@ -33,7 +29,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     autoMine: true,
   });
 
-  const DAI: MockToken = await ethers.getContract("MockDAI");
+  const DAI = await ethers.getContract("MockDAI");
 
   let priceOracle;
 
@@ -50,9 +46,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const closeFactor = convertToUnit(0.05, 18);
   const liquidationIncentive = convertToUnit(1, 18);
 
-  const poolRegistry: PoolRegistry= await ethers.getContract("PoolRegistry");
+  const poolRegistry = await ethers.getContract("PoolRegistry");
 
-  const accessControlManager: AccessControlManager = await ethers.getContract("AccessControlManager");
+  const accessControlManager = await ethers.getContract("AccessControlManager");
 
   const Pool1Comptroller: DeployResult = await deploy("Pool 1", {
     contract: "Comptroller",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -209,13 +209,6 @@ const config: HardhatUserConfig = {
     acc1:1,
     acc2:2,
   },
-  external: {
-    contracts: [
-      {
-        artifacts: `${__dirname}/node_modules/@venusprotocol/oracle/artifacts/`,
-      },
-    ],
-  }
 };
 
 function isFork() {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint:sol:fix": "prettier --write \"contracts/**/*.sol\"",
     "build": "rm -rf dist && tsc --declaration && hardhat compile && cp -r ./{package.json,yarn.lock,artifacts,networks,contracts,deployments} dist/",
     "publish:dist": "yarn build && yarn publish dist -f --access public",
-    "hardhat:coverage-validator": "./script/coverageValidator.sh"
+    "hardhat:coverage-validator": "./script/coverageValidator.sh",
+    "postinstall": "./copy_contracts.sh"
   },
   "repository": {
     "type": "git",
@@ -48,7 +49,7 @@
     "@types/node": "^12.20.50",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
-    "@venusprotocol/oracle": "^1.1.3",
+    "@venusprotocol/oracle": "^1.2.0",
     "bignumber.js": "9.0.0",
     "chai": "^4.3.6",
     "dotenv": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,10 +1262,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@venusprotocol/oracle@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/@venusprotocol/oracle/-/oracle-1.1.3.tgz#ac7ea322494ef77a1d3a5d124de13aa541259de6"
-  integrity sha512-vA/6hN8V1YYG4xpzHJCDVyv8IkNwTmKv7lnTeF9lCxTeQ+vVNaQLvv7unEtsZYqJ2on9hqmmFBRJQORS75QGLw==
+"@venusprotocol/oracle@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@venusprotocol/oracle/-/oracle-1.2.0.tgz#3789bc21a2b94568f549f6d1c690be13099ecd85"
+  integrity sha512-uALKoTasx885G+rv2mrrc4xosAosAL58PjpS62EGEmif+wE0c+pfXN+U1bnu23FUk4LyajtqK3zkcK8o2wRuYw==
   dependencies:
     "@openzeppelin/contracts" "^4.6.0"
     "@openzeppelin/contracts-upgradeable" "^4.7.3"


### PR DESCRIPTION
## Description
When running deploy scripts there is a discrepency with the build info included in the oracle package
and the build info hash generated when running the deploy scripts.

To get around this, after installing the contracts are copied directly from node_modules
