### PR TITLE
fix: [013] make function names adhere to Solidity style guide

### DIFF
--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -225,19 +225,16 @@ contract PoolRegistry is OwnableUpgradeable {
         Comptroller comptrollerProxy = Comptroller(proxyAddress);
 
         // Set Venus pool parameters
+        require(comptrollerProxy.setCloseFactor(closeFactor) == 0, "RegistryPool: Failed to set close factor of Pool.");
         require(
-            comptrollerProxy._setCloseFactor(closeFactor) == 0,
-            "RegistryPool: Failed to set close factor of Pool."
-        );
-        require(
-            comptrollerProxy._setLiquidationIncentive(liquidationIncentive) == 0,
+            comptrollerProxy.setLiquidationIncentive(liquidationIncentive) == 0,
             "RegistryPool: Failed to set liquidation incentive of Pool."
         );
 
-        comptrollerProxy._setMinLiquidatableCollateral(minLiquidatableCollateral);
+        comptrollerProxy.setMinLiquidatableCollateral(minLiquidatableCollateral);
 
         require(
-            comptrollerProxy._setPriceOracle(PriceOracle(priceOracle)) == 0,
+            comptrollerProxy.setPriceOracle(PriceOracle(priceOracle)) == 0,
             "RegistryPool: Failed to set price oracle of Pool."
         );
 
@@ -328,8 +325,8 @@ contract PoolRegistry is OwnableUpgradeable {
 
         VToken vToken = vTokenFactory.deployVTokenProxy(initializeArgs);
 
-        comptroller._supportMarket(vToken);
-        comptroller._setCollateralFactor(vToken, input.collateralFactor, input.liquidationThreshold);
+        comptroller.supportMarket(vToken);
+        comptroller.setCollateralFactor(vToken, input.collateralFactor, input.liquidationThreshold);
 
         _vTokens[input.comptroller][input.asset] = address(vToken);
         _supportedPools[input.asset].push(input.comptroller);

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -333,13 +333,13 @@ abstract contract VTokenInterface is VTokenStorage {
 
     /*** Admin Functions ***/
 
-    function _setComptroller(ComptrollerInterface newComptroller) external virtual returns (uint256);
+    function setComptroller(ComptrollerInterface newComptroller) external virtual;
 
-    function _setReserveFactor(uint256 newReserveFactorMantissa) external virtual returns (uint256);
+    function setReserveFactor(uint256 newReserveFactorMantissa) external virtual;
 
-    function _reduceReserves(uint256 reduceAmount) external virtual returns (uint256);
+    function reduceReserves(uint256 reduceAmount) external virtual;
 
-    function _setInterestRateModel(InterestRateModel newInterestRateModel) external virtual returns (uint256);
+    function setInterestRateModel(InterestRateModel newInterestRateModel) external virtual;
 
-    function _addReserves(uint256 addAmount) external virtual returns (uint256);
+    function addReserves(uint256 addAmount) external virtual;
 }

--- a/contracts/test/UpgradedVToken.sol
+++ b/contracts/test/UpgradedVToken.sol
@@ -41,7 +41,7 @@ contract UpgradedVToken is VToken {
         admin = payable(msg.sender);
 
         // Initialize the market
-        initializeInternal(
+        _initialize(
             underlying_,
             comptroller_,
             interestRateModel_,

--- a/contracts/test/VTokenHarness.sol
+++ b/contracts/test/VTokenHarness.sol
@@ -38,35 +38,35 @@ contract VTokenHarness is VToken {
         );
     }
 
-    function doTransferOut(address payable to, uint256 amount) internal override {
+    function _doTransferOut(address payable to, uint256 amount) internal override {
         require(failTransferToAddresses[to] == false, "HARNESS_TOKEN_TRANSFER_OUT_FAILED");
-        return super.doTransferOut(to, amount);
+        return super._doTransferOut(to, amount);
     }
 
-    function exchangeRateStoredInternal() internal view override returns (uint256) {
+    function _exchangeRateStored() internal view override returns (uint256) {
         if (harnessExchangeRateStored) {
             return harnessExchangeRate;
         }
-        return super.exchangeRateStoredInternal();
+        return super._exchangeRateStored();
     }
 
-    function getBlockNumber() internal view override returns (uint256) {
+    function _getBlockNumber() internal view override returns (uint256) {
         return blockNumber;
     }
 
-    function getBorrowRateMaxMantissa() public pure returns (uint256) {
+    function getBorrowRateMaxMantissa() external pure returns (uint256) {
         return borrowRateMaxMantissa;
     }
 
-    function harnessSetAccrualBlockNumber(uint256 _accrualblockNumber) public {
-        accrualBlockNumber = _accrualblockNumber;
+    function harnessSetAccrualBlockNumber(uint256 accrualBlockNumber_) external {
+        accrualBlockNumber = accrualBlockNumber_;
     }
 
-    function harnessSetBlockNumber(uint256 newBlockNumber) public {
+    function harnessSetBlockNumber(uint256 newBlockNumber) external {
         blockNumber = newBlockNumber;
     }
 
-    function harnessFastForward(uint256 blocks) public {
+    function harnessFastForward(uint256 blocks) external {
         blockNumber += blocks;
     }
 
@@ -74,15 +74,15 @@ contract VTokenHarness is VToken {
         accountTokens[account] = amount;
     }
 
-    function harnessSetTotalSupply(uint256 totalSupply_) public {
+    function harnessSetTotalSupply(uint256 totalSupply_) external {
         totalSupply = totalSupply_;
     }
 
-    function harnessSetTotalBorrows(uint256 totalBorrows_) public {
+    function harnessSetTotalBorrows(uint256 totalBorrows_) external {
         totalBorrows = totalBorrows_;
     }
 
-    function harnessSetTotalReserves(uint256 totalReserves_) public {
+    function harnessSetTotalReserves(uint256 totalReserves_) external {
         totalReserves = totalReserves_;
     }
 
@@ -90,36 +90,34 @@ contract VTokenHarness is VToken {
         uint256 totalSupply_,
         uint256 totalBorrows_,
         uint256 totalReserves_
-    ) public {
+    ) external {
         totalSupply = totalSupply_;
         totalBorrows = totalBorrows_;
         totalReserves = totalReserves_;
     }
 
-    function harnessSetExchangeRate(uint256 exchangeRate) public {
+    function harnessSetExchangeRate(uint256 exchangeRate) external {
         harnessExchangeRate = exchangeRate;
         harnessExchangeRateStored = true;
     }
 
-    function harnessSetFailTransferToAddress(address _to, bool _fail) public {
-        failTransferToAddresses[_to] = _fail;
+    function harnessSetFailTransferToAddress(address to_, bool fail_) external {
+        failTransferToAddresses[to_] = fail_;
     }
 
-    function harnessMintFresh(address account, uint256 mintAmount) public returns (uint256) {
-        super.mintFresh(account, mintAmount);
-        return NO_ERROR;
+    function harnessMintFresh(address account, uint256 mintAmount) external {
+        super._mintFresh(account, mintAmount);
     }
 
     function harnessRedeemFresh(
         address payable account,
         uint256 vTokenAmount,
         uint256 underlyingAmount
-    ) public returns (uint256) {
-        super.redeemFresh(account, vTokenAmount, underlyingAmount);
-        return NO_ERROR;
+    ) external {
+        super._redeemFresh(account, vTokenAmount, underlyingAmount);
     }
 
-    function harnessAccountBorrows(address account) public view returns (uint256 principal, uint256 interestIndex) {
+    function harnessAccountBorrows(address account) external view returns (uint256 principal, uint256 interestIndex) {
         BorrowSnapshot memory snapshot = accountBorrows[account];
         return (snapshot.principal, snapshot.interestIndex);
     }
@@ -128,26 +126,24 @@ contract VTokenHarness is VToken {
         address account,
         uint256 principal,
         uint256 interestIndex
-    ) public {
+    ) external {
         accountBorrows[account] = BorrowSnapshot({ principal: principal, interestIndex: interestIndex });
     }
 
-    function harnessSetBorrowIndex(uint256 borrowIndex_) public {
+    function harnessSetBorrowIndex(uint256 borrowIndex_) external {
         borrowIndex = borrowIndex_;
     }
 
-    function harnessBorrowFresh(address payable account, uint256 borrowAmount) public returns (uint256) {
-        borrowFresh(account, borrowAmount);
-        return NO_ERROR;
+    function harnessBorrowFresh(address payable account, uint256 borrowAmount) external {
+        _borrowFresh(account, borrowAmount);
     }
 
     function harnessRepayBorrowFresh(
         address payer,
         address account,
         uint256 repayAmount
-    ) public returns (uint256) {
-        repayBorrowFresh(payer, account, repayAmount);
-        return NO_ERROR;
+    ) external {
+        _repayBorrowFresh(payer, account, repayAmount);
     }
 
     function harnessLiquidateBorrowFresh(
@@ -156,21 +152,20 @@ contract VTokenHarness is VToken {
         uint256 repayAmount,
         VToken vTokenCollateral,
         bool skipLiquidityCheck
-    ) public returns (uint256) {
-        liquidateBorrowFresh(liquidator, borrower, repayAmount, vTokenCollateral, skipLiquidityCheck);
-        return NO_ERROR;
+    ) external {
+        _liquidateBorrowFresh(liquidator, borrower, repayAmount, vTokenCollateral, skipLiquidityCheck);
     }
 
-    function harnessReduceReservesFresh(uint256 amount) public returns (uint256) {
+    function harnessReduceReservesFresh(uint256 amount) external {
         return _reduceReservesFresh(amount);
     }
 
-    function harnessSetReserveFactorFresh(uint256 newReserveFactorMantissa) public returns (uint256) {
-        return _setReserveFactorFresh(newReserveFactorMantissa);
+    function harnessSetReserveFactorFresh(uint256 newReserveFactorMantissa) external {
+        _setReserveFactorFresh(newReserveFactorMantissa);
     }
 
-    function harnessSetInterestRateModelFresh(InterestRateModel newInterestRateModel) public returns (uint256) {
-        return _setInterestRateModelFresh(newInterestRateModel);
+    function harnessSetInterestRateModelFresh(InterestRateModel newInterestRateModel) external {
+        _setInterestRateModelFresh(newInterestRateModel);
     }
 
     function harnessSetInterestRateModel(address newInterestRateModelAddress) public {
@@ -217,7 +212,7 @@ contract VTokenScenario is VToken {
         totalReserves = totalReserves_;
     }
 
-    function getBlockNumber() internal view override returns (uint256) {
+    function _getBlockNumber() internal view override returns (uint256) {
         ComptrollerScenario comptrollerScenario = ComptrollerScenario(address(comptroller));
         return comptrollerScenario.blockNumber();
     }

--- a/deploy/001-deploy-pool-registry.ts
+++ b/deploy/001-deploy-pool-registry.ts
@@ -124,28 +124,28 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   tx = await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
-    "_setCollateralFactor(VToken,uint256,uint256)",
+    "setCollateralFactor(address,uint256,uint256)",
     poolRegistry.address,
   );
   await tx.wait();
 
   tx = await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
-    "_setLiquidationIncentive(uint)",
+    "setLiquidationIncentive(uint256)",
     poolRegistry.address,
   );
   await tx.wait();
 
   tx = await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
-    "_setMinLiquidatableCollateral(uint256)",
+    "setMinLiquidatableCollateral(uint256)",
     poolRegistry.address,
   );
   await tx.wait();
 
   tx = await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
-    "_supportMarket(VToken)",
+    "supportMarket(address)",
     poolRegistry.address,
   );
   await tx.wait();

--- a/deploy/001-deploy-pool-registry.ts
+++ b/deploy/001-deploy-pool-registry.ts
@@ -152,7 +152,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   tx = await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
-    "_setInterestRateModelFresh(InterestRateModel)",
+    "setInterestRateModel(address)",
     vBep20Factory.address,
   );
   await tx.wait();

--- a/deploy/003-deploy-pools.ts
+++ b/deploy/003-deploy-pools.ts
@@ -122,12 +122,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   });
   await tx.wait();
 
-  comptroller1Proxy._setMarketBorrowCaps(
+  comptroller1Proxy.setMarketBorrowCaps(
     [tokenImplementation.address],
     ["0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],
   );
 
-  comptroller1Proxy._setMarketSupplyCaps(
+  comptroller1Proxy.setMarketSupplyCaps(
     [tokenImplementation.address],
     ["0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],
   );

--- a/tests/hardhat/Comptroller/accountLiquidityTest.ts
+++ b/tests/hardhat/Comptroller/accountLiquidityTest.ts
@@ -33,7 +33,7 @@ async function makeComptroller(): Promise<AccountLiquidityTestFixture> {
   const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
   accessControl.isAllowedToCall.returns(true);
-  await comptroller._setPriceOracle(oracle.address);
+  await comptroller.setPriceOracle(oracle.address);
   return { accessControl, comptroller, oracle, poolRegistry };
 }
 
@@ -61,19 +61,19 @@ async function makeVToken({
   configureVToken({ vToken, comptroller, exchangeRate });
   if (supportMarket) {
     const poolRegistrySigner = await ethers.getSigner(poolRegistry.address);
-    await comptroller.connect(poolRegistrySigner)._supportMarket(vToken.address);
+    await comptroller.connect(poolRegistrySigner).supportMarket(vToken.address);
   }
   if (underlyingPrice) {
     oracle.getUnderlyingPrice.whenCalledWith(vToken.address).returns(convertToUnit(underlyingPrice, 18));
   }
   if (collateralFactor) {
-    await comptroller._setCollateralFactor(
+    await comptroller.setCollateralFactor(
       vToken.address,
       convertToUnit(collateralFactor, 18),
       convertToUnit(collateralFactor, 18),
     );
   }
-  await comptroller._setMarketSupplyCaps([vToken.address], [100000000000]);
+  await comptroller.setMarketSupplyCaps([vToken.address], [100000000000]);
 
   return vToken;
 }

--- a/tests/hardhat/Comptroller/assetsListTest.ts
+++ b/tests/hardhat/Comptroller/assetsListTest.ts
@@ -49,7 +49,7 @@ describe("assetListTest", () => {
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
     accessControl.isAllowedToCall.returns(true);
-    await comptroller._setPriceOracle(oracle.address);
+    await comptroller.setPriceOracle(oracle.address);
     const names = ["OMG", "ZRX", "BAT", "sketch"];
     const [OMG, ZRX, BAT, SKT] = await Promise.all(
       names.map(async name => {
@@ -64,7 +64,7 @@ describe("assetListTest", () => {
             });
           }
           const poolRegistrySigner = await ethers.getSigner(poolRegistry.address);
-          await comptroller.connect(poolRegistrySigner)._supportMarket(vToken.address);
+          await comptroller.connect(poolRegistrySigner).supportMarket(vToken.address);
         }
         return vToken;
       }),
@@ -97,7 +97,7 @@ describe("assetListTest", () => {
       },
       [[], []],
     );
-    await comptroller._setMarketBorrowCaps(addresses, caps);
+    await comptroller.setMarketBorrowCaps(addresses, caps);
   });
 
   async function checkMarkets(expectedTokens: FakeContract<VToken>[]) {
@@ -168,7 +168,7 @@ describe("assetListTest", () => {
     it("the market must be listed for add to succeed", async () => {
       await enterAndCheckMarkets([SKT], [], [Error.MARKET_NOT_LISTED]);
       const poolRegistrySigner = await ethers.getSigner(poolRegistry.address);
-      await comptroller.connect(poolRegistrySigner)._supportMarket(SKT.address);
+      await comptroller.connect(poolRegistrySigner).supportMarket(SKT.address);
       await enterAndCheckMarkets([SKT], [SKT]);
     });
 

--- a/tests/hardhat/Comptroller/healAccountTest.ts
+++ b/tests/hardhat/Comptroller/healAccountTest.ts
@@ -49,9 +49,9 @@ describe("healAccount", () => {
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
     accessControl.isAllowedToCall.returns(true);
-    await comptroller._setPriceOracle(oracle.address);
-    await comptroller._setLiquidationIncentive(convertToUnit("1.1", 18));
-    await comptroller._setMinLiquidatableCollateral(convertToUnit("100", 18));
+    await comptroller.setPriceOracle(oracle.address);
+    await comptroller.setLiquidationIncentive(convertToUnit("1.1", 18));
+    await comptroller.setMinLiquidatableCollateral(convertToUnit("100", 18));
     const names = ["OMG", "ZRX", "BAT"];
     const [OMG, ZRX, BAT, SKT] = await Promise.all(
       names.map(async () => {
@@ -65,7 +65,7 @@ describe("healAccount", () => {
           });
         }
         const poolRegistrySigner = await ethers.getSigner(poolRegistry.address);
-        await comptroller.connect(poolRegistrySigner)._supportMarket(vToken.address);
+        await comptroller.connect(poolRegistrySigner).supportMarket(vToken.address);
         return vToken;
       }),
     );
@@ -122,7 +122,7 @@ describe("healAccount", () => {
     });
 
     it("fails if collateral exceeds threshold", async () => {
-      await comptroller._setMinLiquidatableCollateral("2199999999999999999");
+      await comptroller.setMinLiquidatableCollateral("2199999999999999999");
       await expect(comptroller.connect(liquidator).healAccount(userAddress))
         .to.be.revertedWithCustomError(comptroller, "CollateralExceedsThreshold")
         .withArgs("2199999999999999999", "2200000000000000000");

--- a/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
+++ b/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
@@ -62,8 +62,8 @@ describe("Comptroller", () => {
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
     accessControl.isAllowedToCall.returns(true);
-    await comptroller._setPriceOracle(oracle.address);
-    await comptroller._setLiquidationIncentive(convertToUnit("1.1", 18));
+    await comptroller.setPriceOracle(oracle.address);
+    await comptroller.setLiquidationIncentive(convertToUnit("1.1", 18));
 
     const vTokenBorrowed = await smock.fake<VToken>("VToken");
     const vTokenCollateral = await smock.fake<VToken>("VToken");
@@ -142,7 +142,7 @@ describe("Comptroller", () => {
 
         await setOraclePrice(vTokenCollateral, collateralPrice);
         await setOraclePrice(vTokenBorrowed, borrowedPrice);
-        await comptroller._setLiquidationIncentive(liquidationIncentive);
+        await comptroller.setLiquidationIncentive(liquidationIncentive);
         vTokenCollateral.exchangeRateStored.returns(exchangeRate);
 
         const seizeAmount = (repayAmount * liquidationIncentive * borrowedPrice) / collateralPrice;

--- a/tests/hardhat/Comptroller/pauseTest.ts
+++ b/tests/hardhat/Comptroller/pauseTest.ts
@@ -38,7 +38,7 @@ async function pauseFixture(): Promise<PauseFixture> {
 
   accessControl.isAllowedToCall.returns(true);
   const [root] = await ethers.getSigners();
-  await comptroller._setPriceOracle(oracle.address);
+  await comptroller.setPriceOracle(oracle.address);
   const names = ["OMG", "ZRX", "BAT", "sketch"];
   const [OMG, ZRX, BAT, SKT] = await Promise.all(
     names.map(async name => {
@@ -53,7 +53,7 @@ async function pauseFixture(): Promise<PauseFixture> {
           });
         }
         const poolRegistrySigner = await ethers.getSigner(poolRegistry.address);
-        await comptroller.connect(poolRegistrySigner)._supportMarket(vToken.address);
+        await comptroller.connect(poolRegistrySigner).supportMarket(vToken.address);
       }
       return vToken;
     }),
@@ -91,43 +91,43 @@ describe("Comptroller", () => {
     rootAddress = await root.getAddress();
   });
 
-  describe("_setActionsPaused", () => {
+  describe("setActionsPaused", () => {
     it("reverts if AccessControlManager does not allow it", async () => {
       accessControl.isAllowedToCall
-        .whenCalledWith(rootAddress, "_setActionsPaused(VToken[],Action[],bool)")
+        .whenCalledWith(rootAddress, "setActionsPaused(address[],uint256[],bool)")
         .returns(false);
-      await expect(comptroller._setActionsPaused([OMG.address], [1], true)).to.be.revertedWith(
+      await expect(comptroller.setActionsPaused([OMG.address], [1], true)).to.be.revertedWith(
         "only authorised addresses can pause",
       );
     });
 
     it("reverts if the market is not listed", async () => {
-      await expect(comptroller._setActionsPaused([SKT.address], [1], true)).to.be.revertedWith(
+      await expect(comptroller.setActionsPaused([SKT.address], [1], true)).to.be.revertedWith(
         "cannot pause a market that is not listed",
       );
     });
 
     it("does nothing if the actions list is empty", async () => {
-      await comptroller._setActionsPaused([OMG.address, ZRX.address], [], true);
+      await comptroller.setActionsPaused([OMG.address, ZRX.address], [], true);
       expect(await comptroller.actionPaused(OMG.address, 1)).to.equal(false);
       expect(await comptroller.actionPaused(ZRX.address, 2)).to.equal(false);
     });
 
     it("does nothing if the markets list is empty", async () => {
-      await comptroller._setActionsPaused([], [1, 2, 3, 4, 5], true);
+      await comptroller.setActionsPaused([], [1, 2, 3, 4, 5], true);
       expect(await comptroller.actionPaused(OMG.address, 1)).to.equal(false);
       expect(await comptroller.actionPaused(ZRX.address, 2)).to.equal(false);
     });
 
     it("can pause one action on several markets", async () => {
-      await comptroller._setActionsPaused([OMG.address, BAT.address], [1], true);
+      await comptroller.setActionsPaused([OMG.address, BAT.address], [1], true);
       expect(await comptroller.actionPaused(OMG.address, 1)).to.equal(true);
       expect(await comptroller.actionPaused(ZRX.address, 1)).to.equal(false);
       expect(await comptroller.actionPaused(BAT.address, 1)).to.equal(true);
     });
 
     it("can pause several actions on one market", async () => {
-      await comptroller._setActionsPaused([OMG.address], [3, 5, 6], true);
+      await comptroller.setActionsPaused([OMG.address], [3, 5, 6], true);
       expect(await comptroller.actionPaused(OMG.address, 3)).to.equal(true);
       expect(await comptroller.actionPaused(OMG.address, 4)).to.equal(false);
       expect(await comptroller.actionPaused(OMG.address, 5)).to.equal(true);
@@ -135,8 +135,8 @@ describe("Comptroller", () => {
     });
 
     it("can pause and unpause several actions on several markets", async () => {
-      await comptroller._setActionsPaused([OMG.address, BAT.address, ZRX.address], [3, 4, 5, 6], true);
-      await comptroller._setActionsPaused([ZRX.address, BAT.address], [3, 5], false);
+      await comptroller.setActionsPaused([OMG.address, BAT.address, ZRX.address], [3, 4, 5, 6], true);
+      await comptroller.setActionsPaused([ZRX.address, BAT.address], [3, 5], false);
       expect(await comptroller.actionPaused(OMG.address, 3)).to.equal(true);
       expect(await comptroller.actionPaused(OMG.address, 4)).to.equal(true);
       expect(await comptroller.actionPaused(OMG.address, 5)).to.equal(true);

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -526,9 +526,9 @@ describe("Risk Fund: Tests", function () {
     it("Below min threshold amount", async function () {
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
-      await cUSDC.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+      await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
 
-      await cUSDC._reduceReserves(convertToUnit(50, 18));
+      await cUSDC.reduceReserves(convertToUnit(50, 18));
 
       const protocolReserveUSDCBal = await USDC.balanceOf(protocolShareReserve.address);
       expect(protocolReserveUSDCBal).equal(convertToUnit(50, 18));
@@ -543,8 +543,8 @@ describe("Risk Fund: Tests", function () {
     it("Above min threshold amount", async function () {
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
-      await cUSDC.connect(usdcUser)._addReserves(convertToUnit(200, 18));
-      await cUSDC._reduceReserves(convertToUnit(100, 18));
+      await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
+      await cUSDC.reduceReserves(convertToUnit(100, 18));
 
       const protocolReserveUSDCBal = await USDC.balanceOf(protocolShareReserve.address);
       expect(protocolReserveUSDCBal).equal(convertToUnit(100, 18));
@@ -564,14 +564,14 @@ describe("Risk Fund: Tests", function () {
     it("Add two assets to riskFund", async function () {
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
-      await cUSDC.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+      await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
 
       await USDT.connect(usdtUser).approve(cUSDT.address, convertToUnit(1000, 18));
 
-      await cUSDT.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+      await cUSDT.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
-      await cUSDT._reduceReserves(convertToUnit(100, 18));
-      await cUSDC._reduceReserves(convertToUnit(100, 18));
+      await cUSDT.reduceReserves(convertToUnit(100, 18));
+      await cUSDC.reduceReserves(convertToUnit(100, 18));
 
       const protocolReserveUSDCBal = await USDC.balanceOf(protocolShareReserve.address);
       expect(protocolReserveUSDCBal).equal(convertToUnit(100, 18));
@@ -618,14 +618,14 @@ describe("Risk Fund: Tests", function () {
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
-      await cUSDC.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+      await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
 
       await USDT.connect(usdtUser).approve(cUSDT.address, convertToUnit(1000, 18));
 
-      await cUSDT.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+      await cUSDT.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
-      await cUSDT._reduceReserves(convertToUnit(100, 18));
-      await cUSDC._reduceReserves(convertToUnit(100, 18));
+      await cUSDT.reduceReserves(convertToUnit(100, 18));
+      await cUSDC.reduceReserves(convertToUnit(100, 18));
       const protocolReserveUSDCBal = await USDC.balanceOf(protocolShareReserve.address);
       expect(protocolReserveUSDCBal).equal(convertToUnit(100, 18));
 
@@ -653,14 +653,14 @@ describe("Risk Fund: Tests", function () {
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
-      await cUSDC.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+      await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
 
       await USDT.connect(usdtUser).approve(cUSDT.address, convertToUnit(1000, 18));
 
-      await cUSDT.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+      await cUSDT.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
-      await cUSDT._reduceReserves(convertToUnit(100, 18));
-      await cUSDC._reduceReserves(convertToUnit(100, 18));
+      await cUSDT.reduceReserves(convertToUnit(100, 18));
+      await cUSDC.reduceReserves(convertToUnit(100, 18));
       await riskFund.swapAllPoolsAssets();
 
       fakeAccessControlManager.isAllowedToCall.returns(false);
@@ -675,34 +675,34 @@ describe("Risk Fund: Tests", function () {
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
-      await cUSDC.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+      await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
 
       await USDT.connect(usdtUser).approve(cUSDT.address, convertToUnit(1000, 18));
 
-      await cUSDT.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+      await cUSDT.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
       await USDC.connect(usdcUser).approve(cUSDC2.address, convertToUnit(1000, 18));
 
-      await cUSDC2.connect(usdcUser)._addReserves(convertToUnit(200, 18));
+      await cUSDC2.connect(usdcUser).addReserves(convertToUnit(200, 18));
 
       await USDT.connect(usdtUser).approve(cUSDT2.address, convertToUnit(1000, 18));
 
-      await cUSDT2.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+      await cUSDT2.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
       await USDT.connect(usdtUser).approve(cUSDT3.address, convertToUnit(1000, 18));
 
-      await cUSDT3.connect(usdtUser)._addReserves(convertToUnit(200, 18));
+      await cUSDT3.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
       await BUSD.connect(busdUser).approve(bUSDT3.address, convertToUnit(1000, 18));
 
-      await bUSDT3.connect(busdUser)._addReserves(convertToUnit(50, 18));
+      await bUSDT3.connect(busdUser).addReserves(convertToUnit(50, 18));
 
-      await cUSDT._reduceReserves(convertToUnit(110, 18));
-      await cUSDC._reduceReserves(convertToUnit(120, 18));
-      await cUSDT2._reduceReserves(convertToUnit(150, 18));
-      await cUSDC2._reduceReserves(convertToUnit(160, 18));
-      await cUSDT3._reduceReserves(convertToUnit(175, 18));
-      await bUSDT3._reduceReserves(convertToUnit(50, 18));
+      await cUSDT.reduceReserves(convertToUnit(110, 18));
+      await cUSDC.reduceReserves(convertToUnit(120, 18));
+      await cUSDT2.reduceReserves(convertToUnit(150, 18));
+      await cUSDC2.reduceReserves(convertToUnit(160, 18));
+      await cUSDT3.reduceReserves(convertToUnit(175, 18));
+      await bUSDT3.reduceReserves(convertToUnit(50, 18));
 
       let protocolUSDTFor1 = await protocolShareReserve.getPoolAssetReserve(comptroller1Proxy.address, USDT.address);
       let protocolUSDCFor1 = await protocolShareReserve.getPoolAssetReserve(comptroller1Proxy.address, USDC.address);

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -353,9 +353,9 @@ const riskFundFixture = async (): Promise<void> => {
   await comptroller3Proxy.connect(user).enterMarkets([cUSDT3.address, bUSDT3.address]);
 
   // Set Oracle
-  await comptroller1Proxy._setPriceOracle(priceOracle.address);
-  await comptroller2Proxy._setPriceOracle(priceOracle.address);
-  await comptroller3Proxy._setPriceOracle(priceOracle.address);
+  await comptroller1Proxy.setPriceOracle(priceOracle.address);
+  await comptroller2Proxy.setPriceOracle(priceOracle.address);
+  await comptroller3Proxy.setPriceOracle(priceOracle.address);
 
   if (FORK_MAINNET) {
     pancakeSwapRouter = await PancakeRouter__factory.connect("0x10ED43C718714eb63d5aA57B78B54704E256024E", admin);

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -192,7 +192,7 @@ describe("PoolRegistry: Tests", function () {
     await comptroller1Proxy.connect(user).enterMarkets([vDAI.address, vWBTC.address]);
 
     // Set Oracle
-    await comptroller1Proxy._setPriceOracle(priceOracle.address);
+    await comptroller1Proxy.setPriceOracle(priceOracle.address);
   });
 
   it("Pools should have correct names", async function () {

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -143,7 +143,7 @@ describe("Rewards: Tests", async function () {
 
     comptrollerProxy = await ethers.getContractAt("Comptroller", pools[0].comptroller);
     await comptrollerProxy.acceptAdmin();
-    await comptrollerProxy._setPriceOracle(fakePriceOracle.address);
+    await comptrollerProxy.setPriceOracle(fakePriceOracle.address);
 
     const VToken = await ethers.getContractFactory("VToken");
     const tokenImplementation = await VToken.deploy();

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -216,13 +216,13 @@ describe("Rewards: Tests", async function () {
     await comptrollerProxy.addRewardsDistributor(rewardsDistributor.address);
     await comptrollerProxy.addRewardsDistributor(rewardsDistributor2.address);
 
-    await rewardsDistributor._setRewardTokenSpeeds(
+    await rewardsDistributor.setRewardTokenSpeeds(
       [vWBTC.address, vDAI.address],
       [convertToUnit(0.5, 18), convertToUnit(0.5, 18)],
       [convertToUnit(0.5, 18), convertToUnit(0.5, 18)],
     );
 
-    await rewardsDistributor2._setRewardTokenSpeeds(
+    await rewardsDistributor2.setRewardTokenSpeeds(
       [vWBTC.address, vDAI.address],
       [convertToUnit(0.4, 18), convertToUnit(0.3, 18)],
       [convertToUnit(0.2, 18), convertToUnit(0.1, 18)],

--- a/tests/hardhat/Tokens/setComptrollerTest.ts
+++ b/tests/hardhat/Tokens/setComptrollerTest.ts
@@ -31,9 +31,9 @@ describe("VToken", function () {
     newComptroller.isComptroller.returns(true);
   });
 
-  describe("_setComptroller", () => {
+  describe("setComptroller", () => {
     it("should fail if called by non-admin", async () => {
-      await expect(vToken.connect(guy)._setComptroller(newComptroller.address)).to.be.revertedWithCustomError(
+      await expect(vToken.connect(guy).setComptroller(newComptroller.address)).to.be.revertedWithCustomError(
         vToken,
         "SetComptrollerOwnerCheck",
       );
@@ -41,7 +41,7 @@ describe("VToken", function () {
     });
 
     it("reverts if passed a contract that doesn't implement isComptroller", async () => {
-      await expect(vToken._setComptroller(accessControlManager.address)).to.be.revertedWithoutReason();
+      await expect(vToken.setComptroller(accessControlManager.address)).to.be.revertedWithoutReason();
       expect(await vToken.comptroller()).to.equal(comptroller.address);
     });
 
@@ -49,12 +49,12 @@ describe("VToken", function () {
       // extremely unlikely to occur, of course, but let's be exhaustive
       const badComptroller = await smock.fake<Comptroller>("Comptroller");
       badComptroller.isComptroller.returns(false);
-      await expect(vToken._setComptroller(badComptroller.address)).to.be.revertedWith("marker method returned false");
+      await expect(vToken.setComptroller(badComptroller.address)).to.be.revertedWith("marker method returned false");
       expect(await vToken.comptroller()).to.equal(comptroller.address);
     });
 
     it("updates comptroller and emits log on success", async () => {
-      const result = await vToken._setComptroller(newComptroller.address);
+      const result = await vToken.setComptroller(newComptroller.address);
 
       await expect(result).to.emit(vToken, "NewComptroller").withArgs(comptroller.address, newComptroller.address);
       expect(await vToken.comptroller()).to.equal(newComptroller.address);

--- a/tests/hardhat/lens/PoolLens.ts
+++ b/tests/hardhat/lens/PoolLens.ts
@@ -226,7 +226,7 @@ describe("PoolLens - PoolView Tests", async function () {
     await comptroller1Proxy.connect(owner).enterMarkets([vDAI.address, vWBTC.address]);
 
     //Set Oracle
-    await comptroller1Proxy._setPriceOracle(priceOracle.address);
+    await comptroller1Proxy.setPriceOracle(priceOracle.address);
 
     const PoolLens = await ethers.getContractFactory("PoolLens");
     poolLens = await PoolLens.deploy();

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -90,23 +90,7 @@ describe("Positive Cases", () => {
 
   beforeEach(async () => {
     ({ fixture } = await setupTest());
-    ({
-      PoolRegistry,
-      AccessControlManager,
-      RiskFund,
-      VTokenFactory,
-      JumpRateModelFactory,
-      WhitePaperRateFactory,
-      ProtocolShareReserve,
-      PriceOracle,
-      Comptroller,
-      vWBTC,
-      vDAI,
-      wBTC,
-      DAI,
-      acc1,
-      acc2,
-    } = fixture);
+    ({ PoolRegistry, AccessControlManager, Comptroller, vWBTC, vDAI, wBTC, DAI, acc1, acc2 } = fixture);
   });
   describe("Setup", () => {
     it("PoolRegistry should be initialized properly", async function () {

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -43,16 +43,25 @@ const setupTest = deployments.createFixture(async ({ deployments, getNamedAccoun
   await Comptroller.connect(await ethers.getSigner(acc1)).enterMarkets([vDAI.address, vWBTC.address]);
   await Comptroller.connect(await ethers.getSigner(acc2)).enterMarkets([vDAI.address, vWBTC.address]);
 
-  //Enable Access to Supply Caps
+  //Enable access to setting supply and borrow caps
   await AccessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
     "setMarketSupplyCaps(address[],uint256[])",
     deployer,
   );
+  await AccessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
+    "setMarketBorrowCaps(address[],uint256[])",
+    deployer,
+  );
 
-  //Set Supply Caps
+  //Set supply caps
   const supply = convertToUnit(10, 6);
   await Comptroller.setMarketSupplyCaps([vDAI.address, vWBTC.address], [supply, supply]);
+
+  //Set borrow caps
+  const borrowCap = convertToUnit(10, 6);
+  await Comptroller.setMarketBorrowCaps([vDAI.address, vWBTC.address], [borrowCap, borrowCap]);
 
   return {
     fixture: {

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -31,7 +31,7 @@ const setupTest = deployments.createFixture(async ({ deployments, getNamedAccoun
   const DAI = await ethers.getContract("MockDAI");
 
   // Set Oracle
-  await Comptroller._setPriceOracle(PriceOracle.address);
+  await Comptroller.setPriceOracle(PriceOracle.address);
 
   const vWBTCAddress = await PoolRegistry.getVTokenForAsset(Comptroller.address, wBTC.address);
   const vDAIAddress = await PoolRegistry.getVTokenForAsset(Comptroller.address, DAI.address);
@@ -46,13 +46,13 @@ const setupTest = deployments.createFixture(async ({ deployments, getNamedAccoun
   //Enable Access to Supply Caps
   await AccessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
-    "_setMarketSupplyCaps(VToken[],uint256[])",
+    "setMarketSupplyCaps(address[],uint256[])",
     deployer,
   );
 
   //Set Supply Caps
   const supply = convertToUnit(10, 6);
-  await Comptroller._setMarketSupplyCaps([vDAI.address, vWBTC.address], [supply, supply]);
+  await Comptroller.setMarketSupplyCaps([vDAI.address, vWBTC.address], [supply, supply]);
 
   return {
     fixture: {
@@ -124,19 +124,19 @@ describe("Positive Cases", () => {
     it("PoolRegistry has the required permissions ", async function () {
       let canCall = await AccessControlManager.connect(Comptroller.address).isAllowedToCall(
         PoolRegistry.address,
-        "_setCollateralFactor(VToken,uint256,uint256)",
+        "setCollateralFactor(address,uint256,uint256)",
       );
       expect(canCall).to.be.true;
 
       canCall = await AccessControlManager.connect(Comptroller.address).isAllowedToCall(
         PoolRegistry.address,
-        "_supportMarket(VToken)",
+        "supportMarket(address)",
       );
       expect(canCall).to.be.true;
 
       canCall = await AccessControlManager.connect(Comptroller.address).isAllowedToCall(
         PoolRegistry.address,
-        "_setLiquidationIncentive(uint)",
+        "setLiquidationIncentive(uint256)",
       );
       expect(canCall).to.be.true;
     });


### PR DESCRIPTION
This PR changes the function signatures so that they adhere to Solidity style guide:
* `_camelCase` for private and internal functions
* `camelCase` for regular functions, including access-controlled ones

Incidentally, this PR also changes type names in access controls to their canonical versions, and removes the return values from functions that just return Error.NO_ERROR. The remaining part of the error cleanup will be done in a separate PR.

Note that the changes are **BREAKING.**
Note that this PR **changes the access control mechanisms** in some places.