### PR TITLE
Fixes for internal audit findings

### DIFF
--- a/contracts/Governance/AccessControlManager.sol
+++ b/contracts/Governance/AccessControlManager.sol
@@ -28,7 +28,7 @@ contract AccessControlManager is AccessControl {
      * @notice Verifies if the given account can call a contract's guarded function
      * @dev Since restricted contracts using this function as a permission hook, we can get contracts address with msg.sender
      * @param account for which call permissions will be checked
-     * @param functionSig restricted function signature e.g. "functionName(uint,bool)"
+     * @param functionSig restricted function signature e.g. "functionName(uint256,bool)"
      * @return false if the user account cannot call the particular contract function
      *
      */
@@ -48,7 +48,7 @@ contract AccessControlManager is AccessControl {
      * @dev This function is used as a view function to check permissions rather than contract hook for access restriction check.
      * @param account for which call permissions will be checked against
      * @param contractAddress address of the restricted contract
-     * @param functionSig signature of the restricted function e.g. "functionName(uint,bool)"
+     * @param functionSig signature of the restricted function e.g. "functionName(uint256,bool)"
      * @return false if the user account cannot call the particular contract function
      */
     function hasPermission(
@@ -67,7 +67,7 @@ contract AccessControlManager is AccessControl {
      * @param contractAddress address of contract for which call permissions will be granted
      * NOTE: if contractAddress is zero address, the account can access the certain function
      *      on **any** contract managed by this ACL
-     * @param functionSig signature e.g. "functionName(uint,bool)"
+     * @param functionSig signature e.g. "functionName(uint256,bool)"
      * @param accountToPermit account that will be given access to the contract function
      * Emits {PermissionGranted} event.
      */
@@ -86,7 +86,7 @@ contract AccessControlManager is AccessControl {
      * @dev this function can be called only from Role Admin or DEFAULT_ADMIN_ROLE
      * 		May emit a {RoleRevoked} event.
      * @param contractAddress address of contract for which call permissions will be revoked
-     * @param functionSig signature e.g. "functionName(uint,bool)"
+     * @param functionSig signature e.g. "functionName(uint256,bool)"
      * Emits {PermissionRevoked} event.
      */
     function revokeCallPermission(

--- a/contracts/Governance/AccessControlManager.sol
+++ b/contracts/Governance/AccessControlManager.sol
@@ -38,7 +38,7 @@ contract AccessControlManager is AccessControl {
         if (hasRole(role, account)) {
             return true;
         } else {
-            role = keccak256(abi.encodePacked(DEFAULT_ADMIN_ROLE, functionSig));
+            role = keccak256(abi.encodePacked(address(0), functionSig));
             return hasRole(role, account);
         }
     }
@@ -63,10 +63,10 @@ contract AccessControlManager is AccessControl {
     /**
      * @notice Gives a function call permission to one single account
      * @dev this function can be called only from Role Admin or DEFAULT_ADMIN_ROLE
-     * 		May emit a {RoleGranted} event.
+     * 		May emit a {RoleGranted} and {PermissionGranted} events.
      * @param contractAddress address of contract for which call permissions will be granted
-     * NOTE: if contractAddress is zero address, we give the account DEFAULT_ADMIN_ROLE,
-     *      meaning that this account can access the certain function on ANY contract managed by this ACL
+     * NOTE: if contractAddress is zero address, the account can access the certain function
+     *      on **any** contract managed by this ACL
      * @param functionSig signature e.g. "functionName(uint,bool)"
      * @param accountToPermit account that will be given access to the contract function
      * Emits {PermissionGranted} event.
@@ -76,13 +76,7 @@ contract AccessControlManager is AccessControl {
         string memory functionSig,
         address accountToPermit
     ) public {
-        bytes32 role;
-        if (contractAddress == address(0)) {
-            role = keccak256(abi.encodePacked(DEFAULT_ADMIN_ROLE, functionSig));
-        } else {
-            role = keccak256(abi.encodePacked(contractAddress, functionSig));
-        }
-
+        bytes32 role = keccak256(abi.encodePacked(contractAddress, functionSig));
         grantRole(role, accountToPermit);
         emit PermissionGranted(accountToPermit, contractAddress, functionSig);
     }

--- a/contracts/Governance/AccessControlManager.sol
+++ b/contracts/Governance/AccessControlManager.sol
@@ -11,7 +11,7 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
  */
 contract AccessControlManager is AccessControl {
     /// @notice Emitted when an account is given a permission to a certain contract function
-    /// NOTE: If contract address is 0x000..0 this means that the account is a default admin of this function and
+    /// @dev If contract address is 0x000..0 this means that the account is a default admin of this function and
     /// can call any contract function with this signature
     event PermissionGranted(address account, address contractAddress, string functionSig);
 
@@ -63,13 +63,12 @@ contract AccessControlManager is AccessControl {
     /**
      * @notice Gives a function call permission to one single account
      * @dev this function can be called only from Role Admin or DEFAULT_ADMIN_ROLE
-     * 		May emit a {RoleGranted} and {PermissionGranted} events.
      * @param contractAddress address of contract for which call permissions will be granted
-     * NOTE: if contractAddress is zero address, the account can access the certain function
+     * @dev if contractAddress is zero address, the account can access the specified function
      *      on **any** contract managed by this ACL
      * @param functionSig signature e.g. "functionName(uint256,bool)"
      * @param accountToPermit account that will be given access to the contract function
-     * Emits {PermissionGranted} event.
+     * @custom:events Emits a {RoleGranted} and {PermissionGranted} events.
      */
     function giveCallPermission(
         address contractAddress,
@@ -87,7 +86,7 @@ contract AccessControlManager is AccessControl {
      * 		May emit a {RoleRevoked} event.
      * @param contractAddress address of contract for which call permissions will be revoked
      * @param functionSig signature e.g. "functionName(uint256,bool)"
-     * Emits {PermissionRevoked} event.
+     * @custom:events Emits {RoleRevoked} and {PermissionRevoked} events.
      */
     function revokeCallPermission(
         address contractAddress,

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../ExponentialNoError.sol";
 import "../VToken.sol";
 import "../Comptroller.sol";
@@ -81,6 +81,8 @@ contract RewardsDistributor is ExponentialNoError, OwnableUpgradeable {
     Comptroller private comptroller;
 
     IERC20 private rewardToken;
+
+    using SafeERC20 for IERC20;
 
     /**
      * @dev Initializes the deployer to owner.
@@ -311,7 +313,7 @@ contract RewardsDistributor is ExponentialNoError, OwnableUpgradeable {
     function grantRewardTokenInternal(address user, uint256 amount) internal returns (uint256) {
         uint256 rewardTokenRemaining = rewardToken.balanceOf(address(this));
         if (amount > 0 && amount <= rewardTokenRemaining) {
-            rewardToken.transfer(user, amount);
+            rewardToken.safeTransfer(user, amount);
             return 0;
         }
         return amount;

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -25,13 +25,31 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
     address private auctionContractAddress;
     address private accessControl;
 
-    // Store base asset's reserve for specific pool.
+    // Store base asset's reserve for specific pool
     mapping(address => uint256) private poolReserves;
+
+    /// @notice Emitted when pool registry address is updated
+    event PoolRegistryUpdated(address indexed oldPoolRegistry, address indexed newPoolRegistry);
+
+    /// @notice Emitted when convertable base asset address is updated
+    event ConvertableBaseAssetUpdated(address indexed oldBaseAsset, address indexed newBaseAsset);
+
+    /// @notice Emitted when auction contract address is updated
+    event AuctionContractUpdated(address indexed oldAuctionContract, address indexed newAuctionContract);
+
+    /// @notice Emitted when PancakeSwap router contract address is updated
+    event PancakeSwapRouterUpdated(address indexed oldPancakeSwapRouter, address indexed newPancakeSwapRouter);
+
+    /// @notice Emitted when min amount out for PancakeSwap is updated
+    event AmountOutMinUpdated(uint256 oldAmountOutMin, uint256 newAmountOutMin);
+
+    /// @notice Emitted when minimum amount to convert is updated
+    event MinAmountToConvertUpdated(uint256 oldMinAmountToConvert, uint256 newMinAmountToConvert);
 
     /**
      * @dev Initializes the deployer to owner.
-     * @param _pancakeSwapRouter Address of the pancake swap router.
-     * @param _amountOutMin Min amount out for the pancake swap.
+     * @param _pancakeSwapRouter Address of the PancakeSwap router
+     * @param _amountOutMin Min amount out for the PancakeSwap
      * @param _minAmountToConvert Asset should be worth of min amount to convert into base asset
      * @param _convertableBaseAsset Address of the base asset
      * @param _accessControl Address of the access control contract.
@@ -62,7 +80,9 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
      */
     function setPoolRegistry(address _poolRegistry) external onlyOwner {
         require(_poolRegistry != address(0), "Risk Fund: Pool registry address invalid");
+        address oldPoolRegistry = poolRegistry;
         poolRegistry = _poolRegistry;
+        emit PoolRegistryUpdated(oldPoolRegistry, _poolRegistry);
     }
 
     /**
@@ -71,7 +91,9 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
      */
     function setConvertableBaseAsset(address _convertableBaseAsset) external onlyOwner {
         require(_convertableBaseAsset != address(0), "Risk Fund: Asset address invalid");
+        address oldBaseAsset = convertableBaseAsset;
         convertableBaseAsset = _convertableBaseAsset;
+        emit ConvertableBaseAssetUpdated(oldBaseAsset, _convertableBaseAsset);
     }
 
     /**
@@ -80,7 +102,9 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
      */
     function setAuctionContractAddress(address _auctionContractAddress) external onlyOwner {
         require(_auctionContractAddress != address(0), "Risk Fund: Auction contract address invalid");
+        address oldAuctionContractAddress = auctionContractAddress;
         auctionContractAddress = _auctionContractAddress;
+        emit AuctionContractUpdated(oldAuctionContractAddress, _auctionContractAddress);
     }
 
     /**
@@ -88,8 +112,10 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
      * @param _pancakeSwapRouter Address of the pancake swap router.
      */
     function setPancakeSwapRouter(address _pancakeSwapRouter) external onlyOwner {
-        require(_pancakeSwapRouter != address(0), "Risk Fund: Pancake swap address invalid");
+        require(_pancakeSwapRouter != address(0), "Risk Fund: PancakeSwap address invalid");
+        address oldPancakeSwapRouter = pancakeSwapRouter;
         pancakeSwapRouter = _pancakeSwapRouter;
+        emit PancakeSwapRouterUpdated(oldPancakeSwapRouter, _pancakeSwapRouter);
     }
 
     /**
@@ -98,7 +124,9 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
      */
     function setAmountOutMin(uint256 _amountOutMin) external onlyOwner {
         require(_amountOutMin >= 0, "Risk Fund: Min amount out invalid");
+        uint256 oldAmountOutMin = amountOutMin;
         amountOutMin = _amountOutMin;
+        emit AmountOutMinUpdated(oldAmountOutMin, _amountOutMin);
     }
 
     /**
@@ -107,7 +135,9 @@ contract RiskFund is OwnableUpgradeable, ExponentialNoError, ReserveHelpers {
      */
     function setMinAmountToConvert(uint256 _minAmountToConvert) external onlyOwner {
         require(_minAmountToConvert > 0, "Risk Fund: Invalid min amout to convert");
+        uint256 oldMinAmountToConvert = minAmountToConvert;
         minAmountToConvert = _minAmountToConvert;
+        emit MinAmountToConvertUpdated(oldMinAmountToConvert, _minAmountToConvert);
     }
 
     /**

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -65,6 +65,12 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice Emitted when a auction is restarted
     event AuctionRestarted(address indexed comptroller);
 
+    /// @notice Emitted when pool registry address is updated
+    event PoolRegistryUpdated(address indexed oldPoolRegistry, address indexed newPoolRegistry);
+
+    /// @notice Emitted when minimum pool bad debt is updated
+    event MinimumPoolBadDebtUpdated(uint256 oldMinimumPoolBadDebt, uint256 newMinimumPoolBadDebt);
+
     /// @notice Pool registry address
     address public poolRegistry;
 
@@ -115,7 +121,9 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
      * @param _minimumPoolBadDebt Minimum bad debt in BUSD for a pool to start auction
      */
     function updateMinimumPoolBadDebt(uint256 _minimumPoolBadDebt) public onlyOwner {
+        uint256 oldMinimumPoolBadDebt = minimumPoolBadDebt;
         minimumPoolBadDebt = _minimumPoolBadDebt;
+        emit MinimumPoolBadDebtUpdated(oldMinimumPoolBadDebt, _minimumPoolBadDebt);
     }
 
     /**
@@ -124,7 +132,9 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
      */
     function setPoolRegistry(address _poolRegistry) public onlyOwner {
         require(_poolRegistry != address(0), "invalid address");
+        address oldPoolRegistry = poolRegistry;
         poolRegistry = _poolRegistry;
+        emit PoolRegistryUpdated(oldPoolRegistry, _poolRegistry);
     }
 
     /**

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -126,14 +126,6 @@ contract Shortfall is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     }
 
     /**
-     * @notice Modifier to allow only pool registry to call functions
-     */
-    modifier onlyPoolRegistry() {
-        require(msg.sender == poolRegistry, "caller is not pool registry");
-        _;
-    }
-
-    /**
      * @notice Start a auction
      * @param comptroller comptroller of the pool
      */

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -1,6 +1,9 @@
 import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import BigNumber from "bignumber.js";
-import { expect } from "chai";
+import chai from "chai";
+import { constants } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers } from "hardhat";
 import sleep from "sleep-promise";
@@ -19,266 +22,321 @@ import {
   VToken__factory,
 } from "../../typechain";
 
-describe("Shortfall: Tests", async function () {
-  let shortfall: MockContract<Shortfall>;
-  let fakeRiskFund: FakeContract<IRiskFund>;
-  let mockBUSD: MockToken;
-  let mockDAI: MockToken;
-  let mockWBTC: MockToken;
-  let vDAI: MockContract<VToken>;
-  let vWBTC: MockContract<VToken>;
-  let comptroller: MockContract<Comptroller>;
-  let fakeAccessControlManager: FakeContract<AccessControlManager>;
-  let fakePriceOracle: FakeContract<PriceOracle>;
+const { expect } = chai;
+chai.use(smock.matchers);
 
-  let riskFundBalance = "10000";
-  const minimumPoolBadDebt = "10000";
-  let poolId;
+let owner: SignerWithAddress;
+let poolRegistry: SignerWithAddress;
+let someone: SignerWithAddress;
+let shortfall: MockContract<Shortfall>;
+let fakeRiskFund: FakeContract<IRiskFund>;
+let mockBUSD: MockToken;
+let mockDAI: MockToken;
+let mockWBTC: MockToken;
+let vDAI: MockContract<VToken>;
+let vWBTC: MockContract<VToken>;
+let comptroller: MockContract<Comptroller>;
+let fakeAccessControlManager: FakeContract<AccessControlManager>;
+let fakePriceOracle: FakeContract<PriceOracle>;
 
-  async function mineNBlocks(n: number) {
-    for (let index = 0; index < n; index++) {
-      await ethers.provider.send("evm_mine", [Date.now() * 1000]);
-      await sleep(100);
+let riskFundBalance = "10000";
+const minimumPoolBadDebt = "10000";
+let poolId;
+
+async function mineNBlocks(n: number) {
+  for (let index = 0; index < n; index++) {
+    await ethers.provider.send("evm_mine", [Date.now() * 1000]);
+    await sleep(100);
+  }
+}
+
+/**
+ * Deploying required contracts along with the poolRegistry.
+ */
+async function shortfallFixture() {
+  const MockBUSD = await ethers.getContractFactory("MockToken");
+  mockBUSD = await MockBUSD.deploy("BUSD", "BUSD", 18);
+  await mockBUSD.faucet(convertToUnit(100000, 18));
+
+  fakeRiskFund = await smock.fake<IRiskFund>("IRiskFund");
+
+  const Shortfall = await smock.mock<Shortfall__factory>("Shortfall");
+  shortfall = await Shortfall.deploy();
+  await shortfall.initialize(mockBUSD.address, fakeRiskFund.address, parseUnits(minimumPoolBadDebt, "18"));
+
+  [owner, poolRegistry, someone] = await ethers.getSigners();
+  await shortfall.setPoolRegistry(poolRegistry.address);
+
+  //Deploy Mock Tokens
+  const MockDAI = await ethers.getContractFactory("MockToken");
+  mockDAI = await MockDAI.deploy("MakerDAO", "DAI", 18);
+  await mockDAI.faucet(convertToUnit(1000000, 18));
+
+  const MockWBTC = await ethers.getContractFactory("MockToken");
+  mockWBTC = await MockWBTC.deploy("Bitcoin", "BTC", 8);
+  await mockWBTC.faucet(convertToUnit(1000000, 8));
+
+  fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
+  fakeAccessControlManager.isAllowedToCall.returns(true);
+
+  const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
+  comptroller = await Comptroller.deploy(poolRegistry.address, fakeAccessControlManager.address);
+  poolId = comptroller.address;
+
+  const VToken = await smock.mock<VToken__factory>("VToken");
+  vDAI = await VToken.deploy();
+  vWBTC = await VToken.deploy();
+
+  await vWBTC.setVariable("decimals", 8);
+  vDAI.decimals.returns(18);
+
+  vDAI.underlying.returns(mockDAI.address);
+  await vWBTC.setVariable("underlying", mockWBTC.address);
+
+  await vDAI.setVariable("shortfall", shortfall.address);
+  await vWBTC.setVariable("shortfall", shortfall.address);
+
+  comptroller.getAllMarkets.returns(() => {
+    return [vDAI.address, vWBTC.address];
+  });
+
+  fakePriceOracle = await smock.fake<PriceOracle>("PriceOracle");
+
+  const btcPrice = "21000.34";
+  const daiPrice = "1";
+
+  fakePriceOracle.getUnderlyingPrice.returns((args: any) => {
+    if (vDAI && vWBTC) {
+      if (args[0] === vDAI.address) {
+        return convertToUnit(daiPrice, 18);
+      } else {
+        return convertToUnit(btcPrice, 28);
+      }
     }
+
+    return 1;
+  });
+
+  comptroller.oracle.returns(fakePriceOracle.address);
+
+  fakeRiskFund.getPoolReserve.returns(parseUnits(riskFundBalance, 18));
+  fakeRiskFund.transferReserveForAuction.returns(0);
+}
+
+describe("Shortfall: Tests", async function () {
+  async function setup() {
+    await loadFixture(shortfallFixture);
   }
 
-  /**
-   * Deploying required contracts along with the poolRegistry.
-   */
-  before(async function () {
-    const MockBUSD = await ethers.getContractFactory("MockToken");
-    mockBUSD = await MockBUSD.deploy("BUSD", "BUSD", 18);
-    await mockBUSD.faucet(convertToUnit(100000, 18));
+  describe("setters", async function () {
+    beforeEach(setup);
 
-    fakeRiskFund = await smock.fake<IRiskFund>("IRiskFund");
+    describe("setPoolRegistry", async function () {
+      it("reverts on invalid PoolRegistry address", async function () {
+        await expect(shortfall.setPoolRegistry(constants.AddressZero)).to.be.rejectedWith("invalid address");
+      });
 
-    const Shortfall = await smock.mock<Shortfall__factory>("Shortfall");
-    shortfall = await Shortfall.deploy();
-    await shortfall.initialize(mockBUSD.address, fakeRiskFund.address, parseUnits(minimumPoolBadDebt, "18"));
+      it("fails if called by a non-owner", async function () {
+        await expect(shortfall.connect(someone).setPoolRegistry(poolRegistry.address)).to.be.rejectedWith(
+          "Ownable: caller is not the owner",
+        );
+      });
 
-    const [poolRegistry] = await ethers.getSigners();
-    await shortfall.setPoolRegistry(poolRegistry.address);
-
-    //Deploy Mock Tokens
-    const MockDAI = await ethers.getContractFactory("MockToken");
-    mockDAI = await MockDAI.deploy("MakerDAO", "DAI", 18);
-    await mockDAI.faucet(convertToUnit(1000000, 18));
-
-    const MockWBTC = await ethers.getContractFactory("MockToken");
-    mockWBTC = await MockWBTC.deploy("Bitcoin", "BTC", 8);
-    await mockWBTC.faucet(convertToUnit(1000000, 8));
-
-    fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
-    fakeAccessControlManager.isAllowedToCall.returns(true);
-
-    const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-    comptroller = await Comptroller.deploy(poolRegistry.address, fakeAccessControlManager.address);
-    poolId = comptroller.address;
-
-    const VToken = await smock.mock<VToken__factory>("VToken");
-    vDAI = await VToken.deploy();
-    vWBTC = await VToken.deploy();
-
-    await vWBTC.setVariable("decimals", 8);
-    vDAI.decimals.returns(18);
-
-    vDAI.underlying.returns(mockDAI.address);
-    await vWBTC.setVariable("underlying", mockWBTC.address);
-
-    await vDAI.setVariable("shortfall", shortfall.address);
-    await vWBTC.setVariable("shortfall", shortfall.address);
-
-    comptroller.getAllMarkets.returns(() => {
-      return [vDAI.address, vWBTC.address];
+      it("emits PoolRegistryUpdated event", async function () {
+        const tx = shortfall.setPoolRegistry(someone.address);
+        await expect(tx).to.emit(shortfall, "PoolRegistryUpdated").withArgs(poolRegistry.address, someone.address);
+      });
     });
 
-    fakePriceOracle = await smock.fake<PriceOracle>("PriceOracle");
+    describe("updateMinimumPoolBadDebt", async function () {
+      it("fails if called by a non-owner", async function () {
+        await expect(shortfall.connect(someone).updateMinimumPoolBadDebt(1)).to.be.rejectedWith(
+          "Ownable: caller is not the owner",
+        );
+      });
 
-    const btcPrice = "21000.34";
-    const daiPrice = "1";
+      it("updates minimumPoolBadDebt in storage", async function () {
+        await shortfall.updateMinimumPoolBadDebt(1);
+        expect(await shortfall.minimumPoolBadDebt()).to.equal(1);
+      });
 
-    fakePriceOracle.getUnderlyingPrice.returns((args: any) => {
-      if (vDAI && vWBTC) {
-        if (args[0] === vDAI.address) {
-          return convertToUnit(daiPrice, 18);
-        } else {
-          return convertToUnit(btcPrice, 28);
-        }
-      }
+      it("emits MinimumPoolBadDebtUpdated event", async function () {
+        const tx = shortfall.updateMinimumPoolBadDebt(1);
+        await expect(tx)
+          .to.emit(shortfall, "MinimumPoolBadDebtUpdated")
+          .withArgs(parseUnits(minimumPoolBadDebt, "18"), 1);
+      });
+    });
+  });
 
-      return 1;
+  describe("Scenario 1", async function () {
+    before(setup);
+
+    it("Should have debt and reserve", async function () {
+      vDAI.badDebt.returns(parseUnits("1000", 18));
+      vWBTC.badDebt.returns(parseUnits("1", 8));
+
+      expect(await fakeRiskFund.getPoolReserve(comptroller.address)).equal(parseUnits(riskFundBalance, 18).toString());
+
+      expect(await vDAI.badDebt()).equal(parseUnits("1000", 18));
+      expect(await vWBTC.badDebt()).equal(parseUnits("1", 8));
     });
 
-    comptroller.oracle.returns(fakePriceOracle.address);
+    it("Should not be able to start auction", async function () {
+      vDAI.badDebt.returns(parseUnits("20", 18));
+      vWBTC.badDebt.returns(parseUnits("0.01", 8));
 
-    fakeRiskFund.getPoolReserve.returns(parseUnits(riskFundBalance, 18));
-    fakeRiskFund.transferReserveForAuction.returns(0);
+      await expect(shortfall.startAuction(poolId)).to.be.reverted;
+    });
+
+    it("Scenerio 1 - Start auction", async function () {
+      vDAI.badDebt.returns(parseUnits("10000", 18));
+      await vDAI.setVariable("badDebt", parseUnits("10000", 18));
+      vWBTC.badDebt.returns(parseUnits("2", 8));
+      await vWBTC.setVariable("badDebt", parseUnits("2", 8));
+
+      await shortfall.startAuction(poolId);
+
+      const auction = await shortfall.auctions(poolId);
+      expect(auction.status).equal(1);
+      expect(auction.auctionType).equal(0);
+      expect(auction.seizedRiskFund).equal(parseUnits(riskFundBalance, 18));
+
+      const startBidBps = new BigNumber(new BigNumber("10000").times(0.9).times(100)).dividedBy("52000.68").toFixed(2);
+      expect(auction.startBidBps.toString()).equal(new BigNumber(startBidBps).times(100).toString());
+    });
+
+    it("Scenerio 1 - Place bid", async function () {
+      const auction = await shortfall.auctions(poolId);
+
+      await mockDAI.approve(shortfall.address, parseUnits("10000", 18));
+      await mockWBTC.approve(shortfall.address, parseUnits("2", 8));
+
+      const previousDaiBalance = await mockDAI.balanceOf(owner.address);
+      const previousWBTCBalance = await mockWBTC.balanceOf(owner.address);
+
+      await shortfall.placeBid(poolId, auction.startBidBps);
+      expect((await mockDAI.balanceOf(owner.address)).div(parseUnits("1", 18)).toNumber()).lt(
+        previousDaiBalance.div(parseUnits("1", 18)).toNumber(),
+      );
+      expect((await mockWBTC.balanceOf(owner.address)).div(parseUnits("1", 8)).toNumber()).lt(
+        previousWBTCBalance.div(parseUnits("1", 8)).toNumber(),
+      );
+
+      let percentageToDeduct = new BigNumber(auction.startBidBps.toString()).dividedBy(100);
+      let total = new BigNumber((await vDAI.badDebt()).toString()).dividedBy(parseUnits("1", "18").toString());
+      let amountToDeduct = new BigNumber(total).times(percentageToDeduct).dividedBy(100).toString();
+      let amountDeducted = new BigNumber(previousDaiBalance.div(parseUnits("1", 18)).toString())
+        .minus((await mockDAI.balanceOf(owner.address)).div(parseUnits("1", 18)).toString())
+        .toString();
+      expect(amountDeducted).equal(amountToDeduct);
+
+      percentageToDeduct = new BigNumber(auction.startBidBps.toString()).dividedBy(100);
+      total = new BigNumber((await vWBTC.badDebt()).toString()).dividedBy(parseUnits("1", "8").toString());
+      amountToDeduct = new BigNumber(total).times(percentageToDeduct).dividedBy(100).toString();
+      amountDeducted = new BigNumber(previousWBTCBalance.toString())
+        .minus((await mockWBTC.balanceOf(owner.address)).toString())
+        .div(parseUnits("1", 8).toString())
+        .toString();
+      expect(amountDeducted).equal(amountToDeduct);
+    });
+
+    it("Scenario 1 - Close Auction", async function () {
+      await mineNBlocks((await shortfall.nextBidderBlockLimit()).toNumber() + 2);
+
+      //simulate transferReserveForAuction
+      await mockBUSD.transfer(shortfall.address, parseUnits(riskFundBalance, 18));
+
+      await shortfall.closeAuction(poolId);
+      const auction = await shortfall.auctions(poolId);
+      expect(auction.status).equal(2);
+
+      expect(vWBTC.badDebtRecovered).to.have.been.calledOnce;
+      expect(vWBTC.badDebtRecovered).to.have.been.calledWith(parseUnits("2", 8));
+
+      expect(vDAI.badDebtRecovered).to.have.been.calledOnce;
+      expect(vDAI.badDebtRecovered).to.have.been.calledWith(parseUnits("10000", 18));
+    });
   });
 
-  it("Should have debt and reserve", async function () {
-    vDAI.badDebt.returns(parseUnits("1000", 18));
-    vWBTC.badDebt.returns(parseUnits("1", 8));
+  describe("Scenario 2", async function () {
+    before(setup);
 
-    expect(await fakeRiskFund.getPoolReserve(comptroller.address)).equal(parseUnits(riskFundBalance, 18).toString());
+    it("Scenerio 2 - Start auction", async function () {
+      vDAI.badDebt.returns(parseUnits("10000", 18));
+      await vDAI.setVariable("badDebt", parseUnits("10000", 18));
+      vWBTC.badDebt.returns(parseUnits("1", 8));
+      await vWBTC.setVariable("badDebt", parseUnits("1", 8));
 
-    expect(await vDAI.badDebt()).equal(parseUnits("1000", 18));
-    expect(await vWBTC.badDebt()).equal(parseUnits("1", 8));
-  });
+      riskFundBalance = "50000";
+      fakeRiskFund.getPoolReserve.returns(parseUnits(riskFundBalance, 18));
 
-  it("Should not be able to start auction", async function () {
-    vDAI.badDebt.returns(parseUnits("20", 18));
-    vWBTC.badDebt.returns(parseUnits("0.01", 8));
+      await shortfall.startAuction(poolId);
 
-    await expect(shortfall.startAuction(poolId)).to.be.reverted;
-  });
+      const auction = await shortfall.auctions(poolId);
+      expect(auction.status).equal(1);
+      expect(auction.auctionType).equal(1);
 
-  it("Scenerio 1 - Start auction", async function () {
-    vDAI.badDebt.returns(parseUnits("10000", 18));
-    await vDAI.setVariable("badDebt", parseUnits("10000", 18));
-    vWBTC.badDebt.returns(parseUnits("2", 8));
-    await vWBTC.setVariable("badDebt", parseUnits("2", 8));
+      const startBidBps = new BigNumber(new BigNumber("21000.34").plus(10000).times(1.1).times(100)).dividedBy(
+        riskFundBalance,
+      );
+      expect(new BigNumber(startBidBps).times(riskFundBalance).dividedBy(100).toString()).equal(
+        new BigNumber(auction.seizedRiskFund.toString()).dividedBy(parseUnits("1", 18).toString()).toString(),
+      );
+    });
 
-    await shortfall.startAuction(poolId);
+    it("Scenerio 2 - Place bid", async function () {
+      const auction = await shortfall.auctions(poolId);
 
-    const auction = await shortfall.auctions(poolId);
-    expect(auction.status).equal(1);
-    expect(auction.auctionType).equal(0);
-    expect(auction.seizedRiskFund).equal(parseUnits(riskFundBalance, 18));
+      await mockDAI.approve(shortfall.address, parseUnits("10000", 18));
+      await mockWBTC.approve(shortfall.address, parseUnits("1", 8));
 
-    const startBidBps = new BigNumber(new BigNumber("10000").times(0.9).times(100)).dividedBy("52000.68").toFixed(2);
-    expect(auction.startBidBps.toString()).equal(new BigNumber(startBidBps).times(100).toString());
-  });
+      const previousDaiBalance = await mockDAI.balanceOf(owner.address);
+      const previousWBTCBalance = await mockWBTC.balanceOf(owner.address);
 
-  it("Scenerio 1 - Place bid", async function () {
-    const auction = await shortfall.auctions(poolId);
+      await shortfall.placeBid(poolId, auction.startBidBps);
+      expect((await mockDAI.balanceOf(owner.address)).div(parseUnits("1", 18)).toNumber()).lt(
+        previousDaiBalance.div(parseUnits("1", 18)).toNumber(),
+      );
+      expect((await mockWBTC.balanceOf(owner.address)).div(parseUnits("1", 8)).toNumber()).lt(
+        previousWBTCBalance.div(parseUnits("1", 8)).toNumber(),
+      );
 
-    await mockDAI.approve(shortfall.address, parseUnits("10000", 18));
-    await mockWBTC.approve(shortfall.address, parseUnits("2", 8));
+      let percentageToDeduct = new BigNumber(auction.startBidBps.toString()).dividedBy(100);
+      let total = new BigNumber((await vDAI.badDebt()).toString()).dividedBy(parseUnits("1", "18").toString());
+      let amountToDeduct = new BigNumber(total).times(percentageToDeduct).dividedBy(100).toString();
+      let amountDeducted = new BigNumber(previousDaiBalance.div(parseUnits("1", 18)).toString())
+        .minus((await mockDAI.balanceOf(owner.address)).div(parseUnits("1", 18)).toString())
+        .toString();
+      expect(amountDeducted).equal(amountToDeduct);
 
-    const [owner] = await ethers.getSigners();
+      percentageToDeduct = new BigNumber(auction.startBidBps.toString()).dividedBy(100);
+      total = new BigNumber((await vWBTC.badDebt()).toString()).dividedBy(parseUnits("1", "8").toString());
+      amountToDeduct = new BigNumber(total).times(percentageToDeduct).dividedBy(100).toString();
+      amountDeducted = new BigNumber(previousWBTCBalance.toString())
+        .minus((await mockWBTC.balanceOf(owner.address)).toString())
+        .div(parseUnits("1", 8).toString())
+        .toString();
+      expect(amountDeducted).equal(amountToDeduct);
+    });
 
-    const previousDaiBalance = await mockDAI.balanceOf(owner.address);
-    const previousWBTCBalance = await mockWBTC.balanceOf(owner.address);
+    it("Scenerio 2 - Close Auction", async function () {
+      let auction = await shortfall.auctions(poolId);
 
-    await shortfall.placeBid(poolId, auction.startBidBps);
-    expect((await mockDAI.balanceOf(owner.address)).div(parseUnits("1", 18)).toNumber()).lt(
-      previousDaiBalance.div(parseUnits("1", 18)).toNumber(),
-    );
-    expect((await mockWBTC.balanceOf(owner.address)).div(parseUnits("1", 8)).toNumber()).lt(
-      previousWBTCBalance.div(parseUnits("1", 8)).toNumber(),
-    );
+      await mineNBlocks((await shortfall.nextBidderBlockLimit()).toNumber() + 2);
 
-    let percentageToDeduct = new BigNumber(auction.startBidBps.toString()).dividedBy(100);
-    let total = new BigNumber((await vDAI.badDebt()).toString()).dividedBy(parseUnits("1", "18").toString());
-    let amountToDeduct = new BigNumber(total).times(percentageToDeduct).dividedBy(100).toString();
-    let amountDeducted = new BigNumber(previousDaiBalance.div(parseUnits("1", 18)).toString())
-      .minus((await mockDAI.balanceOf(owner.address)).div(parseUnits("1", 18)).toString())
-      .toString();
-    expect(amountDeducted).equal(amountToDeduct);
+      //simulate transferReserveForAuction
+      await mockBUSD.transfer(shortfall.address, auction.seizedRiskFund);
 
-    percentageToDeduct = new BigNumber(auction.startBidBps.toString()).dividedBy(100);
-    total = new BigNumber((await vWBTC.badDebt()).toString()).dividedBy(parseUnits("1", "8").toString());
-    amountToDeduct = new BigNumber(total).times(percentageToDeduct).dividedBy(100).toString();
-    amountDeducted = new BigNumber(previousWBTCBalance.toString())
-      .minus((await mockWBTC.balanceOf(owner.address)).toString())
-      .div(parseUnits("1", 8).toString())
-      .toString();
-    expect(amountDeducted).equal(amountToDeduct);
-  });
+      await shortfall.closeAuction(poolId);
+      auction = await shortfall.auctions(poolId);
+      expect(auction.status).equal(2);
 
-  it("Scenerio 1 - Close Auction", async function () {
-    await mineNBlocks((await shortfall.nextBidderBlockLimit()).toNumber() + 2);
+      expect(vWBTC.badDebtRecovered).to.have.been.calledTwice;
+      expect(vWBTC.badDebtRecovered).to.have.been.calledWith(parseUnits("1", 8));
 
-    //simulate transferReserveForAuction
-    await mockBUSD.transfer(shortfall.address, parseUnits(riskFundBalance, 18));
-
-    await shortfall.closeAuction(poolId);
-    const auction = await shortfall.auctions(poolId);
-    expect(auction.status).equal(2);
-
-    expect(vWBTC.badDebtRecovered).to.have.been.calledOnce;
-    expect(vWBTC.badDebtRecovered).to.have.been.calledWith(parseUnits("2", 8));
-
-    expect(vDAI.badDebtRecovered).to.have.been.calledOnce;
-    expect(vDAI.badDebtRecovered).to.have.been.calledWith(parseUnits("10000", 18));
-  });
-
-  it("Scenerio 2 - Start auction", async function () {
-    vDAI.badDebt.returns(parseUnits("10000", 18));
-    await vDAI.setVariable("badDebt", parseUnits("10000", 18));
-    vWBTC.badDebt.returns(parseUnits("1", 8));
-    await vWBTC.setVariable("badDebt", parseUnits("1", 8));
-
-    riskFundBalance = "50000";
-    fakeRiskFund.getPoolReserve.returns(parseUnits(riskFundBalance, 18));
-
-    await shortfall.startAuction(poolId);
-
-    const auction = await shortfall.auctions(poolId);
-    expect(auction.status).equal(1);
-    expect(auction.auctionType).equal(1);
-
-    const startBidBps = new BigNumber(new BigNumber("21000.34").plus(10000).times(1.1).times(100)).dividedBy(
-      riskFundBalance,
-    );
-    expect(new BigNumber(startBidBps).times(riskFundBalance).dividedBy(100).toString()).equal(
-      new BigNumber(auction.seizedRiskFund.toString()).dividedBy(parseUnits("1", 18).toString()).toString(),
-    );
-  });
-
-  it("Scenerio 2 - Place bid", async function () {
-    const auction = await shortfall.auctions(poolId);
-
-    await mockDAI.approve(shortfall.address, parseUnits("10000", 18));
-    await mockWBTC.approve(shortfall.address, parseUnits("1", 8));
-
-    const [owner] = await ethers.getSigners();
-
-    const previousDaiBalance = await mockDAI.balanceOf(owner.address);
-    const previousWBTCBalance = await mockWBTC.balanceOf(owner.address);
-
-    await shortfall.placeBid(poolId, auction.startBidBps);
-    expect((await mockDAI.balanceOf(owner.address)).div(parseUnits("1", 18)).toNumber()).lt(
-      previousDaiBalance.div(parseUnits("1", 18)).toNumber(),
-    );
-    expect((await mockWBTC.balanceOf(owner.address)).div(parseUnits("1", 8)).toNumber()).lt(
-      previousWBTCBalance.div(parseUnits("1", 8)).toNumber(),
-    );
-
-    let percentageToDeduct = new BigNumber(auction.startBidBps.toString()).dividedBy(100);
-    let total = new BigNumber((await vDAI.badDebt()).toString()).dividedBy(parseUnits("1", "18").toString());
-    let amountToDeduct = new BigNumber(total).times(percentageToDeduct).dividedBy(100).toString();
-    let amountDeducted = new BigNumber(previousDaiBalance.div(parseUnits("1", 18)).toString())
-      .minus((await mockDAI.balanceOf(owner.address)).div(parseUnits("1", 18)).toString())
-      .toString();
-    expect(amountDeducted).equal(amountToDeduct);
-
-    percentageToDeduct = new BigNumber(auction.startBidBps.toString()).dividedBy(100);
-    total = new BigNumber((await vWBTC.badDebt()).toString()).dividedBy(parseUnits("1", "8").toString());
-    amountToDeduct = new BigNumber(total).times(percentageToDeduct).dividedBy(100).toString();
-    amountDeducted = new BigNumber(previousWBTCBalance.toString())
-      .minus((await mockWBTC.balanceOf(owner.address)).toString())
-      .div(parseUnits("1", 8).toString())
-      .toString();
-    expect(amountDeducted).equal(amountToDeduct);
-  });
-
-  it("Scenerio 2 - Close Auction", async function () {
-    let auction = await shortfall.auctions(poolId);
-
-    await mineNBlocks((await shortfall.nextBidderBlockLimit()).toNumber() + 2);
-
-    //simulate transferReserveForAuction
-    await mockBUSD.transfer(shortfall.address, auction.seizedRiskFund);
-
-    await shortfall.closeAuction(poolId);
-    auction = await shortfall.auctions(poolId);
-    expect(auction.status).equal(2);
-
-    expect(vWBTC.badDebtRecovered).to.have.been.calledTwice;
-    expect(vWBTC.badDebtRecovered).to.have.been.calledWith(parseUnits("1", 8));
-
-    expect(vDAI.badDebtRecovered).to.have.been.calledTwice;
-    expect(vDAI.badDebtRecovered).to.have.been.calledWith(parseUnits("10000", 18));
+      expect(vDAI.badDebtRecovered).to.have.been.calledTwice;
+      expect(vDAI.badDebtRecovered).to.have.been.calledWith(parseUnits("10000", 18));
+    });
   });
 });


### PR DESCRIPTION
This is a PR with the fixes for internal audit findings. By now, the following items are addressed:

* VENUS-001 Unused modifier
* VENUS-002 AccessControlManager can not revokeCallPermission if if contractAddress is zero
* VENUS-005 Use safeTransfer instead of transfer
* VENUS-008 Emit events when updating important state variables