### PR TITLE
[VEN-783] Fix: Protocol share reserve for each market and add access control for addMarket.

### DIFF
--- a/contracts/Governance/AccessControlManager.sol
+++ b/contracts/Governance/AccessControlManager.sol
@@ -10,7 +10,6 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
  *		within Venus Smart Contract Ecosystem
  */
 contract AccessControlManager is AccessControl {
-
     /// @notice Emitted when an account is given a permission to a certain contract function
     /// NOTE: If contract address is 0x000..0 this means that the account is a default admin of this function and
     /// can call any contract function with this signature

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -368,8 +368,8 @@ contract PoolRegistry is OwnableUpgradeable {
 
         Comptroller comptroller = Comptroller(input.comptroller);
 
-        VTokenProxyFactory.VTokenArgs
-            memory initializeArgs = VTokenProxyFactory.VTokenArgs(
+        VTokenProxyFactory.VTokenArgs memory initializeArgs = VTokenProxyFactory
+            .VTokenArgs(
                 input.asset,
                 comptroller,
                 rate,
@@ -388,9 +388,7 @@ contract PoolRegistry is OwnableUpgradeable {
                 input.tokenImplementation_
             );
 
-        VToken vToken = vTokenFactory.deployVTokenProxy(
-            initializeArgs
-        );
+        VToken vToken = vTokenFactory.deployVTokenProxy(initializeArgs);
 
         comptroller._supportMarket(vToken);
         comptroller._setCollateralFactor(

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -345,7 +345,7 @@ contract PoolRegistry is OwnableUpgradeable {
     /**
      * @notice Add a market to an existing pool
      */
-    function addMarket(AddMarketInput memory input) external {
+    function addMarket(AddMarketInput memory input) external onlyOwner {
         InterestRateModel rate;
         if (input.rateModel == InterestRateModels.JumpRate) {
             rate = InterestRateModel(

--- a/contracts/RiskFund/IProtocolShareReserve.sol
+++ b/contracts/RiskFund/IProtocolShareReserve.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.10;
+
+interface IProtocolShareReserve {
+    function updateState(address comptroller, address asset) external;
+}

--- a/contracts/RiskFund/IProtocolShareReserve.sol
+++ b/contracts/RiskFund/IProtocolShareReserve.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity ^0.8.10;
+pragma solidity 0.8.13;
 
 interface IProtocolShareReserve {
-    function updateState(address comptroller, address asset) external;
+    function updateAssetsState(address comptroller, address asset) external;
 }

--- a/contracts/RiskFund/IRiskFund.sol
+++ b/contracts/RiskFund/IRiskFund.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity ^0.8.10;
+pragma solidity 0.8.13;
 
 interface IRiskFund {
     function swapAllPoolsAssets() external returns (uint256);
@@ -13,5 +13,5 @@ interface IRiskFund {
         external
         returns (uint256);
 
-    function updateState(address comptroller, address asset) external;
+    function updateAssetsState(address comptroller, address asset) external;
 }

--- a/contracts/RiskFund/IRiskFund.sol
+++ b/contracts/RiskFund/IRiskFund.sol
@@ -12,4 +12,6 @@ interface IRiskFund {
     function transferReserveForAuction(address comptroller, uint256 amount)
         external
         returns (uint256);
+
+    function updateState(address comptroller, address asset) external;
 }

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -122,7 +122,7 @@ contract ProtocolShareReserve is OwnableUpgradeable, ExponentialNoError {
             ).mantissa
         );
 
-        // Update the pool's asset's state in the risk funf for the above transfer.
+        // Update the pool asset's state in the risk fund for the above transfer.
         IRiskFund(riskFund).updateAssetsState(comptroller, asset);
 
         return amount;

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -62,7 +62,7 @@ contract ProtocolShareReserve is
             "Liquidated shares Reserves: Insufficient pool balance"
         );
 
-        previousStateForAssets[asset] -= amount;
+        assetsReserves[asset] -= amount;
         poolsAssetsReserves[comptroller][asset] -= amount;
 
         IERC20(asset).safeTransfer(

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -13,7 +13,8 @@ contract ReserveHelpers {
 
     // Store the asset's reserve per pool in the ProtocolShareReserve.
     // Comptroller(pool) -> Asset -> amount
-    mapping(address => mapping(address => uint256)) internal poolsAssetsReserves;
+    mapping(address => mapping(address => uint256))
+        internal poolsAssetsReserves;
 
     /**
      * @dev Update the reserve of the asset for the specific pool after transferring to risk fund.
@@ -33,9 +34,8 @@ contract ReserveHelpers {
         uint256 assetReserve = assetsReserves[asset];
         if (currentBalance > assetReserve) {
             uint256 balanceDifference;
-            unchecked{
-                balanceDifference = currentBalance -
-                assetReserve;
+            unchecked {
+                balanceDifference = currentBalance - assetReserve;
             }
             assetsReserves[asset] += balanceDifference;
             poolsAssetsReserves[comptroller][asset] += balanceDifference;

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "../ComptrollerInterface.sol";
+
+contract ReserveHelpers {
+    using SafeERC20 for IERC20;
+
+    // Store the previous state for the asset transferred to ProtocolShareReserve combined(for all pools).
+    mapping(address => uint256) internal previousStateForAssets;
+
+    // Store the asset's reserve per pool in the ProtocolShareReserve.
+    // Comptroller(pool) -> Asset -> amount
+    mapping(address => mapping(address => uint256)) internal poolsAssetsReserves;
+
+    /**
+     * @dev Update the reserve of the asset for the specific pool after transferring to risk fund.
+     * @param comptroller  Comptroller address(pool).
+     * @param asset Asset address.
+     */
+    function updateAssetsState(address comptroller, address asset) external {
+        require(
+            ComptrollerInterface(comptroller).isComptroller(),
+            "Liquidated shares Reserves: Comptroller address invalid"
+        );
+        require(
+            asset != address(0),
+            "Liquidated shares Reserves: Asset address invalid"
+        );
+        uint256 currentBalance = IERC20(asset).balanceOf(address(this));
+        if (currentBalance > previousStateForAssets[asset]) {
+            uint256 balanceDifference;
+            unchecked{
+                balanceDifference = currentBalance -
+                previousStateForAssets[asset];
+            }
+            previousStateForAssets[asset] += balanceDifference;
+            poolsAssetsReserves[comptroller][asset] += balanceDifference;
+        }
+    }
+
+    /**
+     * @dev Get the Amount of the asset in the risk fund for the specific pool.
+     * @param comptroller  Comptroller address(pool).
+     * @param asset Asset address.
+     * @return Asset's reserve in risk fund.
+     */
+    function getPoolAssetReserve(address comptroller, address asset)
+        external
+        view
+        returns (uint256)
+    {
+        require(
+            ComptrollerInterface(comptroller).isComptroller(),
+            "Liquidated shares Reserves: Comptroller address invalid"
+        );
+        require(
+            asset != address(0),
+            "Liquidated shares Reserves: Asset address invalid"
+        );
+        return poolsAssetsReserves[comptroller][asset];
+    }
+}

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -9,7 +9,7 @@ contract ReserveHelpers {
     using SafeERC20 for IERC20;
 
     // Store the previous state for the asset transferred to ProtocolShareReserve combined(for all pools).
-    mapping(address => uint256) internal previousStateForAssets;
+    mapping(address => uint256) internal assetsReserves;
 
     // Store the asset's reserve per pool in the ProtocolShareReserve.
     // Comptroller(pool) -> Asset -> amount
@@ -30,13 +30,14 @@ contract ReserveHelpers {
             "Liquidated shares Reserves: Asset address invalid"
         );
         uint256 currentBalance = IERC20(asset).balanceOf(address(this));
-        if (currentBalance > previousStateForAssets[asset]) {
+        uint256 assetReserve = assetsReserves[asset];
+        if (currentBalance > assetReserve) {
             uint256 balanceDifference;
             unchecked{
                 balanceDifference = currentBalance -
-                previousStateForAssets[asset];
+                assetReserve;
             }
-            previousStateForAssets[asset] += balanceDifference;
+            assetsReserves[asset] += balanceDifference;
             poolsAssetsReserves[comptroller][asset] += balanceDifference;
         }
     }

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -179,9 +179,7 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
             );
 
             if (amountInUsd >= minAmountToConvert) {
-                assetsReserves[
-                    underlyingAsset
-                ] -= balanceOfUnderlyingAsset;
+                assetsReserves[underlyingAsset] -= balanceOfUnderlyingAsset;
                 poolsAssetsReserves[comptroller][
                     underlyingAsset
                 ] -= balanceOfUnderlyingAsset;

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -179,7 +179,7 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
             );
 
             if (amountInUsd >= minAmountToConvert) {
-                previousStateForAssets[
+                assetsReserves[
                     underlyingAsset
                 ] -= balanceOfUnderlyingAsset;
                 poolsAssetsReserves[comptroller][

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -1478,7 +1478,8 @@ contract VToken is
         // Transferring an underlying asset to the protocolShareReserve contract to channel the funds for different use.
         doTransferOut(protocolShareReserve, reduceAmount);
 
-        IProtocolShareReserve(protocolShareReserve).updateState(address(comptroller), underlying);
+        // Update the pool's asset's state in the protocol share reserve for the above transfer.
+        IProtocolShareReserve(protocolShareReserve).updateAssetsState(address(comptroller), underlying);
 
         emit ReservesReduced(admin, reduceAmount, totalReservesNew);
 

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -1478,7 +1478,7 @@ contract VToken is
         // Transferring an underlying asset to the protocolShareReserve contract to channel the funds for different use.
         doTransferOut(protocolShareReserve, reduceAmount);
 
-        // Update the pool's asset's state in the protocol share reserve for the above transfer.
+        // Update the pool asset's state in the protocol share reserve for the above transfer.
         IProtocolShareReserve(protocolShareReserve).updateAssetsState(address(comptroller), underlying);
 
         emit ReservesReduced(admin, reduceAmount, totalReservesNew);

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -834,11 +834,7 @@ contract VToken is
      * @notice Sender repays their own borrow
      * @param repayAmount The amount to repay, or -1 for the full outstanding amount
      */
-    function repayBorrow(uint256 repayAmount)
-        external
-        override
-        nonReentrant
-    {
+    function repayBorrow(uint256 repayAmount) external override nonReentrant {
         accrueInterest();
         // repayBorrowFresh emits repay-borrow-specific logs on errors, so we don't need to
         repayBorrowFresh(msg.sender, msg.sender, repayAmount);
@@ -932,7 +928,6 @@ contract VToken is
 
         return actualRepayAmount;
     }
-
 
     /**
      * @notice The sender liquidates the borrowers collateral.
@@ -1479,7 +1474,10 @@ contract VToken is
         doTransferOut(protocolShareReserve, reduceAmount);
 
         // Update the pool asset's state in the protocol share reserve for the above transfer.
-        IProtocolShareReserve(protocolShareReserve).updateAssetsState(address(comptroller), underlying);
+        IProtocolShareReserve(protocolShareReserve).updateAssetsState(
+            address(comptroller),
+            underlying
+        );
 
         emit ReservesReduced(admin, reduceAmount, totalReservesNew);
 
@@ -1645,7 +1643,7 @@ contract VToken is
      * @dev This excludes the value of the current message, if any
      * @return The quantity of underlying tokens owned by this contract
      */
-    function getCashPrior() internal virtual view returns (uint256) {
+    function getCashPrior() internal view virtual returns (uint256) {
         IERC20 token = IERC20(underlying);
         return token.balanceOf(address(this));
     }

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -10,6 +10,7 @@ import "./ErrorReporter.sol";
 import "./InterestRateModel.sol";
 import "./ExponentialNoError.sol";
 import "./Governance/AccessControlManager.sol";
+import "./RiskFund/IProtocolShareReserve.sol";
 
 /**
  * @title Venus VToken Contract
@@ -1476,6 +1477,8 @@ contract VToken is
         // doTransferOut reverts if anything goes wrong, since we can't be sure if side effects occurred.
         // Transferring an underlying asset to the protocolShareReserve contract to channel the funds for different use.
         doTransferOut(protocolShareReserve, reduceAmount);
+
+        IProtocolShareReserve(protocolShareReserve).updateState(address(comptroller), underlying);
 
         emit ReservesReduced(admin, reduceAmount, totalReservesNew);
 

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -286,15 +286,11 @@ abstract contract VTokenInterface is VTokenStorage {
 
     function redeem(uint256 redeemTokens) external virtual;
 
-    function redeemUnderlying(uint256 redeemAmount)
-        external
-        virtual;
+    function redeemUnderlying(uint256 redeemAmount) external virtual;
 
     function borrow(uint256 borrowAmount) external virtual;
 
-    function repayBorrow(uint256 repayAmount)
-        external
-        virtual;
+    function repayBorrow(uint256 repayAmount) external virtual;
 
     function repayBorrowBehalf(address borrower, uint256 repayAmount)
         external

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -332,6 +332,7 @@ describe("Risk Fund: Tests", function () {
         .approve(cUSDC.address, convertToUnit(1000, 18));
 
       await cUSDC.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+
       await cUSDC._reduceReserves(convertToUnit(50, 18));
 
       const protocolReserveUSDCBal = await mainnetUSDC.balanceOf(
@@ -339,6 +340,7 @@ describe("Risk Fund: Tests", function () {
       );
       expect(protocolReserveUSDCBal).equal(convertToUnit(50, 18));
       await protocolShareReserve.releaseFunds(
+        comptroller1Proxy.address,
         mainnetUSDC.address,
         convertToUnit(50, 18)
       );
@@ -363,6 +365,7 @@ describe("Risk Fund: Tests", function () {
       expect(protocolReserveUSDCBal).equal(convertToUnit(100, 18));
 
       await protocolShareReserve.releaseFunds(
+        comptroller1Proxy.address,
         mainnetUSDC.address,
         convertToUnit(100, 18)
       );
@@ -407,10 +410,12 @@ describe("Risk Fund: Tests", function () {
       expect(protocolReserveUSDTBal).equal(convertToUnit(100, 18));
 
       await protocolShareReserve.releaseFunds(
+        comptroller1Proxy.address,
         mainnetUSDC.address,
         convertToUnit(100, 18)
       );
       await protocolShareReserve.releaseFunds(
+        comptroller1Proxy.address,
         mainnetUSDT.address,
         convertToUnit(100, 18)
       );
@@ -480,10 +485,12 @@ describe("Risk Fund: Tests", function () {
       expect(protocolReserveUSDTBal).equal(convertToUnit(100, 18));
 
       await protocolShareReserve.releaseFunds(
+        comptroller1Proxy.address,
         mainnetUSDC.address,
         convertToUnit(100, 18)
       );
       await protocolShareReserve.releaseFunds(
+        comptroller1Proxy.address,
         mainnetUSDT.address,
         convertToUnit(100, 18)
       );

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -24,13 +24,19 @@ import { convertToUnit } from "../../../helpers/utils";
 let poolRegistry: PoolRegistry;
 let comptroller1: Comptroller;
 let comptroller2: Comptroller;
+let comptroller3: Comptroller;
 let mainnetUSDC: MockToken;
 let mainnetBUSD: MockToken;
 let mainnetUSDT: MockToken;
 let cUSDC: VToken;
 let cUSDT: VToken;
+let cUSDC2: VToken;
+let cUSDT2: VToken;
+let cUSDT3: VToken;
 let priceOracle: MockPriceOracle;
 let comptroller1Proxy: Comptroller;
+let comptroller2Proxy: Comptroller;
+let comptroller3Proxy: Comptroller;
 let vTokenFactory: VTokenProxyFactory;
 let jumpRateFactory: JumpRateModelFactory;
 let whitePaperRateFactory: WhitePaperInterestRateModelFactory;
@@ -83,7 +89,7 @@ const riskFundFixture = async (): Promise<void> => {
     ethers.constants.AddressZero,
     ethers.constants.AddressZero,
     convertToUnit("10000", 18)
-  )
+  );
 
   await poolRegistry.initialize(
     vTokenFactory.address,
@@ -94,7 +100,7 @@ const riskFundFixture = async (): Promise<void> => {
     protocolShareReserve.address
   );
 
-  await shortfall.setPoolRegistry(poolRegistry.address)
+  await shortfall.setPoolRegistry(poolRegistry.address);
 
   fakeAccessControlManager = await smock.fake<AccessControlManager>(
     "AccessControlManager"
@@ -102,16 +108,24 @@ const riskFundFixture = async (): Promise<void> => {
   fakeAccessControlManager.isAllowedToCall.returns(true);
 
   const Comptroller = await ethers.getContractFactory("Comptroller");
+
   comptroller1 = await Comptroller.deploy(
     poolRegistry.address,
     fakeAccessControlManager.address
   );
   await comptroller1.deployed();
+
   comptroller2 = await Comptroller.deploy(
     poolRegistry.address,
     fakeAccessControlManager.address
   );
   await comptroller2.deployed();
+
+  comptroller3 = await Comptroller.deploy(
+    poolRegistry.address,
+    fakeAccessControlManager.address
+  );
+  await comptroller3.deployed();
 
   // Impersonate Accounts.
   await network.provider.request({
@@ -181,13 +195,24 @@ const riskFundFixture = async (): Promise<void> => {
     _liquidationIncentive,
     _minLiquidatableCollateral,
     priceOracle.address
-  )
+  );
 
   // Registering the second pool
   await poolRegistry.createRegistryPool(
     "Pool 2",
     proxyAdmin.address,
     comptroller2.address,
+    _closeFactor,
+    _liquidationIncentive,
+    _minLiquidatableCollateral,
+    priceOracle.address
+  );
+
+  // Registering the third pool
+  await poolRegistry.createRegistryPool(
+    "Pool 3",
+    proxyAdmin.address,
+    comptroller3.address,
     _closeFactor,
     _liquidationIncentive,
     _minLiquidatableCollateral,
@@ -202,8 +227,17 @@ const riskFundFixture = async (): Promise<void> => {
   );
   await comptroller1Proxy.acceptAdmin();
 
-  const comptroller2Proxy = await ethers.getContractAt("Comptroller", pools[1].comptroller);
+  comptroller2Proxy = await ethers.getContractAt(
+    "Comptroller",
+    pools[1].comptroller
+  );
   await comptroller2Proxy.acceptAdmin();
+
+  comptroller3Proxy = await ethers.getContractAt(
+    "Comptroller",
+    pools[2].comptroller
+  );
+  await comptroller3Proxy.acceptAdmin();
 
   const VToken = await ethers.getContractFactory("VToken");
   const tokenImplementation = await VToken.deploy();
@@ -246,26 +280,107 @@ const riskFundFixture = async (): Promise<void> => {
     tokenImplementation_: tokenImplementation.address,
   });
 
-  const cUSDTAddress = await poolRegistry.getVTokenForAsset(
+  await poolRegistry.addMarket({
+    comptroller: comptroller2Proxy.address,
+    asset: mainnetUSDT.address,
+    decimals: 8,
+    name: "Compound USDT",
+    symbol: "cUSDT",
+    rateModel: 0,
+    baseRatePerYear: 0,
+    multiplierPerYear: "40000000000000000",
+    jumpMultiplierPerYear: 0,
+    kink_: 0,
+    collateralFactor: convertToUnit(0.7, 18),
+    liquidationThreshold: convertToUnit(0.7, 18),
+    accessControlManager: fakeAccessControlManager.address,
+    vTokenProxyAdmin: proxyAdmin.address,
+    tokenImplementation_: tokenImplementation.address,
+  });
+
+  await poolRegistry.addMarket({
+    comptroller: comptroller2Proxy.address,
+    asset: mainnetUSDC.address,
+    decimals: 18,
+    name: "Compound USDC",
+    symbol: "cUSDC",
+    rateModel: 0,
+    baseRatePerYear: 0,
+    multiplierPerYear: "40000000000000000",
+    jumpMultiplierPerYear: 0,
+    kink_: 0,
+    collateralFactor: convertToUnit(0.7, 18),
+    liquidationThreshold: convertToUnit(0.7, 18),
+    accessControlManager: fakeAccessControlManager.address,
+    vTokenProxyAdmin: proxyAdmin.address,
+    tokenImplementation_: tokenImplementation.address,
+  });
+
+  await poolRegistry.addMarket({
+    comptroller: comptroller3Proxy.address,
+    asset: mainnetUSDT.address,
+    decimals: 8,
+    name: "Compound USDT",
+    symbol: "cUSDT",
+    rateModel: 0,
+    baseRatePerYear: 0,
+    multiplierPerYear: "40000000000000000",
+    jumpMultiplierPerYear: 0,
+    kink_: 0,
+    collateralFactor: convertToUnit(0.7, 18),
+    liquidationThreshold: convertToUnit(0.7, 18),
+    accessControlManager: fakeAccessControlManager.address,
+    vTokenProxyAdmin: proxyAdmin.address,
+    tokenImplementation_: tokenImplementation.address,
+  });
+
+  const cUSDT1Address = await poolRegistry.getVTokenForAsset(
     comptroller1Proxy.address,
     mainnetUSDT.address
   );
-  const cUSDCAddress = await poolRegistry.getVTokenForAsset(
+
+  const cUSDC1Address = await poolRegistry.getVTokenForAsset(
     comptroller1Proxy.address,
     mainnetUSDC.address
   );
 
-  cUSDT = await ethers.getContractAt("VToken", cUSDTAddress);
-  cUSDC = await ethers.getContractAt("VToken", cUSDCAddress);
+  const cUSDT2Address = await poolRegistry.getVTokenForAsset(
+    comptroller2Proxy.address,
+    mainnetUSDT.address
+  );
+
+  const cUSDC2Address = await poolRegistry.getVTokenForAsset(
+    comptroller2Proxy.address,
+    mainnetUSDC.address
+  );
+
+  const cUSDT3Address = await poolRegistry.getVTokenForAsset(
+    comptroller3Proxy.address,
+    mainnetUSDT.address
+  );
+
+  cUSDT = await ethers.getContractAt("VToken", cUSDT1Address);
+  cUSDC = await ethers.getContractAt("VToken", cUSDC1Address);
+  cUSDT2 = await ethers.getContractAt("VToken", cUSDT2Address);
+  cUSDC2 = await ethers.getContractAt("VToken", cUSDC2Address);
+  cUSDT3 = await ethers.getContractAt("VToken", cUSDT3Address);
 
   // Enter Markets
-  await comptroller1Proxy.enterMarkets([cUSDC.address, cUSDT.address]);
+
   await comptroller1Proxy
     .connect(user)
     .enterMarkets([cUSDC.address, cUSDT.address]);
 
+  await comptroller2Proxy
+    .connect(user)
+    .enterMarkets([cUSDC2.address, cUSDT2.address]);
+
+  await comptroller3Proxy.connect(user).enterMarkets([cUSDT3.address]);
+
   // Set Oracle
   await comptroller1Proxy._setPriceOracle(priceOracle.address);
+  await comptroller2Proxy._setPriceOracle(priceOracle.address);
+  await comptroller3Proxy._setPriceOracle(priceOracle.address);
 
   pancakeSwapRouter = await PancakeRouter__factory.connect(
     "0x10ED43C718714eb63d5aA57B78B54704E256024E",
@@ -432,8 +547,12 @@ describe("Risk Fund: Tests", function () {
         Number(convertToUnit(3, 17))
       );
 
-      const pool1Reserve = await riskFund.getPoolReserve(comptroller1Proxy.address);
-      const pool2Reserve = await riskFund.getPoolReserve("0x0000000000000000000000000000000000000000");
+      const pool1Reserve = await riskFund.getPoolReserve(
+        comptroller1Proxy.address
+      );
+      const pool2Reserve = await riskFund.getPoolReserve(
+        "0x0000000000000000000000000000000000000000"
+      );
       expect(Number(pool1Reserve)).to.be.closeTo(
         Number(convertToUnit(60, 18)),
         Number(convertToUnit(3, 17))
@@ -445,14 +564,20 @@ describe("Risk Fund: Tests", function () {
   describe("Transfer to Auction contract", async function () {
     it("Revert while transfering funds to Auction contract", async function () {
       await expect(
-        riskFund.transferReserveForAuction(comptroller1Proxy.address, convertToUnit(30, 18))
+        riskFund.transferReserveForAuction(
+          comptroller1Proxy.address,
+          convertToUnit(30, 18)
+        )
       ).to.be.rejectedWith("Risk Fund: Auction contract invalid address.");
 
       const auctionContract = "0x0000000000000000000000000000000000000001";
       await riskFund.setAuctionContractAddress(auctionContract);
 
       await expect(
-        riskFund.transferReserveForAuction(comptroller1Proxy.address, convertToUnit(100, 18))
+        riskFund.transferReserveForAuction(
+          comptroller1Proxy.address,
+          convertToUnit(100, 18)
+        )
       ).to.be.rejectedWith("Risk Fund: Insufficient pool reserve.");
     });
 
@@ -497,10 +622,15 @@ describe("Risk Fund: Tests", function () {
       await riskFund.swapAllPoolsAssets();
 
       const beforeTransfer = await mainnetBUSD.balanceOf(auctionContract);
-      await riskFund.transferReserveForAuction(comptroller1Proxy.address, convertToUnit(20, 18));
+      await riskFund.transferReserveForAuction(
+        comptroller1Proxy.address,
+        convertToUnit(20, 18)
+      );
       const afterTransfer = await mainnetBUSD.balanceOf(auctionContract);
       const remainingBalance = await mainnetBUSD.balanceOf(riskFund.address);
-      const poolReserve = await riskFund.getPoolReserve(comptroller1Proxy.address);
+      const poolReserve = await riskFund.getPoolReserve(
+        comptroller1Proxy.address
+      );
 
       const amount = Number(afterTransfer) - Number(beforeTransfer);
       expect(amount).to.be.closeTo(
@@ -532,8 +662,217 @@ describe("Risk Fund: Tests", function () {
 
       fakeAccessControlManager.isAllowedToCall.returns(false);
       await expect(
-        riskFund.transferReserveForAuction(comptroller1Proxy.address, convertToUnit(20, 18))
+        riskFund.transferReserveForAuction(
+          comptroller1Proxy.address,
+          convertToUnit(20, 18)
+        )
       ).to.be.rejectedWith("Risk fund: Not authorized to transfer funds.");
+    });
+
+    it("Transfer single asset from multiple pools to riskFund.", async function () {
+      const auctionContract = "0x0000000000000000000000000000000000000001";
+      await riskFund.setAuctionContractAddress(auctionContract);
+
+      await mainnetUSDC
+        .connect(usdcUser)
+        .approve(cUSDC.address, convertToUnit(1000, 18));
+
+      await cUSDC.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+
+      await mainnetUSDT
+        .connect(usdtUser)
+        .approve(cUSDT.address, convertToUnit(1000, 18));
+
+      await cUSDT.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+
+      await mainnetUSDC
+        .connect(usdcUser)
+        .approve(cUSDC2.address, convertToUnit(1000, 18));
+
+      await cUSDC2.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+
+      await mainnetUSDT
+        .connect(usdtUser)
+        .approve(cUSDT2.address, convertToUnit(1000, 18));
+
+      await cUSDT2.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+
+      await mainnetUSDT
+        .connect(usdtUser)
+        .approve(cUSDT3.address, convertToUnit(1000, 18));
+
+      await cUSDT3.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+
+      await cUSDT._reduceReserves(convertToUnit(110, 18));
+      await cUSDC._reduceReserves(convertToUnit(120, 18));
+      await cUSDT2._reduceReserves(convertToUnit(150, 18));
+      await cUSDC2._reduceReserves(convertToUnit(160, 18));
+      await cUSDT3._reduceReserves(convertToUnit(175, 18));
+
+      let protocolUSDTFor1 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller1Proxy.address,
+        mainnetUSDT.address
+      );
+      let protocolUSDCFor1 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller1Proxy.address,
+        mainnetUSDC.address
+      );
+      let protocolUSDTFor2 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller2Proxy.address,
+        mainnetUSDT.address
+      );
+      let protocolUSDCFor2 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller2Proxy.address,
+        mainnetUSDC.address
+      );
+      let protocolUSDTFor3 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller3Proxy.address,
+        mainnetUSDT.address
+      );
+
+      expect(protocolUSDTFor1).equal(convertToUnit(110, 18));
+      expect(protocolUSDTFor2).equal(convertToUnit(150, 18));
+      expect(protocolUSDTFor3).equal(convertToUnit(175, 18));
+      expect(protocolUSDCFor1).equal(convertToUnit(120, 18));
+      expect(protocolUSDCFor2).equal(convertToUnit(160, 18));
+
+      await protocolShareReserve.releaseFunds(
+        comptroller1Proxy.address,
+        mainnetUSDT.address,
+        convertToUnit(100, 18)
+      );
+
+      await protocolShareReserve.releaseFunds(
+        comptroller2Proxy.address,
+        mainnetUSDT.address,
+        convertToUnit(110, 18)
+      );
+
+      await protocolShareReserve.releaseFunds(
+        comptroller3Proxy.address,
+        mainnetUSDT.address,
+        convertToUnit(130, 18)
+      );
+
+      await protocolShareReserve.releaseFunds(
+        comptroller1Proxy.address,
+        mainnetUSDC.address,
+        convertToUnit(90, 18)
+      );
+
+      await protocolShareReserve.releaseFunds(
+        comptroller2Proxy.address,
+        mainnetUSDC.address,
+        convertToUnit(80, 18)
+      );
+
+      protocolUSDTFor1 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller1Proxy.address,
+        mainnetUSDT.address
+      );
+      protocolUSDCFor1 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller1Proxy.address,
+        mainnetUSDC.address
+      );
+      protocolUSDTFor2 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller2Proxy.address,
+        mainnetUSDT.address
+      );
+      protocolUSDCFor2 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller2Proxy.address,
+        mainnetUSDC.address
+      );
+      protocolUSDTFor3 = await protocolShareReserve.getPoolAssetReserve(
+        comptroller3Proxy.address,
+        mainnetUSDT.address
+      );
+
+      expect(protocolUSDTFor1).equal(convertToUnit(10, 18));
+      expect(protocolUSDTFor2).equal(convertToUnit(40, 18));
+      expect(protocolUSDTFor3).equal(convertToUnit(45, 18));
+      expect(protocolUSDCFor1).equal(convertToUnit(30, 18));
+      expect(protocolUSDCFor2).equal(convertToUnit(80, 18));
+
+      let riskUSDTFor1 = await riskFund.getPoolAssetReserve(
+        comptroller1Proxy.address,
+        mainnetUSDT.address
+      );
+      let riskUSDCFor1 = await riskFund.getPoolAssetReserve(
+        comptroller1Proxy.address,
+        mainnetUSDC.address
+      );
+      let riskUSDTFor2 = await riskFund.getPoolAssetReserve(
+        comptroller2Proxy.address,
+        mainnetUSDT.address
+      );
+      let riskUSDCFor2 = await riskFund.getPoolAssetReserve(
+        comptroller2Proxy.address,
+        mainnetUSDC.address
+      );
+      let riskUSDTFor3 = await riskFund.getPoolAssetReserve(
+        comptroller3Proxy.address,
+        mainnetUSDT.address
+      );
+
+      await riskFund.swapAllPoolsAssets();
+
+      expect(riskUSDTFor1).equal(convertToUnit(30, 18));
+      expect(riskUSDCFor1).equal(convertToUnit(27, 18));
+      expect(riskUSDTFor2).equal(convertToUnit(33, 18));
+      expect(riskUSDCFor2).equal(convertToUnit(24, 18));
+      expect(riskUSDTFor3).equal(convertToUnit(39, 18));
+
+      riskUSDTFor1 = await riskFund.getPoolAssetReserve(
+        comptroller1Proxy.address,
+        mainnetUSDT.address
+      );
+      riskUSDCFor1 = await riskFund.getPoolAssetReserve(
+        comptroller1Proxy.address,
+        mainnetUSDC.address
+      );
+      riskUSDTFor2 = await riskFund.getPoolAssetReserve(
+        comptroller2Proxy.address,
+        mainnetUSDT.address
+      );
+      riskUSDCFor2 = await riskFund.getPoolAssetReserve(
+        comptroller2Proxy.address,
+        mainnetUSDC.address
+      );
+      riskUSDTFor3 = await riskFund.getPoolAssetReserve(
+        comptroller3Proxy.address,
+        mainnetUSDT.address
+      );
+
+      expect(riskUSDTFor1).equal(0);
+      expect(riskUSDCFor1).equal(0);
+      expect(riskUSDTFor2).equal(0);
+      expect(riskUSDCFor2).equal(0);
+      expect(riskUSDTFor3).equal(0);
+
+      const poolReserve1 = await riskFund.getPoolReserve(
+        comptroller1Proxy.address
+      );
+
+      const poolReserve2 = await riskFund.getPoolReserve(
+        comptroller2Proxy.address
+      );
+
+      const poolReserve3 = await riskFund.getPoolReserve(
+        comptroller3Proxy.address
+      );
+
+      expect(poolReserve1).to.be.closeTo(
+        convertToUnit(56, 18),
+        convertToUnit(9, 17)
+      );
+      expect(poolReserve2).to.be.closeTo(
+        convertToUnit(56, 18),
+        convertToUnit(9, 17)
+      );
+      expect(poolReserve3).to.be.closeTo(
+        convertToUnit(38, 18),
+        convertToUnit(9, 17)
+      );
     });
   });
 });

--- a/tests/hardhat/ProtocolShareReserve.ts
+++ b/tests/hardhat/ProtocolShareReserve.ts
@@ -69,13 +69,15 @@ describe("Liquidated shares reserves: Tests", function () {
   });
 
   it("Release liquidated share reserve", async function () {
+    const comptrollerAddress = "0x0000000000000000000000000000000000000111";
+
     await mockDAI.transfer(
       protocolShareReserve.address,
       convertToUnit(100, 18)
     );
 
     await protocolShareReserve.updateAssetsState(
-      "0x0000000000000000000000000000000000000111", // Mock comptroller address
+      comptrollerAddress, // Mock comptroller address
       mockDAI.address
     );
 
@@ -83,11 +85,25 @@ describe("Liquidated shares reserves: Tests", function () {
 
     expect(balance).equal(convertToUnit(100, 18));
 
-    await protocolShareReserve.releaseFunds(
-      "0x0000000000000000000000000000000000000111", // Mock comptroller address
-      mockDAI.address,
-      convertToUnit(100, 18)
+    let protocolUSDT = await protocolShareReserve.getPoolAssetReserve(
+      comptrollerAddress,
+      mockDAI.address
     );
+
+    expect(protocolUSDT).equal(convertToUnit(100, 18));
+
+    await protocolShareReserve.releaseFunds(
+      comptrollerAddress, // Mock comptroller address
+      mockDAI.address,
+      convertToUnit(90, 18)
+    );
+
+    protocolUSDT = await protocolShareReserve.getPoolAssetReserve(
+      comptrollerAddress,
+      mockDAI.address
+    );
+
+    expect(protocolUSDT).equal(convertToUnit(10, 18));
 
     const riskFundBal = await mockDAI.balanceOf(fakeRiskFund.address);
     const liquidatedShareBal = await mockDAI.balanceOf(
@@ -97,8 +113,8 @@ describe("Liquidated shares reserves: Tests", function () {
       protocolShareReserve.address
     );
 
-    expect(riskFundBal).equal(convertToUnit(30, 18));
-    expect(liquidatedShareBal).equal(convertToUnit(70, 18));
-    expect(protocolShareReserveBal).equal("0");
+    expect(riskFundBal).equal(convertToUnit(27, 18));
+    expect(liquidatedShareBal).equal(convertToUnit(63, 18));
+    expect(protocolShareReserveBal).equal(convertToUnit(10, 18));
   });
 });

--- a/tests/hardhat/ProtocolShareReserve.ts
+++ b/tests/hardhat/ProtocolShareReserve.ts
@@ -49,6 +49,7 @@ describe("Liquidated shares reserves: Tests", function () {
   it("Revert on invalid asset address.", async function () {
     await expect(
       protocolShareReserve.releaseFunds(
+        "0x0000000000000000000000000000000000000111",
         "0x0000000000000000000000000000000000000000",
         10
       )
@@ -57,8 +58,14 @@ describe("Liquidated shares reserves: Tests", function () {
 
   it("Revert on Insufficient balance.", async function () {
     await expect(
-      protocolShareReserve.releaseFunds(mockDAI.address, 10)
-    ).to.be.rejectedWith("Liquidated shares Reserves: Insufficient balance");
+      protocolShareReserve.releaseFunds(
+        "0x0000000000000000000000000000000000000111", // Mock comptroller address
+        mockDAI.address,
+        10
+      )
+    ).to.be.rejectedWith(
+      "Liquidated shares Reserves: Insufficient pool balance"
+    );
   });
 
   it("Release liquidated share reserve", async function () {
@@ -66,11 +73,18 @@ describe("Liquidated shares reserves: Tests", function () {
       protocolShareReserve.address,
       convertToUnit(100, 18)
     );
+
+    await protocolShareReserve.updateState(
+      "0x0000000000000000000000000000000000000111", // Mock comptroller address
+      mockDAI.address
+    );
+
     const balance = await mockDAI.balanceOf(protocolShareReserve.address);
 
     expect(balance).equal(convertToUnit(100, 18));
 
     await protocolShareReserve.releaseFunds(
+      "0x0000000000000000000000000000000000000111", // Mock comptroller address
       mockDAI.address,
       convertToUnit(100, 18)
     );

--- a/tests/hardhat/ProtocolShareReserve.ts
+++ b/tests/hardhat/ProtocolShareReserve.ts
@@ -74,7 +74,7 @@ describe("Liquidated shares reserves: Tests", function () {
       convertToUnit(100, 18)
     );
 
-    await protocolShareReserve.updateState(
+    await protocolShareReserve.updateAssetsState(
       "0x0000000000000000000000000000000000000111", // Mock comptroller address
       mockDAI.address
     );


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->
This PR contains:
- Logic to handle the protocol share reserve and risk fund for multiple pools having same asset.
- Added tests for Risk fund and Protocol share reserve to test for multiple pools having same assets.
- Added a check for base asset (Stable asset in which all the assets will be swapped into, in risk fund) before swapping it with pancakeswap.
- Added setter(only owner) for the base asset in the Risk fund.
- Added access control check for the addMarket in the poolRegistry.

## Checklist
<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->
- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
