### PR TITLE
fix: update path for removing oracle test

### DIFF
--- a/copy_contracts.sh
+++ b/copy_contracts.sh
@@ -4,4 +4,4 @@
 rm -rf ./contracts/oracle
 mkdir -p ./contracts/oracle
 cp -rf ./node_modules/@venusprotocol/oracle/contracts/ ./contracts/oracle
-rm -rf ./contracts/oracle/contracts/test
+rm -rf ./contracts/oracle/test


### PR DESCRIPTION
## Description

We copy oracle tests to the contracts directory for convenience when compiling and deploying contracts. We need to remove the test directory correctly because it contains contracts duplicated in the isolated-pools contract directory