### PR TITLE
[018] fix: add access control to swap pool asset

### DIFF
--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -224,6 +224,11 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
      * @return Number of swapped tokens.
      */
     function swapAllPoolsAssets() external returns (uint256) {
+        bool canSwapAllPoolsAsset = AccessControlManager(accessControl).isAllowedToCall(
+            msg.sender,
+            "swapAllPoolsAssets()"
+        );
+        require(canSwapAllPoolsAsset, "Risk fund: Not authorized to swap pool assets.");
         require(poolRegistry != address(0), "Risk fund: Invalid pool registry.");
         PoolRegistryInterface poolRegistryInterface = PoolRegistryInterface(poolRegistry);
         PoolRegistry.VenusPool[] memory venusPools = poolRegistryInterface.getAllPools();
@@ -251,7 +256,7 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
     function transferReserveForAuction(address comptroller, uint256 amount) external returns (uint256) {
         bool canTransferFunds = AccessControlManager(accessControl).isAllowedToCall(
             msg.sender,
-            "transferReserveForAuction(uint256,uint256)"
+            "transferReserveForAuction(address,uint256)"
         );
 
         require(canTransferFunds, "Risk fund: Not authorized to transfer funds.");

--- a/deploy/004-deploy-pool-registry.ts
+++ b/deploy/004-deploy-pool-registry.ts
@@ -164,6 +164,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     deployer,
   );
   await tx.wait();
+
+  tx = await accessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
+    "swapAllPoolsAssets(uint256)",
+    deployer,
+  );
+  await tx.wait();
 };
 
 func.tags = ["PoolsRegistry"];


### PR DESCRIPTION
## Description

Problem:
`swapAllAssets` could be called to fail maliciously.

Solution:
Add accessControlManager check to `swapAllAssets`

Note: 
I tried to keep using mocks in the tests but they weren't resetting properly so I deployed the contract and am revoking and setting permissions.

There was also a typo in the `transferReserveForAuction` signature string
