### PR TITLE
fix!: [012] add _disableInitializers to all upgradeable contracts

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -112,6 +112,7 @@ contract Comptroller is
         // constructor. Use initialize() or reinitializers to set the state variables.
         poolRegistry = poolRegistry_;
         accessControl = accessControl_;
+        _disableInitializers();
     }
 
     function initialize() public initializer {

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -31,6 +31,13 @@ contract PoolRegistry is Ownable2StepUpgradeable {
     address payable private riskFund;
     address payable private protocolShareReserve;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        // Note that the contract is upgradeable. Use initialize() or reinitializers
+        // to set the state variables.
+        _disableInitializers();
+    }
+
     /**
      * @dev Initializes the deployer to owner.
      * @param _vTokenFactory vToken factory address.

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -14,6 +14,13 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
     address private protocolIncome;
     address private riskFund;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        // Note that the contract is upgradeable. Use initialize() or reinitializers
+        // to set the state variables.
+        _disableInitializers();
+    }
+
     /**
      * @dev Initializes the deployer to owner.
      * @param _protocolIncome  remaining protocol income.

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -46,6 +46,13 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
     /// @notice Emitted when minimum amount to convert is updated
     event MinAmountToConvertUpdated(uint256 oldMinAmountToConvert, uint256 newMinAmountToConvert);
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        // Note that the contract is upgradeable. Use initialize() or reinitializers
+        // to set the state variables.
+        _disableInitializers();
+    }
+
     /**
      * @dev Initializes the deployer to owner.
      * @param _pancakeSwapRouter Address of the PancakeSwap router

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -100,6 +100,13 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice Emitted when minimum pool bad debt is updated
     event MinimumPoolBadDebtUpdated(uint256 oldMinimumPoolBadDebt, uint256 newMinimumPoolBadDebt);
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        // Note that the contract is upgradeable. Use initialize() or reinitializers
+        // to set the state variables.
+        _disableInitializers();
+    }
+
     /**
      * @notice Initalize the shortfall contract
      * @param _minimumPoolBadDebt Minimum bad debt in BUSD for a pool to start auction

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -19,6 +19,13 @@ import "./RiskFund/IProtocolShareReserve.sol";
 contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError, TokenErrorReporter {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        // Note that the contract is upgradeable. Use initialize() or reinitializers
+        // to set the state variables.
+        _disableInitializers();
+    }
+
     /**
      * @notice Construct a new money market
      * @param underlying_ The address of the underlying asset

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,6 +2,7 @@ import "@nomicfoundation/hardhat-chai-matchers";
 import "@nomicfoundation/hardhat-toolbox";
 import "@nomiclabs/hardhat-ethers";
 import "@nomiclabs/hardhat-etherscan";
+import "@openzeppelin/hardhat-upgrades";
 import "@typechain/hardhat";
 import * as dotenv from "dotenv";
 import "hardhat-deploy";

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "^4.8.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.0",
+    "@openzeppelin/hardhat-upgrades": "^1.21.0",
     "@solidity-parser/parser": "^0.13.2",
     "ethers": "^5.7.0",
     "hardhat-deploy": "^0.11.14"

--- a/tests/hardhat/Comptroller/accountLiquidityTest.ts
+++ b/tests/hardhat/Comptroller/accountLiquidityTest.ts
@@ -2,7 +2,7 @@ import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture, setBalance } from "@nomicfoundation/hardhat-network-helpers";
 import chai from "chai";
 import { BigNumber, BigNumberish, Signer } from "ethers";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../../helpers/utils";
 import {
@@ -28,9 +28,11 @@ interface AccountLiquidityTestFixture {
 async function makeComptroller(): Promise<AccountLiquidityTestFixture> {
   const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
   const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
-  const comptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
-  const comptroller = await comptrollerFactory.deploy(poolRegistry.address, accessControl.address);
-  await comptroller.initialize();
+  const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
+  const comptroller = await upgrades.deployProxy(Comptroller, [], {
+    constructorArgs: [poolRegistry.address, accessControl.address],
+    initializer: "initialize()",
+  });
   const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
   accessControl.isAllowedToCall.returns(true);

--- a/tests/hardhat/Comptroller/assetsListTest.ts
+++ b/tests/hardhat/Comptroller/assetsListTest.ts
@@ -2,7 +2,7 @@ import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture, setBalance } from "@nomicfoundation/hardhat-network-helpers";
 import chai from "chai";
 import { Signer } from "ethers";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../../helpers/utils";
 import {
@@ -44,9 +44,11 @@ describe("assetListTest", () => {
   async function assetListFixture(): Promise<AssetListFixture> {
     poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
     const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
-    const ComptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
-    const comptroller = await ComptrollerFactory.deploy(poolRegistry.address, accessControl.address);
-    await comptroller.initialize();
+    const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
+    const comptroller = await upgrades.deployProxy(Comptroller, [], {
+      constructorArgs: [poolRegistry.address, accessControl.address],
+      initializer: "initialize()",
+    });
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
     accessControl.isAllowedToCall.returns(true);

--- a/tests/hardhat/Comptroller/healAccountTest.ts
+++ b/tests/hardhat/Comptroller/healAccountTest.ts
@@ -2,7 +2,7 @@ import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture, setBalance } from "@nomicfoundation/hardhat-network-helpers";
 import chai from "chai";
 import { Signer } from "ethers";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../../helpers/utils";
 import {
@@ -44,9 +44,11 @@ describe("healAccount", () => {
   async function healAccountFixture(): Promise<HealAccountFixture> {
     const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
     const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
-    const ComptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
-    const comptroller = await ComptrollerFactory.deploy(poolRegistry.address, accessControl.address);
-    await comptroller.initialize();
+    const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
+    const comptroller = await upgrades.deployProxy(Comptroller, [], {
+      constructorArgs: [poolRegistry.address, accessControl.address],
+      initializer: "initialize()",
+    });
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
     accessControl.isAllowedToCall.returns(true);

--- a/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
+++ b/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
@@ -3,7 +3,7 @@ import { PANIC_CODES } from "@nomicfoundation/hardhat-chai-matchers/panic";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import chai from "chai";
 import { BigNumberish, constants } from "ethers";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../../helpers/utils";
 import {
@@ -57,9 +57,11 @@ describe("Comptroller", () => {
   async function liquidateFixture(): Promise<LiquidateFixture> {
     const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
     const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
-    const ComptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
-    const comptroller = await ComptrollerFactory.deploy(poolRegistry.address, accessControl.address);
-    await comptroller.initialize();
+    const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
+    const comptroller = await upgrades.deployProxy(Comptroller, [], {
+      constructorArgs: [poolRegistry.address, accessControl.address],
+      initializer: "initialize()",
+    });
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
     accessControl.isAllowedToCall.returns(true);

--- a/tests/hardhat/Comptroller/pauseTest.ts
+++ b/tests/hardhat/Comptroller/pauseTest.ts
@@ -2,7 +2,7 @@ import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
 import { loadFixture, setBalance } from "@nomicfoundation/hardhat-network-helpers";
 import chai from "chai";
 import { Signer } from "ethers";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 
 import {
   AccessControlManager,
@@ -32,9 +32,11 @@ type PauseFixture = {
 async function pauseFixture(): Promise<PauseFixture> {
   const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
   const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
-  const ComptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
-  const comptroller = await ComptrollerFactory.deploy(poolRegistry.address, accessControl.address);
-  await comptroller.initialize();
+  const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
+  const comptroller = await upgrades.deployProxy(Comptroller, [], {
+    constructorArgs: [poolRegistry.address, accessControl.address],
+    initializer: "initialize()",
+  });
   const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
   accessControl.isAllowedToCall.returns(true);

--- a/tests/hardhat/ProtocolShareReserve.ts
+++ b/tests/hardhat/ProtocolShareReserve.ts
@@ -1,7 +1,7 @@
 import { FakeContract, smock } from "@defi-wonderland/smock";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../helpers/utils";
 import { Comptroller, MockToken, ProtocolShareReserve, RiskFund } from "../../typechain";
@@ -24,10 +24,10 @@ const fixture = async (): Promise<void> => {
 
   // ProtocolShareReserve contract deployment
   const ProtocolShareReserve = await ethers.getContractFactory("ProtocolShareReserve");
-  protocolShareReserve = await ProtocolShareReserve.deploy();
-  await protocolShareReserve.deployed();
-
-  await protocolShareReserve.initialize(fakeProtocolIncome.address, fakeRiskFund.address);
+  protocolShareReserve = await upgrades.deployProxy(ProtocolShareReserve, [
+    fakeProtocolIncome.address,
+    fakeRiskFund.address,
+  ]);
 };
 
 describe("ProtocolShareReserve: Tests", function () {

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -1,6 +1,6 @@
 import { FakeContract, MockContract, smock } from "@defi-wonderland/smock";
 import { expect } from "chai";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../helpers/utils";
 import {
@@ -14,10 +14,9 @@ import {
   PriceOracle,
   PriceOracle__factory,
   ProtocolShareReserve,
-  ProtocolShareReserve__factory,
   RewardsDistributor,
   RiskFund,
-  RiskFund__factory,
+  Shortfall,
   VToken,
   VTokenProxyFactory,
   WhitePaperInterestRateModelFactory,
@@ -38,8 +37,6 @@ let rewardsDistributor: RewardsDistributor;
 let xvs: MockToken;
 let fakePriceOracle: FakeContract<PriceOracle>;
 let fakeAccessControlManager: FakeContract<AccessControlManager>;
-let protocolShareReserve: FakeContract<ProtocolShareReserve>;
-let riskFund: FakeContract<RiskFund>;
 
 describe("Rewards: Tests", async function () {
   /**
@@ -59,33 +56,19 @@ describe("Rewards: Tests", async function () {
     whitePaperRateFactory = await WhitePaperInterestRateModelFactory.deploy();
     await whitePaperRateFactory.deployed();
 
-    const RiskFund = await smock.mock<RiskFund__factory>("RiskFund");
-    riskFund = await RiskFund.deploy();
-    await riskFund.deployed();
+    const riskFund = await smock.fake<RiskFund>("RiskFund");
+    const protocolShareReserve = await smock.fake<ProtocolShareReserve>("ProtocolShareReserve");
+    const shortfall = await smock.fake<Shortfall>("Shortfall");
 
-    const ProtocolShareReserve = await smock.mock<ProtocolShareReserve__factory>("ProtocolShareReserve");
-    protocolShareReserve = await ProtocolShareReserve.deploy();
-    await protocolShareReserve.deployed();
-
-    const PoolRegistryFactory = await smock.mock<PoolRegistry__factory>("PoolRegistry");
-    poolRegistry = await PoolRegistryFactory.deploy();
-    await poolRegistry.deployed();
-
-    const Shortfall = await ethers.getContractFactory("Shortfall");
-    const shortfall = await Shortfall.deploy();
-
-    await shortfall.initialize(ethers.constants.AddressZero, ethers.constants.AddressZero, convertToUnit("10000", 18));
-
-    await poolRegistry.initialize(
+    const PoolRegistry = await smock.mock<PoolRegistry__factory>("PoolRegistry");
+    poolRegistry = await upgrades.deployProxy(PoolRegistry, [
       vTokenFactory.address,
       jumpRateFactory.address,
       whitePaperRateFactory.address,
       shortfall.address,
       riskFund.address,
       protocolShareReserve.address,
-    );
-
-    await shortfall.setPoolRegistry(poolRegistry.address);
+    ]);
 
     fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
     fakeAccessControlManager.isAllowedToCall.returns(true);

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -5,7 +5,7 @@ import BigNumber from "bignumber.js";
 import chai from "chai";
 import { constants } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../helpers/utils";
 import {
@@ -55,8 +55,11 @@ async function shortfallFixture() {
   fakeRiskFund = await smock.fake<IRiskFund>("IRiskFund");
 
   const Shortfall = await smock.mock<Shortfall__factory>("Shortfall");
-  shortfall = await Shortfall.deploy();
-  await shortfall.initialize(mockBUSD.address, fakeRiskFund.address, parseUnits(minimumPoolBadDebt, "18"));
+  shortfall = await upgrades.deployProxy(Shortfall, [
+    mockBUSD.address,
+    fakeRiskFund.address,
+    parseUnits(minimumPoolBadDebt, "18"),
+  ]);
 
   [owner, poolRegistry, someone, bidder1, bidder2] = await ethers.getSigners();
   await shortfall.setPoolRegistry(poolRegistry.address);
@@ -431,10 +434,10 @@ describe("Shortfall: Tests", async function () {
     });
   });
 
-  describe("Restart Action", async function () {
+  describe("Restart Auction", async function () {
     beforeEach(setup);
 
-    it(" Can't restart auction early ", async function () {
+    it("Can't restart auction early ", async function () {
       vDAI.badDebt.returns(parseUnits("10000", 18));
       await vDAI.setVariable("badDebt", parseUnits("10000", 18));
       vWBTC.badDebt.returns(parseUnits("2", 8));

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,6 +990,29 @@
   resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz#6854c37df205dd2c056bdfa1b853f5d732109109"
   integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
 
+"@openzeppelin/hardhat-upgrades@^1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.21.0.tgz#e90fb7d858093f35a300b3a5a2fd32bca6179dfc"
+  integrity sha512-Kwl7IN0Hlhj4HluMTTl0DrtU90OI/Q6rG3sAyd2pv3fababe9EuZqs9DydOlkWM45JwTzC+eBzX3TgHsqI13eA==
+  dependencies:
+    "@openzeppelin/upgrades-core" "^1.20.0"
+    chalk "^4.1.0"
+    debug "^4.1.1"
+    proper-lockfile "^4.1.1"
+
+"@openzeppelin/upgrades-core@^1.20.0":
+  version "1.20.5"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.20.5.tgz#1650b7805a847a5ccc097cd676ec12316a5a4b8d"
+  integrity sha512-Wp4uUov9/8cY0H4xHYsGCkLh0EItrpusSdQPWOTI1Q/YDDfu4uTH3LYyTeVAavzEvkAuKCCuTOPnZBibLZGxSw==
+  dependencies:
+    cbor "^8.0.0"
+    chalk "^4.1.0"
+    compare-versions "^5.0.0"
+    debug "^4.1.1"
+    ethereumjs-util "^7.0.3"
+    proper-lockfile "^4.1.1"
+    solidity-ast "^0.4.15"
+
 "@scure/base@~1.1.0":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
@@ -3174,6 +3197,13 @@ cbor@^5.0.2:
     bignumber.js "^9.0.1"
     nofilter "^1.0.4"
 
+cbor@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
+
 chai-as-promised@^7.1.1:
   version "7.1.1"
   resolved "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
@@ -3538,6 +3568,11 @@ commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+compare-versions@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-5.0.1.tgz#14c6008436d994c3787aba38d4087fabe858555e"
+  integrity sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -5018,7 +5053,7 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0, ethereumjs-util@^6.2.0, ethereum
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
-ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.2, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.4, ethereumjs-util@^7.1.5:
+ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.3, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.4, ethereumjs-util@^7.1.5:
   version "7.1.5"
   resolved "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz#9ecf04861e4fbbeed7465ece5f23317ad1129181"
   integrity sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==
@@ -6194,7 +6229,7 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
+graceful-fs@^4.0.0, graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -8419,6 +8454,11 @@ nofilter@^1.0.4:
   resolved "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
   integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
 
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
+
 nopt@3.x:
   version "3.0.6"
   resolved "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -9125,6 +9165,15 @@ promise@^8.0.0:
   dependencies:
     asap "~2.0.6"
 
+proper-lockfile@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -9686,6 +9735,11 @@ ret@~0.1.10:
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -10179,7 +10233,7 @@ solhint@^3.3.7:
   optionalDependencies:
     prettier "^1.14.3"
 
-solidity-ast@^0.4.38:
+solidity-ast@^0.4.15, solidity-ast@^0.4.38:
   version "0.4.38"
   resolved "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.38.tgz#103e8340e871882e10cfb5c06fab9bf8dff4100a"
   integrity sha512-e7gT6g8l8M2rAzH648QA3/IihCNy/anFoWyChVD+T+zfX4FjXbT8AO2DB3wG1iEmIBib9/+vD+GvTElWWpdw+w==


### PR DESCRIPTION
Problem: Uninitialized implementation may be initialized by an attacker if the contract is not deployed in the same transaction as proxy deployment or upgrade.

Solution: Add _disableInitializers call to the constructors. This affects tests, so this commit also updates tests (with some refactoring to replace unnecessary deployments with fakes).

Note that these changes are **BREAKING.** The corresponding commits are marked with `!`

Fixes the internal audit finding **012**.

**Note:** The PR is based on https://github.com/VenusProtocol/isolated-pools/pull/110 and marked as draft. The base should be changed to main and the PR can be marked as ready after https://github.com/VenusProtocol/isolated-pools/pull/110 is merged.