### PR TITLE
Audit improvements, low-hanging fruits

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -133,7 +133,7 @@ contract Comptroller is
         uint256 len = vTokens.length;
 
         uint256[] memory results = new uint256[](len);
-        for (uint256 i = 0; i < len; ++i) {
+        for (uint256 i; i < len; ++i) {
             VToken vToken = VToken(vTokens[i]);
 
             results[i] = uint256(addToMarketInternal(vToken, msg.sender));
@@ -215,7 +215,7 @@ contract Comptroller is
         VToken[] memory userAssetList = accountAssets[msg.sender];
         uint256 len = userAssetList.length;
         uint256 assetIndex = len;
-        for (uint256 i = 0; i < len; ++i) {
+        for (uint256 i; i < len; ++i) {
             if (userAssetList[i] == vToken) {
                 assetIndex = i;
                 break;
@@ -268,7 +268,7 @@ contract Comptroller is
 
         // Keep the flywheel moving
         uint256 rewardDistributorsCount = rewardsDistributors.length;
-        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
+        for (uint256 i; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].updateRewardTokenSupplyIndex(vToken);
             rewardsDistributors[i].distributeSupplierRewardToken(vToken, minter);
         }
@@ -324,7 +324,7 @@ contract Comptroller is
 
         // Keep the flywheel moving
         uint256 rewardDistributorsCount = rewardsDistributors.length;
-        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
+        for (uint256 i; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].updateRewardTokenSupplyIndex(vToken);
             rewardsDistributors[i].distributeSupplierRewardToken(vToken, redeemer);
         }
@@ -449,7 +449,7 @@ contract Comptroller is
 
         // Keep the flywheel moving
         uint256 rewardDistributorsCount = rewardsDistributors.length;
-        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
+        for (uint256 i; i < rewardDistributorsCount; ++i) {
             Exp memory borrowIndex = Exp({ mantissa: VToken(vToken).borrowIndex() });
             rewardsDistributors[i].updateRewardTokenBorrowIndex(vToken, borrowIndex);
             rewardsDistributors[i].distributeBorrowerRewardToken(vToken, borrower, borrowIndex);
@@ -509,7 +509,7 @@ contract Comptroller is
 
         // Keep the flywheel moving
         uint256 rewardDistributorsCount = rewardsDistributors.length;
-        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
+        for (uint256 i; i < rewardDistributorsCount; ++i) {
             Exp memory borrowIndex = Exp({ mantissa: VToken(vToken).borrowIndex() });
             rewardsDistributors[i].updateRewardTokenBorrowIndex(vToken, borrowIndex);
             rewardsDistributors[i].distributeBorrowerRewardToken(vToken, borrower, borrowIndex);
@@ -682,7 +682,7 @@ contract Comptroller is
 
         // Keep the flywheel moving
         uint256 rewardDistributorsCount = rewardsDistributors.length;
-        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
+        for (uint256 i; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].updateRewardTokenSupplyIndex(vTokenCollateral);
             rewardsDistributors[i].distributeSupplierRewardToken(vTokenCollateral, borrower);
             rewardsDistributors[i].distributeSupplierRewardToken(vTokenCollateral, liquidator);
@@ -746,7 +746,7 @@ contract Comptroller is
 
         // Keep the flywheel moving
         uint256 rewardDistributorsCount = rewardsDistributors.length;
-        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
+        for (uint256 i; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].updateRewardTokenSupplyIndex(vToken);
             rewardsDistributors[i].distributeSupplierRewardToken(vToken, src);
             rewardsDistributors[i].distributeSupplierRewardToken(vToken, dst);
@@ -795,7 +795,7 @@ contract Comptroller is
         uint256 userAssetsCount = userAssets.length;
         address liquidator = msg.sender;
         // We need all user's markets to be fresh for the computations to be correct
-        for (uint256 i = 0; i < userAssetsCount; ++i) {
+        for (uint256 i; i < userAssetsCount; ++i) {
             userAssets[i].accrueInterest();
             oracle.updatePrice(address(userAssets[i]));
         }
@@ -818,7 +818,7 @@ contract Comptroller is
             revert CollateralExceedsThreshold(scaledBorrows.mantissa, collateral.mantissa);
         }
 
-        for (uint256 i = 0; i < userAssetsCount; ++i) {
+        for (uint256 i; i < userAssetsCount; ++i) {
             VToken market = userAssets[i];
 
             (uint256 tokens, uint256 borrowBalance, ) = _safeGetAccountSnapshot(market, user);
@@ -879,7 +879,7 @@ contract Comptroller is
         }
 
         uint256 ordersCount = orders.length;
-        for (uint256 i = 0; i < ordersCount; ++i) {
+        for (uint256 i; i < ordersCount; ++i) {
             LiquidationOrder calldata order = orders[i];
             order.vTokenCollateral.forceLiquidateBorrow(
                 msg.sender,
@@ -892,7 +892,7 @@ contract Comptroller is
 
         VToken[] memory markets = accountAssets[borrower];
         uint256 marketsCount = markets.length;
-        for (uint256 i = 0; i < marketsCount; ++i) {
+        for (uint256 i; i < marketsCount; ++i) {
             // Read the balances and exchange rate from the vToken
             (uint256 oErr, , uint256 borrowBalance, ) = markets[i].getAccountSnapshot(borrower);
             if (oErr != 0) {
@@ -998,7 +998,7 @@ contract Comptroller is
         // For each asset the account is in
         VToken[] memory assets = accountAssets[account];
         uint256 assetsCount = assets.length;
-        for (uint256 i = 0; i < assetsCount; ++i) {
+        for (uint256 i; i < assetsCount; ++i) {
             VToken asset = assets[i];
 
             // Read the balances and exchange rate from the vToken
@@ -1262,7 +1262,7 @@ contract Comptroller is
         _addMarketInternal(address(vToken));
 
         uint256 rewardDistributorsCount = rewardsDistributors.length;
-        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
+        for (uint256 i; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].initializeMarket(address(vToken));
         }
 
@@ -1271,7 +1271,7 @@ contract Comptroller is
 
     function _addMarketInternal(address vToken) internal {
         uint256 marketsCount = allMarkets.length;
-        for (uint256 i = 0; i < marketsCount; ++i) {
+        for (uint256 i; i < marketsCount; ++i) {
             require(allMarkets[i] != VToken(vToken), "market already added");
         }
         allMarkets.push(VToken(vToken));
@@ -1297,7 +1297,7 @@ contract Comptroller is
 
         require(numMarkets != 0 && numMarkets == numBorrowCaps, "invalid input");
 
-        for (uint256 i = 0; i < numMarkets; ++i) {
+        for (uint256 i; i < numMarkets; ++i) {
             borrowCaps[address(vTokens[i])] = newBorrowCaps[i];
             emit NewBorrowCap(vTokens[i], newBorrowCaps[i]);
         }
@@ -1319,7 +1319,7 @@ contract Comptroller is
         require(vTokensCount != 0, "invalid number of markets");
         require(vTokensCount == newSupplyCaps.length, "invalid number of markets");
 
-        for (uint256 i = 0; i < vTokensCount; ++i) {
+        for (uint256 i; i < vTokensCount; ++i) {
             supplyCaps[address(vTokens[i])] = newSupplyCaps[i];
             emit NewSupplyCap(vTokens[i], newSupplyCaps[i]);
         }
@@ -1344,8 +1344,8 @@ contract Comptroller is
 
         uint256 marketsCount = marketsList.length;
         uint256 actionsCount = actionsList.length;
-        for (uint256 marketIdx = 0; marketIdx < marketsCount; ++marketIdx) {
-            for (uint256 actionIdx = 0; actionIdx < actionsCount; ++actionIdx) {
+        for (uint256 marketIdx; marketIdx < marketsCount; ++marketIdx) {
+            for (uint256 actionIdx; actionIdx < actionsCount; ++actionIdx) {
                 setActionPausedInternal(address(marketsList[marketIdx]), actionsList[actionIdx], paused);
             }
         }
@@ -1400,7 +1400,7 @@ contract Comptroller is
         rewardsDistributorExists[address(_rewardsDistributor)] = true;
 
         uint256 marketsCount = allMarkets.length;
-        for (uint256 i = 0; i < marketsCount; ++i) {
+        for (uint256 i; i < marketsCount; ++i) {
             _rewardsDistributor.initializeMarket(address(allMarkets[i]));
         }
 

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -157,7 +157,7 @@ contract Comptroller is
             return Error.MARKET_NOT_LISTED;
         }
 
-        if (marketToJoin.accountMembership[borrower] == true) {
+        if (marketToJoin.accountMembership[borrower]) {
             // already joined
             return Error.NO_ERROR;
         }

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -267,7 +267,8 @@ contract Comptroller is
         require(nextTotalSupply <= supplyCap, "market supply cap reached");
 
         // Keep the flywheel moving
-        for (uint256 i = 0; i < rewardsDistributors.length; ++i) {
+        uint256 rewardDistributorsCount = rewardsDistributors.length;
+        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].updateRewardTokenSupplyIndex(vToken);
             rewardsDistributors[i].distributeSupplierRewardToken(vToken, minter);
         }
@@ -322,7 +323,8 @@ contract Comptroller is
         }
 
         // Keep the flywheel moving
-        for (uint256 i = 0; i < rewardsDistributors.length; ++i) {
+        uint256 rewardDistributorsCount = rewardsDistributors.length;
+        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].updateRewardTokenSupplyIndex(vToken);
             rewardsDistributors[i].distributeSupplierRewardToken(vToken, redeemer);
         }
@@ -446,7 +448,8 @@ contract Comptroller is
         }
 
         // Keep the flywheel moving
-        for (uint256 i = 0; i < rewardsDistributors.length; ++i) {
+        uint256 rewardDistributorsCount = rewardsDistributors.length;
+        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
             Exp memory borrowIndex = Exp({ mantissa: VToken(vToken).borrowIndex() });
             rewardsDistributors[i].updateRewardTokenBorrowIndex(vToken, borrowIndex);
             rewardsDistributors[i].distributeBorrowerRewardToken(vToken, borrower, borrowIndex);
@@ -505,7 +508,8 @@ contract Comptroller is
         }
 
         // Keep the flywheel moving
-        for (uint256 i = 0; i < rewardsDistributors.length; ++i) {
+        uint256 rewardDistributorsCount = rewardsDistributors.length;
+        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
             Exp memory borrowIndex = Exp({ mantissa: VToken(vToken).borrowIndex() });
             rewardsDistributors[i].updateRewardTokenBorrowIndex(vToken, borrowIndex);
             rewardsDistributors[i].distributeBorrowerRewardToken(vToken, borrower, borrowIndex);
@@ -677,7 +681,8 @@ contract Comptroller is
         }
 
         // Keep the flywheel moving
-        for (uint256 i = 0; i < rewardsDistributors.length; ++i) {
+        uint256 rewardDistributorsCount = rewardsDistributors.length;
+        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].updateRewardTokenSupplyIndex(vTokenCollateral);
             rewardsDistributors[i].distributeSupplierRewardToken(vTokenCollateral, borrower);
             rewardsDistributors[i].distributeSupplierRewardToken(vTokenCollateral, liquidator);
@@ -740,7 +745,8 @@ contract Comptroller is
         }
 
         // Keep the flywheel moving
-        for (uint256 i = 0; i < rewardsDistributors.length; ++i) {
+        uint256 rewardDistributorsCount = rewardsDistributors.length;
+        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].updateRewardTokenSupplyIndex(vToken);
             rewardsDistributors[i].distributeSupplierRewardToken(vToken, src);
             rewardsDistributors[i].distributeSupplierRewardToken(vToken, dst);
@@ -786,9 +792,10 @@ contract Comptroller is
      */
     function healAccount(address user) external {
         VToken[] memory userAssets = accountAssets[user];
+        uint256 userAssetsCount = userAssets.length;
         address liquidator = msg.sender;
         // We need all user's markets to be fresh for the computations to be correct
-        for (uint256 i = 0; i < userAssets.length; ++i) {
+        for (uint256 i = 0; i < userAssetsCount; ++i) {
             userAssets[i].accrueInterest();
             oracle.updatePrice(address(userAssets[i]));
         }
@@ -798,6 +805,7 @@ contract Comptroller is
         if (snapshot.totalCollateral > minLiquidatableCollateral) {
             revert CollateralExceedsThreshold(minLiquidatableCollateral, snapshot.totalCollateral);
         }
+
         // percentage = collateral / (borrows * liquidation incentive)
         Exp memory collateral = Exp({ mantissa: snapshot.totalCollateral });
         Exp memory scaledBorrows = mul_(
@@ -809,14 +817,11 @@ contract Comptroller is
         if (lessThanExp(Exp({ mantissa: mantissaOne }), percentage)) {
             revert CollateralExceedsThreshold(scaledBorrows.mantissa, collateral.mantissa);
         }
-        for (uint256 i = 0; i < userAssets.length; ++i) {
+
+        for (uint256 i = 0; i < userAssetsCount; ++i) {
             VToken market = userAssets[i];
 
-            (uint256 oErr, uint256 tokens, uint256 borrowBalance, ) = market.getAccountSnapshot(user);
-            if (oErr != 0) {
-                revert SnapshotError();
-            }
-
+            (uint256 tokens, uint256 borrowBalance, ) = _safeGetAccountSnapshot(market, user);
             uint256 repaymentAmount = mul_ScalarTruncate(percentage, borrowBalance);
 
             // Seize the entire collateral
@@ -873,7 +878,8 @@ contract Comptroller is
             revert InsufficientCollateral(collateralToSeize, snapshot.totalCollateral);
         }
 
-        for (uint256 i = 0; i < orders.length; ++i) {
+        uint256 ordersCount = orders.length;
+        for (uint256 i = 0; i < ordersCount; ++i) {
             LiquidationOrder calldata order = orders[i];
             order.vTokenCollateral.forceLiquidateBorrow(
                 msg.sender,
@@ -885,7 +891,8 @@ contract Comptroller is
         }
 
         VToken[] memory markets = accountAssets[borrower];
-        for (uint256 i = 0; i < markets.length; ++i) {
+        uint256 marketsCount = markets.length;
+        for (uint256 i = 0; i < marketsCount; ++i) {
             // Read the balances and exchange rate from the vToken
             (uint256 oErr, , uint256 borrowBalance, ) = markets[i].getAccountSnapshot(borrower);
             if (oErr != 0) {
@@ -990,15 +997,15 @@ contract Comptroller is
     ) internal view returns (AccountLiquiditySnapshot memory snapshot) {
         // For each asset the account is in
         VToken[] memory assets = accountAssets[account];
-        for (uint256 i = 0; i < assets.length; ++i) {
+        uint256 assetsCount = assets.length;
+        for (uint256 i = 0; i < assetsCount; ++i) {
             VToken asset = assets[i];
 
             // Read the balances and exchange rate from the vToken
-            (uint256 oErr, uint256 vTokenBalance, uint256 borrowBalance, uint256 exchangeRateMantissa) = asset
-                .getAccountSnapshot(account);
-            if (oErr != 0) {
-                revert SnapshotError();
-            }
+            (uint256 vTokenBalance, uint256 borrowBalance, uint256 exchangeRateMantissa) = _safeGetAccountSnapshot(
+                asset,
+                account
+            );
 
             // Get the normalized price of the asset
             Exp memory oraclePrice = Exp({ mantissa: safeGetUnderlyingPrice(asset) });
@@ -1254,7 +1261,8 @@ contract Comptroller is
 
         _addMarketInternal(address(vToken));
 
-        for (uint256 i = 0; i < rewardsDistributors.length; ++i) {
+        uint256 rewardDistributorsCount = rewardsDistributors.length;
+        for (uint256 i = 0; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].initializeMarket(address(vToken));
         }
 
@@ -1262,7 +1270,8 @@ contract Comptroller is
     }
 
     function _addMarketInternal(address vToken) internal {
-        for (uint256 i = 0; i < allMarkets.length; ++i) {
+        uint256 marketsCount = allMarkets.length;
+        for (uint256 i = 0; i < marketsCount; ++i) {
             require(allMarkets[i] != VToken(vToken), "market already added");
         }
         allMarkets.push(VToken(vToken));
@@ -1305,10 +1314,12 @@ contract Comptroller is
             AccessControlManager(accessControl).isAllowedToCall(msg.sender, "_setMarketSupplyCaps(VToken[],uint256[])"),
             "only whitelisted accounts can set supply caps"
         );
-        require(vTokens.length != 0, "invalid number of markets");
-        require(vTokens.length == newSupplyCaps.length, "invalid number of markets");
+        uint256 vTokensCount = vTokens.length;
 
-        for (uint256 i = 0; i < vTokens.length; ++i) {
+        require(vTokensCount != 0, "invalid number of markets");
+        require(vTokensCount == newSupplyCaps.length, "invalid number of markets");
+
+        for (uint256 i = 0; i < vTokensCount; ++i) {
             supplyCaps[address(vTokens[i])] = newSupplyCaps[i];
             emit NewSupplyCap(vTokens[i], newSupplyCaps[i]);
         }
@@ -1331,8 +1342,10 @@ contract Comptroller is
         );
         require(canCallFunction, "only authorised addresses can pause");
 
-        for (uint256 marketIdx = 0; marketIdx < marketsList.length; ++marketIdx) {
-            for (uint256 actionIdx = 0; actionIdx < actionsList.length; ++actionIdx) {
+        uint256 marketsCount = marketsList.length;
+        uint256 actionsCount = actionsList.length;
+        for (uint256 marketIdx = 0; marketIdx < marketsCount; ++marketIdx) {
+            for (uint256 actionIdx = 0; actionIdx < actionsCount; ++actionIdx) {
                 setActionPausedInternal(address(marketsList[marketIdx]), actionsList[actionIdx], paused);
             }
         }
@@ -1386,7 +1399,8 @@ contract Comptroller is
         rewardsDistributors.push(_rewardsDistributor);
         rewardsDistributorExists[address(_rewardsDistributor)] = true;
 
-        for (uint256 i = 0; i < allMarkets.length; ++i) {
+        uint256 marketsCount = allMarkets.length;
+        for (uint256 i = 0; i < marketsCount; ++i) {
             _rewardsDistributor.initializeMarket(address(allMarkets[i]));
         }
 
@@ -1430,5 +1444,30 @@ contract Comptroller is
 
     function getBlockNumber() public view virtual returns (uint256) {
         return block.number;
+    }
+
+    /**
+     * @dev Returns supply and borrow balances of user in vToken, reverts on failure
+     * @param vToken market to query
+     * @param user user address
+     * @return vTokenBalance balance of vTokens, the same as vToken.balanceOf(user)
+     * @return borrowBalance borrowed amount, including the interest
+     * @return exchangeRateMantissa stored exchange rate
+     */
+    function _safeGetAccountSnapshot(VToken vToken, address user)
+        internal
+        view
+        returns (
+            uint256 vTokenBalance,
+            uint256 borrowBalance,
+            uint256 exchangeRateMantissa
+        )
+    {
+        uint256 err;
+        (err, vTokenBalance, borrowBalance, exchangeRateMantissa) = vToken.getAccountSnapshot(user);
+        if (err != 0) {
+            revert SnapshotError();
+        }
+        return (vTokenBalance, borrowBalance, exchangeRateMantissa);
     }
 }

--- a/contracts/Lens/PoolLens.sol
+++ b/contracts/Lens/PoolLens.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
-pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@venusprotocol/oracle/contracts/PriceOracle.sol";

--- a/contracts/Pool/PoolRegistryInterface.sol
+++ b/contracts/Pool/PoolRegistryInterface.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
-pragma experimental ABIEncoderV2;
 
 import "./PoolRegistry.sol";
 

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -409,14 +409,14 @@ contract RewardsDistributor is ExponentialNoError, OwnableUpgradeable {
         for (uint256 i; i < vTokensCount; ++i) {
             VToken vToken = vTokens[i];
             require(comptroller.isMarketListed(vToken), "market must be listed");
-            if (borrowers == true) {
+            if (borrowers) {
                 Exp memory borrowIndex = Exp({ mantissa: vToken.borrowIndex() });
                 _updateRewardTokenBorrowIndex(address(vToken), borrowIndex);
                 for (uint256 j; j < holdersCount; ++j) {
                     _distributeBorrowerRewardToken(address(vToken), holders[j], borrowIndex);
                 }
             }
-            if (suppliers == true) {
+            if (suppliers) {
                 _updateRewardTokenSupplyIndex(address(vToken));
                 for (uint256 j; j < holdersCount; ++j) {
                     _distributeSupplierRewardToken(address(vToken), holders[j]);

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -135,7 +135,7 @@ contract RewardsDistributor is ExponentialNoError, OwnableUpgradeable {
             "Comptroller::_setRewardTokenSpeeds invalid input"
         );
 
-        for (uint256 i = 0; i < numTokens; ++i) {
+        for (uint256 i; i < numTokens; ++i) {
             setRewardTokenSpeedInternal(vTokens[i], supplySpeeds[i], borrowSpeeds[i]);
         }
     }
@@ -406,24 +406,24 @@ contract RewardsDistributor is ExponentialNoError, OwnableUpgradeable {
     ) internal {
         uint256 vTokensCount = vTokens.length;
         uint256 holdersCount = holders.length;
-        for (uint256 i = 0; i < vTokensCount; ++i) {
+        for (uint256 i; i < vTokensCount; ++i) {
             VToken vToken = vTokens[i];
             require(comptroller.isMarketListed(vToken), "market must be listed");
             if (borrowers == true) {
                 Exp memory borrowIndex = Exp({ mantissa: vToken.borrowIndex() });
                 _updateRewardTokenBorrowIndex(address(vToken), borrowIndex);
-                for (uint256 j = 0; j < holdersCount; ++j) {
+                for (uint256 j; j < holdersCount; ++j) {
                     _distributeBorrowerRewardToken(address(vToken), holders[j], borrowIndex);
                 }
             }
             if (suppliers == true) {
                 _updateRewardTokenSupplyIndex(address(vToken));
-                for (uint256 j = 0; j < holdersCount; ++j) {
+                for (uint256 j; j < holdersCount; ++j) {
                     _distributeSupplierRewardToken(address(vToken), holders[j]);
                 }
             }
         }
-        for (uint256 j = 0; j < holdersCount; ++j) {
+        for (uint256 j; j < holdersCount; ++j) {
             rewardTokenAccrued[holders[j]] = grantRewardTokenInternal(holders[j], rewardTokenAccrued[holders[j]]);
         }
     }

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -404,24 +404,24 @@ contract RewardsDistributor is ExponentialNoError, OwnableUpgradeable {
         bool borrowers,
         bool suppliers
     ) internal {
-        for (uint256 i = 0; i < vTokens.length; i++) {
+        for (uint256 i = 0; i < vTokens.length; ++i) {
             VToken vToken = vTokens[i];
             require(comptroller.isMarketListed(vToken), "market must be listed");
             if (borrowers == true) {
                 Exp memory borrowIndex = Exp({ mantissa: vToken.borrowIndex() });
                 _updateRewardTokenBorrowIndex(address(vToken), borrowIndex);
-                for (uint256 j = 0; j < holders.length; j++) {
+                for (uint256 j = 0; j < holders.length; ++j) {
                     _distributeBorrowerRewardToken(address(vToken), holders[j], borrowIndex);
                 }
             }
             if (suppliers == true) {
                 _updateRewardTokenSupplyIndex(address(vToken));
-                for (uint256 j = 0; j < holders.length; j++) {
+                for (uint256 j = 0; j < holders.length; ++j) {
                     _distributeSupplierRewardToken(address(vToken), holders[j]);
                 }
             }
         }
-        for (uint256 j = 0; j < holders.length; j++) {
+        for (uint256 j = 0; j < holders.length; ++j) {
             rewardTokenAccrued[holders[j]] = grantRewardTokenInternal(holders[j], rewardTokenAccrued[holders[j]]);
         }
     }

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -404,24 +404,26 @@ contract RewardsDistributor is ExponentialNoError, OwnableUpgradeable {
         bool borrowers,
         bool suppliers
     ) internal {
-        for (uint256 i = 0; i < vTokens.length; ++i) {
+        uint256 vTokensCount = vTokens.length;
+        uint256 holdersCount = holders.length;
+        for (uint256 i = 0; i < vTokensCount; ++i) {
             VToken vToken = vTokens[i];
             require(comptroller.isMarketListed(vToken), "market must be listed");
             if (borrowers == true) {
                 Exp memory borrowIndex = Exp({ mantissa: vToken.borrowIndex() });
                 _updateRewardTokenBorrowIndex(address(vToken), borrowIndex);
-                for (uint256 j = 0; j < holders.length; ++j) {
+                for (uint256 j = 0; j < holdersCount; ++j) {
                     _distributeBorrowerRewardToken(address(vToken), holders[j], borrowIndex);
                 }
             }
             if (suppliers == true) {
                 _updateRewardTokenSupplyIndex(address(vToken));
-                for (uint256 j = 0; j < holders.length; ++j) {
+                for (uint256 j = 0; j < holdersCount; ++j) {
                     _distributeSupplierRewardToken(address(vToken), holders[j]);
                 }
             }
         }
-        for (uint256 j = 0; j < holders.length; ++j) {
+        for (uint256 j = 0; j < holdersCount; ++j) {
             rewardTokenAccrued[holders[j]] = grantRewardTokenInternal(holders[j], rewardTokenAccrued[holders[j]]);
         }
     }

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -17,7 +17,7 @@ contract ReserveHelpers {
 
     // Event emitted after the updation of the assets reserves.
     // amount -> reserve increased by amount.
-    event AssetsReservesUpdated(address comptroller, address asset, uint256 amount);
+    event AssetsReservesUpdated(address indexed comptroller, address indexed asset, uint256 amount);
 
     /**
      * @dev Update the reserve of the asset for the specific pool after transferring to risk fund.

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -164,11 +164,13 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
      */
     function swapPoolsAssets(PoolRegistry.VenusPool[] memory venusPools) public returns (uint256) {
         uint256 totalAmount;
-        for (uint256 i; i < venusPools.length; ++i) {
+        uint256 poolsCount = venusPools.length;
+        for (uint256 i; i < poolsCount; ++i) {
             if (venusPools[i].comptroller != address(0)) {
                 VToken[] memory vTokens = ComptrollerInterface(venusPools[i].comptroller).getAllMarkets();
 
-                for (uint256 j; j < vTokens.length; ++j) {
+                uint256 vTokensCount = vTokens.length;
+                for (uint256 j; j < vTokensCount; ++j) {
                     address comptroller = venusPools[i].comptroller;
                     VToken vToken = vTokens[j];
                     uint256 swappedTokens = swapAsset(vToken, comptroller);

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -147,7 +147,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         );
 
         uint256 marketsCount = auction.markets.length;
-        for (uint256 i = 0; i < marketsCount; ++i) {
+        for (uint256 i; i < marketsCount; ++i) {
             VToken vToken = auction.markets[i];
             auction.marketDebt[vToken] = 0;
             auction.highestBidBps = 0;
@@ -159,12 +159,12 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         VToken[] memory vTokens = _getAllMarkets(comptroller);
         marketsCount = vTokens.length;
         PriceOracle priceOracle = _getPriceOracle(comptroller);
-        uint256 poolBadDebt = 0;
+        uint256 poolBadDebt;
 
         uint256[] memory marketsDebt = new uint256[](marketsCount);
         auction.markets = new VToken[](marketsCount);
 
-        for (uint256 i = 0; i < marketsCount; ++i) {
+        for (uint256 i; i < marketsCount; ++i) {
             uint256 marketBadDebt = vTokens[i].badDebt();
 
             priceOracle.updatePrice(address(vTokens[i]));
@@ -234,7 +234,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         );
 
         uint256 marketsCount = auction.markets.length;
-        for (uint256 i = 0; i < marketsCount; ++i) {
+        for (uint256 i; i < marketsCount; ++i) {
             VToken vToken = VToken(address(auction.markets[i]));
             IERC20 erc20 = IERC20(address(vToken.underlying()));
 
@@ -281,7 +281,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
         auction.status = AuctionStatus.ENDED;
 
-        for (uint256 i = 0; i < marketsCount; ++i) {
+        for (uint256 i; i < marketsCount; ++i) {
             VToken vToken = VToken(address(auction.markets[i]));
             IERC20 erc20 = IERC20(address(vToken.underlying()));
 

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -40,7 +40,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
     /// @notice Emitted when a auction starts
     event AuctionStarted(
-        address comptroller,
+        address indexed comptroller,
         uint256 startBlock,
         AuctionType auctionType,
         VToken[] markets,
@@ -50,12 +50,12 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     );
 
     /// @notice Emitted when a bid is placed
-    event BidPlaced(address comptroller, uint256 bidBps, address bidder);
+    event BidPlaced(address indexed comptroller, uint256 bidBps, address indexed bidder);
 
     /// @notice Emitted when a auction is completed
     event AuctionClosed(
-        address comptroller,
-        address highestBidder,
+        address indexed comptroller,
+        address indexed highestBidder,
         uint256 highestBidBps,
         uint256 seizedRiskFind,
         VToken[] markets,
@@ -63,7 +63,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     );
 
     /// @notice Emitted when a auction is restarted
-    event AuctionRestarted(address comptroller);
+    event AuctionRestarted(address indexed comptroller);
 
     /// @notice Pool registry address
     address public poolRegistry;

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -146,7 +146,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             "auction is on-going"
         );
 
-        for (uint256 i = 0; i < auction.markets.length; i++) {
+        for (uint256 i = 0; i < auction.markets.length; ++i) {
             VToken vToken = auction.markets[i];
             auction.marketDebt[vToken] = 0;
             auction.highestBidBps = 0;
@@ -164,7 +164,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         uint256[] memory marketsDebt = new uint256[](vTokens.length);
         auction.markets = new VToken[](vTokens.length);
 
-        for (uint256 i = 0; i < vTokens.length; i++) {
+        for (uint256 i = 0; i < vTokens.length; ++i) {
             uint256 marketBadDebt = vTokens[i].badDebt();
 
             priceOracle.updatePrice(address(vTokens[i]));
@@ -233,7 +233,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             "your bid is not the highest"
         );
 
-        for (uint256 i = 0; i < auction.markets.length; i++) {
+        for (uint256 i = 0; i < auction.markets.length; ++i) {
             VToken vToken = VToken(address(auction.markets[i]));
             IERC20 erc20 = IERC20(address(vToken.underlying()));
 
@@ -279,7 +279,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
         auction.status = AuctionStatus.ENDED;
 
-        for (uint256 i = 0; i < auction.markets.length; i++) {
+        for (uint256 i = 0; i < auction.markets.length; ++i) {
             VToken vToken = VToken(address(auction.markets[i]));
             IERC20 erc20 = IERC20(address(vToken.underlying()));
 

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -168,7 +168,7 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             uint256 marketBadDebt = vTokens[i].badDebt();
 
             priceOracle.updatePrice(address(vTokens[i]));
-            uint256 usdValue = (priceOracle.getUnderlyingPrice(address(vTokens[i])) * marketBadDebt) / 10**18;
+            uint256 usdValue = (priceOracle.getUnderlyingPrice(address(vTokens[i])) * marketBadDebt) / 1e18;
 
             poolBadDebt = poolBadDebt + usdValue;
             auction.markets[i] = vTokens[i];

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -149,7 +149,7 @@ contract VToken is WithAdminUpgradeable, VTokenInterface, ExponentialNoError, To
         }
 
         /* Get the allowance, infinite for the account owner */
-        uint256 startingAllowance = 0;
+        uint256 startingAllowance;
         if (spender == src) {
             startingAllowance = type(uint256).max;
         } else {


### PR DESCRIPTION
This PR implements the following improvement suggestions from the internal audit report:

- **VENUS-IMP-001** ABICoder V2 Enabled By The Default After 0.8.x
- **VENUS-IMP-003** `++i` is cheaper than `i++`
- **VENUS-IMP-004** Caching array length can save gas
- **VENUS-IMP-005** Events are not indexed
- **VENUS-IMP-006** No need to initialize variables with default value
- **VENUS-IMP-008** Dont compare boolean expressions to boolean literals
- **VENUS-IMP-010** Use of power operations instead of their exponential form

Other improvement suggestions either need further discussion or will be addressed in the scope of a bigger refactoring (e.g. moving from error strings to custom error messages).

Note that "caching the error length" commit also moves some logic to separate internal functions to prevent stack too deep errors, so these are not purely stylistic changes and should be reviewed with full attention.