### PR TITLE
fix: remove unused ActionPaused event

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -60,9 +60,6 @@ contract Comptroller is
         PriceOracle newPriceOracle
     );
 
-    /// @notice Emitted when an action is paused globally
-    event ActionPaused(string action, bool pauseState);
-
     /// @notice Emitted when an action is paused on a market
     event ActionPausedMarket(VToken vToken, Action action, bool pauseState);
 


### PR DESCRIPTION
## Description

This action isn't referenced anywhere else in the code so it can be removed.
