### PR TITLE
refactor: make pool idx internal, comptroller as id

### DIFF
--- a/contracts/Lens/PoolLens.sol
+++ b/contracts/Lens/PoolLens.sol
@@ -16,7 +16,6 @@ contract PoolLens is ExponentialNoError {
     * @dev Struct for PoolDetails.
     */
     struct PoolData {
-        uint256 poolId;
         string name;
         address creator;
         address comptroller;
@@ -68,15 +67,12 @@ contract PoolLens is ExponentialNoError {
 
             PoolRegistryInterface poolRegistryInterface = PoolRegistryInterface(poolRegistryAddress);
 
-            uint256 poolId = poolRegistryInterface.getPoolIDByComptroller(venusPool.comptroller);
-
             //get PoolMetada via lookup on comptrollerAddress to poolId and then poolId to poolMetadata
-            PoolRegistry.VenusPoolMetaData memory venusPoolMetaData = poolRegistryInterface.getVenusPoolMetadata(poolId);
+            PoolRegistry.VenusPoolMetaData memory venusPoolMetaData = poolRegistryInterface.getVenusPoolMetadata(venusPool.comptroller);
 
             ComptrollerViewInterface comptrollerViewInstance = ComptrollerViewInterface(venusPool.comptroller);
 
             PoolData memory poolData = PoolData({
-                poolId: venusPool.poolId,
                 name: venusPool.name,
                 creator: venusPool.creator,
                 comptroller: venusPool.comptroller,
@@ -109,13 +105,13 @@ contract PoolLens is ExponentialNoError {
 
     /**
     * @param poolRegistryAddress The address of Pool.
-    * @param poolId The poolIndex.  
+    * @param comptroller The pool comptroller.
     * @param asset The underlyingAsset of VToken.
     * @notice Returns VToken in a Pool for an Asset.
     */
-    function getVTokenForAsset(address poolRegistryAddress, uint poolId, address asset) external view returns (address) {
+    function getVTokenForAsset(address poolRegistryAddress, address comptroller, address asset) external view returns (address) {
         PoolRegistryInterface poolRegistryInterface = PoolRegistryInterface(poolRegistryAddress);
-        return poolRegistryInterface.getVTokenForAsset(poolId, asset);
+        return poolRegistryInterface.getVTokenForAsset(comptroller, asset);
     }
 
     /**

--- a/contracts/Pool/PoolRegistryInterface.sol
+++ b/contracts/Pool/PoolRegistryInterface.sol
@@ -9,24 +9,18 @@ abstract contract PoolRegistryInterface {
     /*** get All Pools in PoolRegistry ***/
     function getAllPools() virtual external view returns (PoolRegistry.VenusPool[] memory);
 
-    /*** get a Pool by PoolIndex ***/
-    function getPoolByID(uint256 index) virtual external view returns (PoolRegistry.VenusPool memory);
-
     /*** get a Pool by comptrollerAddress ***/
     function getPoolByComptroller(address comptroller) virtual external view returns (PoolRegistry.VenusPool memory);
-
-    /*** get a PoolId by comptrollerAddress ***/
-    function getPoolIDByComptroller(address comptroller) virtual external view returns (uint256);
 
     /*** get all Bookmarks made by an account ***/
     function getBookmarks(address account) virtual external view returns (address[] memory);
 
     /*** get VToken in the Pool for an Asset ***/
-    function getVTokenForAsset(uint poolId, address asset) virtual external view returns (address);
+    function getVTokenForAsset(address comptroller, address asset) virtual external view returns (address);
 
     /*** get Pools supported by Asset ***/
     function getPoolsSupportedByAsset(address asset) virtual external view returns (uint256[] memory);
 
-    /*** get metadata of a Pool by poolId ***/
-    function getVenusPoolMetadata(uint256 poolId) virtual external view returns (PoolRegistry.VenusPoolMetaData memory);
+    /*** get metadata of a Pool by comptroller ***/
+    function getVenusPoolMetadata(address comptroller) virtual external view returns (PoolRegistry.VenusPoolMetaData memory);
 }

--- a/contracts/RiskFund/IRiskFund.sol
+++ b/contracts/RiskFund/IRiskFund.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.10;
 interface IRiskFund {
     function swapAllPoolsAssets() external returns (uint256);
 
-    function getPoolReserve(uint256 poolId) external view returns (uint256);
+    function getPoolReserve(address comptroller) external view returns (uint256);
 
-    function transferReserveForAuction(uint256 poolId, uint256 amount)
+    function transferReserveForAuction(address comptroller, uint256 amount)
         external
         returns (uint256);
 }

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -178,7 +178,7 @@ describe("PoolRegistry: Tests", function () {
 
     // Deploy VTokens
     await poolRegistry.addMarket({
-      poolId: 1,
+      comptroller: comptroller1Proxy.address,
       asset: mockWBTC.address,
       decimals: 8,
       name: "Compound WBTC",
@@ -196,7 +196,7 @@ describe("PoolRegistry: Tests", function () {
     });
 
     await poolRegistry.addMarket({
-      poolId: 1,
+      comptroller: comptroller1Proxy.address,
       asset: mockDAI.address,
       decimals: 18,
       name: "Compound DAI",
@@ -214,11 +214,11 @@ describe("PoolRegistry: Tests", function () {
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(
-      1,
+      comptroller1Proxy.address,
       mockWBTC.address
     );
     const vDAIAddress = await poolRegistry.getVTokenForAsset(
-      1,
+      comptroller1Proxy.address,
       mockDAI.address
     );
 
@@ -247,12 +247,12 @@ describe("PoolRegistry: Tests", function () {
   });
 
   it("Should change pool name", async function () {
-    await expect(poolRegistry.setPoolName(1, "Pool 1 updated"))
+    await expect(poolRegistry.setPoolName(comptroller1Proxy.address, "Pool 1 updated"))
       .to.emit(poolRegistry, "PoolNameSet")
-      .withArgs(1, "Pool 1 updated");
+      .withArgs(comptroller1Proxy.address, "Pool 1 updated");
     const pools = await poolRegistry.callStatic.getAllPools();
     expect(pools[0].name).equal("Pool 1 updated");
-    await poolRegistry.setPoolName(1, "Pool 1");
+    await poolRegistry.setPoolName(comptroller1Proxy.address, "Pool 1");
   });
 
   it("Bookmark pool and get the bookmarked pools", async function () {
@@ -265,12 +265,6 @@ describe("PoolRegistry: Tests", function () {
 
     expect(bookmarkedPools.length).equal(1);
     expect(bookmarkedPools[0]).equal(pools[0].comptroller);
-  });
-
-  it("Should get pool by pools index", async function () {
-    const pool = await poolRegistry.getPoolByID(2);
-
-    expect(pool.name).equal("Pool 2");
   });
 
   it("Get pool by comptroller", async function () {
@@ -287,18 +281,6 @@ describe("PoolRegistry: Tests", function () {
     expect(pool2[1]).equal("Pool 2");
   });
 
-  it("Should get poolID by comptroller", async function () {
-    const poolIndex1 = await poolRegistry.getPoolIDByComptroller(
-      comptroller1Proxy.address
-    );
-    expect(poolIndex1).equal(1);
-
-    const poolIndex2 = await poolRegistry.getPoolIDByComptroller(
-      comptroller2Proxy.address
-    );
-    expect(poolIndex2).equal(2);
-  });
-
   it("Should be correct balances in tokens", async function () {
     const [owner] = await ethers.getSigners();
     await mockWBTC.faucet(convertToUnit(1000, 8));
@@ -313,7 +295,7 @@ describe("PoolRegistry: Tests", function () {
   // Get all pools that support a given asset
   it("Get pools with asset", async function () {
     const pools = await poolRegistry.getPoolsSupportedByAsset(mockWBTC.address);
-    expect(pools[0].toString()).equal("1");
+    expect(pools[0].toString()).equal(comptroller1Proxy.address);
   });
 
   it("Enter Market", async function () {
@@ -328,7 +310,7 @@ describe("PoolRegistry: Tests", function () {
     const category = "High market cap";
     const logoURL = "http://venus.io/pool1";
     const description = "An sample description";
-    const oldMetadata = await poolRegistry.metadata(0);
+    const oldMetadata = await poolRegistry.metadata(comptroller1Proxy.address);
     const newMetadata = {
       riskRating,
       category,
@@ -336,11 +318,11 @@ describe("PoolRegistry: Tests", function () {
       description,
     };
 
-    await expect(poolRegistry.updatePoolMetadata(0, newMetadata))
+    await expect(poolRegistry.updatePoolMetadata(comptroller1Proxy.address, newMetadata))
       .to.emit(poolRegistry, "PoolMetadataUpdated")
-      .withArgs(0, oldMetadata, [riskRating, category, logoURL, description]);
+      .withArgs(comptroller1Proxy.address, oldMetadata, [riskRating, category, logoURL, description]);
 
-    const metadata = await poolRegistry.metadata(0);
+    const metadata = await poolRegistry.metadata(comptroller1Proxy.address);
     expect(metadata.riskRating).equal(riskRating);
     expect(metadata.category).equal(category);
     expect(metadata.logoURL).equal(logoURL);

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -175,7 +175,7 @@ describe("Rewards: Tests", async function () {
 
     //Deploy VTokens
     await poolRegistry.addMarket({
-      poolId: 1,
+      comptroller: comptrollerProxy.address,
       asset: mockWBTC.address,
       decimals: 8,
       name: "Compound WBTC",
@@ -193,7 +193,7 @@ describe("Rewards: Tests", async function () {
     });
 
     await poolRegistry.addMarket({
-      poolId: 1,
+      comptroller: comptrollerProxy.address,
       asset: mockDAI.address,
       decimals: 18,
       name: "Compound DAI",
@@ -211,11 +211,11 @@ describe("Rewards: Tests", async function () {
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(
-      1,
+      comptrollerProxy.address,
       mockWBTC.address
     );
     const vDAIAddress = await poolRegistry.getVTokenForAsset(
-      1,
+      comptrollerProxy.address,
       mockDAI.address
     );
 

--- a/tests/hardhat/UpgradedVBEP20.ts
+++ b/tests/hardhat/UpgradedVBEP20.ts
@@ -141,7 +141,7 @@ describe("UpgradedVBEP20: Tests", function () {
 
     // Deploy VTokens
     await poolRegistry.addMarket({
-      poolId: 1,
+      comptroller: pools[0].comptroller,
       asset: mockWBTC.address,
       decimals: 8,
       name: "Compound WBTC",
@@ -159,7 +159,7 @@ describe("UpgradedVBEP20: Tests", function () {
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(
-      1,
+      pools[0].comptroller,
       mockWBTC.address
     );
 

--- a/tests/hardhat/lens/PoolLens.ts
+++ b/tests/hardhat/lens/PoolLens.ts
@@ -172,56 +172,6 @@ describe("PoolLens - PoolView Tests", async function () {
     const tokenImplementation = await VBep20Immutable.deploy();
     await tokenImplementation.deployed();
 
-    await poolRegistry.addMarket({
-      poolId: 1,
-      asset: mockWBTC.address,
-      decimals: 8,
-      name: "Compound WBTC",
-      symbol: "vWBTC",
-      rateModel: 0,
-      baseRatePerYear: 0,
-      multiplierPerYear: "40000000000000000",
-      jumpMultiplierPerYear: 0,
-      kink_: 0,
-      collateralFactor: convertToUnit(0.7, 18),
-      liquidationThreshold: convertToUnit(0.7, 18),
-      accessControlManager: fakeAccessControlManager.address,
-      vTokenProxyAdmin: proxyAdmin.address,
-      tokenImplementation_: tokenImplementation.address,
-    });
-
-    await poolRegistry.addMarket({
-      poolId: 1,
-      asset: mockDAI.address,
-      decimals: 18,
-      name: "Compound DAI",
-      symbol: "vDAI",
-      rateModel: 0,
-      baseRatePerYear: 0,
-      multiplierPerYear: "40000000000000000",
-      jumpMultiplierPerYear: 0,
-      kink_: 0,
-      collateralFactor: convertToUnit(0.7, 18),
-      liquidationThreshold: convertToUnit(0.7, 18),
-      accessControlManager: fakeAccessControlManager.address,
-      vTokenProxyAdmin: proxyAdmin.address,
-      tokenImplementation_: tokenImplementation.address,
-    });
-
-    await poolRegistry.updatePoolMetadata(1, {
-      riskRating: 2,
-      category: "Hign market cap",
-      logoURL: "http://venis.io/pool1",
-      description: "Pool1 description",
-    });
-
-    await poolRegistry.updatePoolMetadata(2, {
-      riskRating: 0,
-      category: "Low market cap",
-      logoURL: "http://highrisk.io/pool2",
-      description: "Pool2 description",
-    });
-
     // Get all pools list.
     const pools = await poolRegistry.callStatic.getAllPools();
     expect(pools[0].name).equal("Pool 1");
@@ -249,13 +199,63 @@ describe("PoolLens - PoolView Tests", async function () {
     );
     await unitroller2._acceptAdmin();
 
+    await poolRegistry.addMarket({
+      comptroller: comptroller1Proxy.address,
+      asset: mockWBTC.address,
+      decimals: 8,
+      name: "Compound WBTC",
+      symbol: "vWBTC",
+      rateModel: 0,
+      baseRatePerYear: 0,
+      multiplierPerYear: "40000000000000000",
+      jumpMultiplierPerYear: 0,
+      kink_: 0,
+      collateralFactor: convertToUnit(0.7, 18),
+      liquidationThreshold: convertToUnit(0.7, 18),
+      accessControlManager: fakeAccessControlManager.address,
+      vTokenProxyAdmin: proxyAdmin.address,
+      tokenImplementation_: tokenImplementation.address,
+    });
+
+    await poolRegistry.addMarket({
+      comptroller: comptroller1Proxy.address,
+      asset: mockDAI.address,
+      decimals: 18,
+      name: "Compound DAI",
+      symbol: "vDAI",
+      rateModel: 0,
+      baseRatePerYear: 0,
+      multiplierPerYear: "40000000000000000",
+      jumpMultiplierPerYear: 0,
+      kink_: 0,
+      collateralFactor: convertToUnit(0.7, 18),
+      liquidationThreshold: convertToUnit(0.7, 18),
+      accessControlManager: fakeAccessControlManager.address,
+      vTokenProxyAdmin: proxyAdmin.address,
+      tokenImplementation_: tokenImplementation.address,
+    });
+
+    await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {
+      riskRating: 2,
+      category: "Hign market cap",
+      logoURL: "http://venis.io/pool1",
+      description: "Pool1 description",
+    });
+
+    await poolRegistry.updatePoolMetadata(comptroller2Proxy.address, {
+      riskRating: 0,
+      category: "Low market cap",
+      logoURL: "http://highrisk.io/pool2",
+      description: "Pool2 description",
+    });
+
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(
-      1,
+      comptroller1Proxy.address,
       mockWBTC.address
     );
     const vDAIAddress = await poolRegistry.getVTokenForAsset(
-      1,
+      comptroller1Proxy.address,
       mockDAI.address
     );
 
@@ -282,25 +282,24 @@ describe("PoolLens - PoolView Tests", async function () {
 
     const venusPool_1_Actual = poolData[0];
 
-    expect(venusPool_1_Actual[0]).equal(1);
-    expect(venusPool_1_Actual[1]).equal("Pool 1");
-    expect(venusPool_1_Actual[2]).equal(ownerAddress);
-    expect(venusPool_1_Actual[3]).equal(comptroller1Proxy.address);
-    expect(venusPool_1_Actual[6]).equal(2);
-    expect(venusPool_1_Actual[7]).equal("Hign market cap");
-    expect(venusPool_1_Actual[8]).equal("http://venis.io/pool1");
-    expect(venusPool_1_Actual[9]).equal("Pool1 description");
-    expect(venusPool_1_Actual[10]).equal(priceOracle.address);
-    expect(venusPool_1_Actual[11]).equal(closeFactor1);
-    expect(venusPool_1_Actual[12]).equal(liquidationIncentive1);
-    expect(venusPool_1_Actual[13]).equal(0);
+    expect(venusPool_1_Actual[0]).equal("Pool 1");
+    expect(venusPool_1_Actual[1]).equal(ownerAddress);
+    expect(venusPool_1_Actual[2]).equal(comptroller1Proxy.address);
+    expect(venusPool_1_Actual[5]).equal(2);
+    expect(venusPool_1_Actual[6]).equal("Hign market cap");
+    expect(venusPool_1_Actual[7]).equal("http://venis.io/pool1");
+    expect(venusPool_1_Actual[8]).equal("Pool1 description");
+    expect(venusPool_1_Actual[9]).equal(priceOracle.address);
+    expect(venusPool_1_Actual[10]).equal(closeFactor1);
+    expect(venusPool_1_Actual[11]).equal(liquidationIncentive1);
+    expect(venusPool_1_Actual[12]).equal(0);
 
-    const vTokens_Actual = venusPool_1_Actual[14];
+    const vTokens_Actual = venusPool_1_Actual[13];
     expect(vTokens_Actual.length).equal(2);
 
     // get VToken for Asset-1 : WBTC
     const vTokenAddress_WBTC = await poolRegistry.getVTokenForAsset(
-      1,
+      comptroller1Proxy.address,
       mockWBTC.address
     );
     const vTokenMetadata_WBTC_Expected = await poolLens.vTokenMetadata(
@@ -313,24 +312,24 @@ describe("PoolLens - PoolView Tests", async function () {
     );
 
     // get VToken for Asset-2 : DAI
-    const vTokenAddress_DAI = await poolRegistry.getVTokenForAsset(1, mockDAI.address);
+    const vTokenAddress_DAI = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, mockDAI.address);
     const vTokenMetadata_DAI_Expected = await poolLens.vTokenMetadata(vTokenAddress_DAI);
     const vTokenMetadata_DAI_Actual = vTokens_Actual[1];
     assertVTokenMetadata(vTokenMetadata_DAI_Actual, vTokenMetadata_DAI_Expected);
 
     const venusPool_2_Actual = poolData[1];
-    expect(venusPool_2_Actual[0]).equal(2);
-    expect(venusPool_2_Actual[1]).equal("Pool 2");
-    expect(venusPool_2_Actual[2]).equal(ownerAddress);
-    expect(venusPool_2_Actual[3]).equal(comptroller2Proxy.address);
-    expect(venusPool_2_Actual[6]).equal(0);
-    expect(venusPool_2_Actual[7]).equal("Low market cap");
-    expect(venusPool_2_Actual[8]).equal("http://highrisk.io/pool2");
-    expect(venusPool_2_Actual[9]).equal("Pool2 description");
-    expect(venusPool_1_Actual[10]).equal(priceOracle.address);
-    expect(venusPool_1_Actual[11]).equal(closeFactor2);
-    expect(venusPool_1_Actual[12]).equal(liquidationIncentive2);
-    expect(venusPool_1_Actual[13]).equal(0);
+    // expect(venusPool_2_Actual[0]).equal(2);
+    expect(venusPool_2_Actual[0]).equal("Pool 2");
+    expect(venusPool_2_Actual[1]).equal(ownerAddress);
+    expect(venusPool_2_Actual[2]).equal(comptroller2Proxy.address);
+    expect(venusPool_2_Actual[5]).equal(0);
+    expect(venusPool_2_Actual[6]).equal("Low market cap");
+    expect(venusPool_2_Actual[7]).equal("http://highrisk.io/pool2");
+    expect(venusPool_2_Actual[8]).equal("Pool2 description");
+    expect(venusPool_1_Actual[9]).equal(priceOracle.address);
+    expect(venusPool_1_Actual[10]).equal(closeFactor2);
+    expect(venusPool_1_Actual[11]).equal(liquidationIncentive2);
+    expect(venusPool_1_Actual[12]).equal(0);
   });
 
   it("getPoolData By Comptroller", async function () {
@@ -339,25 +338,25 @@ describe("PoolLens - PoolView Tests", async function () {
       comptroller1Proxy.address
     );
 
-    expect(poolData[0]).equal(1);
-    expect(poolData[1]).equal("Pool 1");
-    expect(poolData[2]).equal(ownerAddress);
-    expect(poolData[3]).equal(comptroller1Proxy.address);
-    expect(poolData[6]).equal(2);
-    expect(poolData[7]).equal("Hign market cap");
-    expect(poolData[8]).equal("http://venis.io/pool1");
-    expect(poolData[9]).equal("Pool1 description");
-    expect(poolData[10]).equal(priceOracle.address);
-    expect(poolData[11]).equal(closeFactor1);
-    expect(poolData[12]).equal(liquidationIncentive1);
-    expect(poolData[13]).equal(0);
+    // expect(poolData[0]).equal(1);
+    expect(poolData[0]).equal("Pool 1");
+    expect(poolData[1]).equal(ownerAddress);
+    expect(poolData[2]).equal(comptroller1Proxy.address);
+    expect(poolData[5]).equal(2);
+    expect(poolData[6]).equal("Hign market cap");
+    expect(poolData[7]).equal("http://venis.io/pool1");
+    expect(poolData[8]).equal("Pool1 description");
+    expect(poolData[9]).equal(priceOracle.address);
+    expect(poolData[10]).equal(closeFactor1);
+    expect(poolData[11]).equal(liquidationIncentive1);
+    expect(poolData[12]).equal(0);
 
-    const vTokens_Actual = poolData[14];
+    const vTokens_Actual = poolData[13];
     expect(vTokens_Actual.length).equal(2);
 
     // get VToken for Asset-1 : WBTC
     const vTokenAddress_WBTC = await poolRegistry.getVTokenForAsset(
-      1,
+      comptroller1Proxy.address,
       mockWBTC.address
     );
     const vTokenMetadata_WBTC_Expected = await poolLens.vTokenMetadata(
@@ -371,7 +370,7 @@ describe("PoolLens - PoolView Tests", async function () {
 
     // get VToken for Asset-2 : DAI
     const vTokenAddress_DAI = await poolRegistry.getVTokenForAsset(
-      1,
+      comptroller1Proxy.address,
       mockDAI.address
     );
     const vTokenMetadata_DAI_Expected = await poolLens.vTokenMetadata(
@@ -392,6 +391,11 @@ describe("PoolLens - VTokens Query Tests", async function () {
   before(async function () {
     const [owner, proxyAdmin] = await ethers.getSigners();
     ownerAddress = await owner.getAddress();
+
+    fakeAccessControlManager = await smock.fake<AccessControlManager>(
+      "AccessControlManager"
+    );
+    fakeAccessControlManager.isAllowedToCall.returns(true);
 
     const VBep20ImmutableProxyFactory = await ethers.getContractFactory(
       "VBep20ImmutableProxyFactory"
@@ -506,56 +510,6 @@ describe("PoolLens - VTokens Query Tests", async function () {
     const tokenImplementation = await VBep20Immutable.deploy();
     await tokenImplementation.deployed();
 
-    await poolRegistry.addMarket({
-      poolId: 1,
-      asset: mockWBTC.address,
-      decimals: 8,
-      name: "Compound WBTC",
-      symbol: "vWBTC",
-      rateModel: 0,
-      baseRatePerYear: 0,
-      multiplierPerYear: "40000000000000000",
-      jumpMultiplierPerYear: 0,
-      kink_: 0,
-      collateralFactor: convertToUnit(0.7, 18),
-      liquidationThreshold: convertToUnit(0.7, 18),
-      accessControlManager: fakeAccessControlManager.address,
-      vTokenProxyAdmin: proxyAdmin.address,
-      tokenImplementation_: tokenImplementation.address,
-    });
-
-    await poolRegistry.addMarket({
-      poolId: 1,
-      asset: mockDAI.address,
-      decimals: 18,
-      name: "Compound DAI",
-      symbol: "vDAI",
-      rateModel: 0,
-      baseRatePerYear: 0,
-      multiplierPerYear: "40000000000000000",
-      jumpMultiplierPerYear: 0,
-      kink_: 0,
-      collateralFactor: convertToUnit(0.7, 18),
-      liquidationThreshold: convertToUnit(0.7, 18),
-      accessControlManager: fakeAccessControlManager.address,
-      vTokenProxyAdmin: proxyAdmin.address,
-      tokenImplementation_: tokenImplementation.address,
-    });
-
-    await poolRegistry.updatePoolMetadata(1, {
-      riskRating: 2,
-      category: "Hign market cap",
-      logoURL: "http://venis.io/pool1",
-      description: "Pool1 description",
-    });
-
-    await poolRegistry.updatePoolMetadata(2, {
-      riskRating: 0,
-      category: "Low market cap",
-      logoURL: "http://highrisk.io/pool2",
-      description: "Pool2 description",
-    });
-
     // Get all pools list.
     const pools = await poolRegistry.callStatic.getAllPools();
     expect(pools[0].name).equal("Pool 1");
@@ -583,6 +537,56 @@ describe("PoolLens - VTokens Query Tests", async function () {
     );
     await unitroller2._acceptAdmin();
 
+    await poolRegistry.addMarket({
+      comptroller: comptroller1Proxy.address,
+      asset: mockWBTC.address,
+      decimals: 8,
+      name: "Compound WBTC",
+      symbol: "vWBTC",
+      rateModel: 0,
+      baseRatePerYear: 0,
+      multiplierPerYear: "40000000000000000",
+      jumpMultiplierPerYear: 0,
+      kink_: 0,
+      collateralFactor: convertToUnit(0.7, 18),
+      liquidationThreshold: convertToUnit(0.7, 18),
+      accessControlManager: fakeAccessControlManager.address,
+      vTokenProxyAdmin: proxyAdmin.address,
+      tokenImplementation_: tokenImplementation.address,
+    });
+
+    await poolRegistry.addMarket({
+      comptroller: comptroller1Proxy.address,
+      asset: mockDAI.address,
+      decimals: 18,
+      name: "Compound DAI",
+      symbol: "vDAI",
+      rateModel: 0,
+      baseRatePerYear: 0,
+      multiplierPerYear: "40000000000000000",
+      jumpMultiplierPerYear: 0,
+      kink_: 0,
+      collateralFactor: convertToUnit(0.7, 18),
+      liquidationThreshold: convertToUnit(0.7, 18),
+      accessControlManager: fakeAccessControlManager.address,
+      vTokenProxyAdmin: proxyAdmin.address,
+      tokenImplementation_: tokenImplementation.address,
+    });
+
+    await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {
+      riskRating: 2,
+      category: "Hign market cap",
+      logoURL: "http://venis.io/pool1",
+      description: "Pool1 description",
+    });
+
+    await poolRegistry.updatePoolMetadata(comptroller2Proxy.address, {
+      riskRating: 0,
+      category: "Low market cap",
+      logoURL: "http://highrisk.io/pool2",
+      description: "Pool2 description",
+    });
+
     const PoolLens = await ethers.getContractFactory("PoolLens");
     poolLens = await PoolLens.deploy();
   });
@@ -590,7 +594,7 @@ describe("PoolLens - VTokens Query Tests", async function () {
   it("is correct for WBTC as underlyingAsset", async () => {
     // get CToken for Asset-1 : WBTC
     const vTokenAddress_WBTC = await poolRegistry.getVTokenForAsset(
-      1,
+      comptroller1Proxy.address,
       mockWBTC.address
     );
     const vTokenMetadata_Actual = await poolLens.vTokenMetadata(

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -62,8 +62,8 @@ const setupTest = deployments.createFixture(
     // Set Oracle
     await Comptroller._setPriceOracle(PriceOracle.address);
 
-    const vWBTCAddress = await PoolRegistry.getVTokenForAsset(1, wBTC.address);
-    const vDAIAddress = await PoolRegistry.getVTokenForAsset(1, DAI.address);
+    const vWBTCAddress = await PoolRegistry.getVTokenForAsset(Comptroller.address, wBTC.address);
+    const vDAIAddress = await PoolRegistry.getVTokenForAsset(Comptroller.address, DAI.address);
 
     const vWBTC = await ethers.getContractAt("VBep20Immutable", vWBTCAddress);
     const vDAI = await ethers.getContractAt("VBep20Immutable", vDAIAddress);


### PR DESCRIPTION
## Description

Events and functions accessing pools through index
have been refactored to use comptroller address

Accessers using poolID are removed
Mapping on shortfall for indexing with poolId has been removed
PoolId is no longer returned as it is used internally for looping over all pools only
