### PR TITLE
Emit poolid with name set event

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN wget https://github.com/ethereum/solidity/releases/download/v0.8.13/solc-sta
 RUN mkdir -p /usr/app
 WORKDIR /usr/app
 
+ENV NODE_OPTIONS=--max-old-space-size=4096 
+
 # First add deps
 RUN npm install -g yarn
 

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -156,7 +156,7 @@ contract PoolRegistry is OwnableUpgradeable {
     /**
      * @dev Emitted when a pool name is set.
      */
-    event PoolNameSet(address comptroller, string name);
+    event PoolNameSet(uint256 index, string name);
 
     /**
      * @dev Emitted when a pool metadata is updated.
@@ -278,7 +278,7 @@ contract PoolRegistry is OwnableUpgradeable {
         require(msg.sender == _comptroller.admin() || msg.sender == owner());
 
         _poolsByID[poolId].name = name;
-        emit PoolNameSet(address(_comptroller), name);
+        emit PoolNameSet(poolId, name);
     }
 
     /**

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -258,7 +258,9 @@ describe("PoolRegistry: Tests", function () {
   });
 
   it("Should change pool name", async function () {
-    await poolRegistry.setPoolName(1, "Pool 1 updated");
+    await expect(poolRegistry.setPoolName(1, "Pool 1 updated"))
+      .to.emit(poolRegistry, "PoolNameSet")
+      .withArgs(1, "Pool 1 updated");
     const pools = await poolRegistry.callStatic.getAllPools();
     expect(pools[0].name).equal("Pool 1 updated");
     await poolRegistry.setPoolName(1, "Pool 1");


### PR DESCRIPTION
## Description

Events related to the pool should emit the same identifier for consistency. This id needs to match the id in the subgraph for easy querying. 

Since other events emit the pool index it is logic to use this as the id and emit it with all pool events. This PR updates the pool name set event to use the index as the identifier