### PR TITLE
[010] Initial Supply for Markets

### DIFF
--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -24,6 +24,8 @@ import "../VTokenInterfaces.sol";
  * @notice PoolRegistry is a registry for Venus interest rate pools.
  */
 contract PoolRegistry is Ownable2StepUpgradeable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
     /**
      * @dev Struct for a Venus interest rate pool.
      */
@@ -281,8 +283,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
         _supportedPools[input.asset].push(input.comptroller);
 
         IERC20Upgradeable token = IERC20Upgradeable(input.asset);
-        bool success = token.transferFrom(owner(), address(this), input.initialSupply);
-        require(success == true, "asset transfer to pool registry failed");
+        token.safeTransferFrom(owner(), address(this), input.initialSupply);
         token.approve(address(vToken), input.initialSupply);
 
         vToken.mintBehalf(owner(), input.initialSupply);

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -284,7 +284,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
 
         IERC20Upgradeable token = IERC20Upgradeable(input.asset);
         token.safeTransferFrom(owner(), address(this), input.initialSupply);
-        token.approve(address(vToken), input.initialSupply);
+        token.safeApprove(address(vToken), input.initialSupply);
 
         vToken.mintBehalf(owner(), input.initialSupply);
 

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -77,6 +77,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
         AccessControlManager accessControlManager;
         address vTokenProxyAdmin;
         address beaconAddress;
+        uint256 initialSupply;
     }
 
     VTokenProxyFactory private vTokenFactory;
@@ -223,7 +224,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
     }
 
     /**
-     * @notice Add a market to an existing pool
+     * @notice Add a market to an existing pool and then mint to provide initial supply
      */
     function addMarket(AddMarketInput memory input) external onlyOwner {
         InterestRateModel rate;
@@ -265,6 +266,12 @@ contract PoolRegistry is Ownable2StepUpgradeable {
 
         _vTokens[input.comptroller][input.asset] = address(vToken);
         _supportedPools[input.asset].push(input.comptroller);
+
+        IERC20Upgradeable token = IERC20Upgradeable(input.asset);
+        token.transferFrom(owner(), address(this), input.initialSupply);
+        // token.approve(address(vToken), input.initialSupply);
+
+        // vToken.mintBehalf(owner(), input.initialSupply);
 
         emit MarketAdded(address(comptroller), address(vToken));
     }

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -79,6 +79,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
         address beaconAddress;
         uint256 initialSupply;
         uint256 supplyCap;
+        uint256 borrowCap;
     }
 
     VTokenProxyFactory private vTokenFactory;
@@ -266,12 +267,15 @@ contract PoolRegistry is Ownable2StepUpgradeable {
         comptroller.setCollateralFactor(vToken, input.collateralFactor, input.liquidationThreshold);
 
         uint256[] memory newSupplyCaps = new uint256[](1);
+        uint256[] memory newBorrowCaps = new uint256[](1);
         VToken[] memory vTokens = new VToken[](1);
 
         newSupplyCaps[0] = input.supplyCap;
+        newBorrowCaps[0] = input.borrowCap;
         vTokens[0] = vToken;
 
         comptroller.setMarketSupplyCaps(vTokens, newSupplyCaps);
+        comptroller.setMarketBorrowCaps(vTokens, newBorrowCaps);
 
         _vTokens[input.comptroller][input.asset] = address(vToken);
         _supportedPools[input.asset].push(input.comptroller);

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -281,7 +281,8 @@ contract PoolRegistry is Ownable2StepUpgradeable {
         _supportedPools[input.asset].push(input.comptroller);
 
         IERC20Upgradeable token = IERC20Upgradeable(input.asset);
-        token.transferFrom(owner(), address(this), input.initialSupply);
+        bool success = token.transferFrom(owner(), address(this), input.initialSupply);
+        require(success == true, "asset transfer to pool registry failed");
         token.approve(address(vToken), input.initialSupply);
 
         vToken.mintBehalf(owner(), input.initialSupply);

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -78,6 +78,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
         address vTokenProxyAdmin;
         address beaconAddress;
         uint256 initialSupply;
+        uint256 supplyCap;
     }
 
     VTokenProxyFactory private vTokenFactory;
@@ -264,14 +265,22 @@ contract PoolRegistry is Ownable2StepUpgradeable {
         comptroller.supportMarket(vToken);
         comptroller.setCollateralFactor(vToken, input.collateralFactor, input.liquidationThreshold);
 
+        uint256[] memory newSupplyCaps = new uint256[](1);
+        VToken[] memory vTokens = new VToken[](1);
+
+        newSupplyCaps[0] = input.supplyCap;
+        vTokens[0] = vToken;
+
+        comptroller.setMarketSupplyCaps(vTokens, newSupplyCaps);
+
         _vTokens[input.comptroller][input.asset] = address(vToken);
         _supportedPools[input.asset].push(input.comptroller);
 
         IERC20Upgradeable token = IERC20Upgradeable(input.asset);
         token.transferFrom(owner(), address(this), input.initialSupply);
-        // token.approve(address(vToken), input.initialSupply);
+        token.approve(address(vToken), input.initialSupply);
 
-        // vToken.mintBehalf(owner(), input.initialSupply);
+        vToken.mintBehalf(owner(), input.initialSupply);
 
         emit MarketAdded(address(comptroller), address(vToken));
     }

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -483,7 +483,11 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         _mintFreshBehalf(msg.sender, minter, mintAmount);
     }
 
-    function _mintFreshBehalf(address sender, address minter, uint256 mintAmount) internal {
+    function _mintFreshBehalf(
+        address sender,
+        address minter,
+        uint256 mintAmount
+    ) internal {
         /* Fail if mint not allowed */
         uint256 allowed = comptroller.mintAllowed(address(this), minter, mintAmount);
         if (allowed != 0) {

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -486,12 +486,12 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     /**
      * @notice User supplies assets into the market and receives vTokens in exchange
      * @dev Assumes interest has already been accrued up to the current block
-     * @param sender The address of the account which is sending the assets for supply
+     * @param payer The address of the account which is sending the assets for supply
      * @param minter The address of the account which is supplying the assets
      * @param mintAmount The amount of the underlying asset to supply
      */
     function _mintFresh(
-        address sender,
+        address payer,
         address minter,
         uint256 mintAmount
     ) internal {
@@ -520,7 +520,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
          *  in case of a fee. On success, the vToken holds an additional `actualMintAmount`
          *  of cash.
          */
-        uint256 actualMintAmount = _doTransferIn(sender, mintAmount);
+        uint256 actualMintAmount = _doTransferIn(payer, mintAmount);
 
         /*
          * We get the current exchange rate and calculate the number of vTokens to be minted:

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -469,7 +469,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     function mint(uint256 mintAmount) external override nonReentrant {
         accrueInterest();
         // _mintFresh emits the actual Mint event if successful and logs on errors, so we don't need to
-        _mintFresh(msg.sender, mintAmount);
+        _mintFresh(msg.sender, msg.sender, mintAmount);
     }
 
     /**
@@ -480,21 +480,17 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     function mintBehalf(address minter, uint256 mintAmount) external override nonReentrant {
         accrueInterest();
         // _mintFresh emits the actual Mint event if successful and logs on errors, so we don't need to
-        _mintFreshBehalf(msg.sender, minter, mintAmount);
+        _mintFresh(msg.sender, minter, mintAmount);
     }
 
     /**
-     * @notice Sender supplies assets into the market and minter receives vTokens in exchange
+     * @notice User supplies assets into the market and receives vTokens in exchange
      * @dev Assumes interest has already been accrued up to the current block
-     * @param sender The address which provides assets on behalf of minter
+     * @param sender The address of the account which is sending the assets for supply
      * @param minter The address of the account which is supplying the assets
      * @param mintAmount The amount of the underlying asset to supply
      */
-    function _mintFreshBehalf(
-        address sender,
-        address minter,
-        uint256 mintAmount
-    ) internal {
+    function _mintFresh(address sender, address minter, uint256 mintAmount) internal {
         /* Fail if mint not allowed */
         uint256 allowed = comptroller.mintAllowed(address(this), minter, mintAmount);
         if (allowed != 0) {
@@ -521,65 +517,6 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
          *  of cash.
          */
         uint256 actualMintAmount = _doTransferIn(sender, mintAmount);
-
-        /*
-         * We get the current exchange rate and calculate the number of vTokens to be minted:
-         *  mintTokens = actualMintAmount / exchangeRate
-         */
-
-        uint256 mintTokens = div_(actualMintAmount, exchangeRate);
-
-        /*
-         * We calculate the new total supply of vTokens and minter token balance, checking for overflow:
-         *  totalSupplyNew = totalSupply + mintTokens
-         *  accountTokensNew = accountTokens[minter] + mintTokens
-         * And write them into storage
-         */
-        totalSupply = totalSupply + mintTokens;
-        accountTokens[minter] = accountTokens[minter] + mintTokens;
-
-        /* We emit a Mint event, and a Transfer event */
-        emit Mint(minter, actualMintAmount, mintTokens);
-        emit Transfer(address(this), minter, mintTokens);
-
-        /* We call the defense hook */
-        // unused function
-        // comptroller.mintVerify(address(this), minter, actualMintAmount, mintTokens);
-    }
-
-    /**
-     * @notice User supplies assets into the market and receives vTokens in exchange
-     * @dev Assumes interest has already been accrued up to the current block
-     * @param minter The address of the account which is supplying the assets
-     * @param mintAmount The amount of the underlying asset to supply
-     */
-    function _mintFresh(address minter, uint256 mintAmount) internal {
-        /* Fail if mint not allowed */
-        uint256 allowed = comptroller.mintAllowed(address(this), minter, mintAmount);
-        if (allowed != 0) {
-            revert MintComptrollerRejection(allowed);
-        }
-
-        /* Verify market's block number equals current block number */
-        if (accrualBlockNumber != _getBlockNumber()) {
-            revert MintFreshnessCheck();
-        }
-
-        Exp memory exchangeRate = Exp({ mantissa: _exchangeRateStored() });
-
-        /////////////////////////
-        // EFFECTS & INTERACTIONS
-        // (No safe failures beyond this point)
-
-        /*
-         *  We call `_doTransferIn` for the minter and the mintAmount.
-         *  Note: The vToken must handle variations between ERC-20 and ETH underlying.
-         *  `_doTransferIn` reverts if anything goes wrong, since we can't be sure if
-         *  side-effects occurred. The function returns the amount actually transferred,
-         *  in case of a fee. On success, the vToken holds an additional `actualMintAmount`
-         *  of cash.
-         */
-        uint256 actualMintAmount = _doTransferIn(minter, mintAmount);
 
         /*
          * We get the current exchange rate and calculate the number of vTokens to be minted:

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -483,6 +483,13 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         _mintFreshBehalf(msg.sender, minter, mintAmount);
     }
 
+    /**
+     * @notice Sender supplies assets into the market and minter receives vTokens in exchange
+     * @dev Assumes interest has already been accrued up to the current block
+     * @param sender The address which provides assets on behalf of minter
+     * @param minter The address of the account which is supplying the assets
+     * @param mintAmount The amount of the underlying asset to supply
+     */
     function _mintFreshBehalf(
         address sender,
         address minter,

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -490,7 +490,11 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param minter The address of the account which is supplying the assets
      * @param mintAmount The amount of the underlying asset to supply
      */
-    function _mintFresh(address sender, address minter, uint256 mintAmount) internal {
+    function _mintFresh(
+        address sender,
+        address minter,
+        uint256 mintAmount
+    ) internal {
         /* Fail if mint not allowed */
         uint256 allowed = comptroller.mintAllowed(address(this), minter, mintAmount);
         if (allowed != 0) {

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -248,6 +248,8 @@ abstract contract VTokenInterface is VTokenStorage {
 
     function mint(uint256 mintAmount) external virtual;
 
+    function mintBehalf(address minter, uint256 mintAllowed) external virtual;
+
     function redeem(uint256 redeemTokens) external virtual;
 
     function redeemUnderlying(uint256 redeemAmount) external virtual;

--- a/contracts/test/VTokenHarness.sol
+++ b/contracts/test/VTokenHarness.sol
@@ -107,7 +107,7 @@ contract VTokenHarness is VToken {
     }
 
     function harnessMintFresh(address account, uint256 mintAmount) external {
-        super._mintFresh(account, mintAmount);
+        super._mintFresh(account, account, mintAmount);
     }
 
     function harnessRedeemFresh(

--- a/deploy/004-deploy-pool-registry.ts
+++ b/deploy/004-deploy-pool-registry.ts
@@ -131,6 +131,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   tx = await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
+    "setMarketBorrowCaps(address[],uint256[])",
+    poolRegistry.address,
+  );
+  await tx.wait();
+
+  tx = await accessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
     "setLiquidationIncentive(uint256)",
     poolRegistry.address,
   );

--- a/deploy/004-deploy-pool-registry.ts
+++ b/deploy/004-deploy-pool-registry.ts
@@ -124,6 +124,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   tx = await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
+    "setMarketSupplyCaps(address[],uint256[])",
+    poolRegistry.address,
+  );
+  await tx.wait();
+
+  tx = await accessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
     "setLiquidationIncentive(uint256)",
     poolRegistry.address,
   );

--- a/deploy/006-deploy-mock-pools.ts
+++ b/deploy/006-deploy-mock-pools.ts
@@ -72,6 +72,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const initialSupply = convertToUnit(1, 18);
   const supplyCap = convertToUnit(10000, 18);
+  const borrowCap = convertToUnit(10000, 18);
   await BNX.faucet(initialSupply);
   await BNX.approve(poolRegistry.address, initialSupply);
 
@@ -93,6 +94,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     beaconAddress: vTokenBeacon.address,
     initialSupply,
     supplyCap,
+    borrowCap,
   });
   await tx.wait();
 
@@ -120,6 +122,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     beaconAddress: vTokenBeacon.address,
     initialSupply,
     supplyCap,
+    borrowCap,
   });
 
   const PoolLens = await ethers.getContract("PoolLens");

--- a/deploy/006-deploy-mock-pools.ts
+++ b/deploy/006-deploy-mock-pools.ts
@@ -70,6 +70,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     autoMine: true,
   });
 
+  const initialSupply = convertToUnit(1, 18);
+  const supplyCap = convertToUnit(10000, 18);
+  await BNX.faucet(initialSupply);
+  await BNX.approve(poolRegistry.address, initialSupply);
+
   tx = await poolRegistry.addMarket({
     comptroller: comptroller1Proxy.address,
     asset: BNX.address,
@@ -86,11 +91,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin,
     beaconAddress: vTokenBeacon.address,
+    initialSupply,
+    supplyCap
   });
   await tx.wait();
 
   const vBSWImplementation = await VToken.deploy();
   await vBSWImplementation.deployed();
+
+  await BSW.faucet(initialSupply);
+  await BSW.approve(poolRegistry.address, initialSupply);
 
   tx = await poolRegistry.addMarket({
     comptroller: comptroller1Proxy.address,
@@ -108,6 +118,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin,
     beaconAddress: vTokenBeacon.address,
+    initialSupply,
+    supplyCap
   });
 
   const PoolLens = await ethers.getContract("PoolLens");

--- a/deploy/006-deploy-mock-pools.ts
+++ b/deploy/006-deploy-mock-pools.ts
@@ -92,7 +92,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     vTokenProxyAdmin: proxyAdmin,
     beaconAddress: vTokenBeacon.address,
     initialSupply,
-    supplyCap
+    supplyCap,
   });
   await tx.wait();
 
@@ -119,7 +119,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     vTokenProxyAdmin: proxyAdmin,
     beaconAddress: vTokenBeacon.address,
     initialSupply,
-    supplyCap
+    supplyCap,
   });
 
   const PoolLens = await ethers.getContract("PoolLens");

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -179,6 +179,12 @@ const riskFundFixture = async (): Promise<void> => {
 
   await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
+    "setMarketBorrowCaps(address[],uint256[])",
+    poolRegistry.address,
+  );
+
+  await accessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
     "setLiquidationIncentive(uint256)",
     poolRegistry.address,
   );
@@ -312,6 +318,7 @@ const riskFundFixture = async (): Promise<void> => {
     beaconAddress: vTokenBeacon.address,
     initialSupply,
     supplyCap: initialSupply,
+    borrowCap: initialSupply,
   });
 
   await poolRegistry.addMarket({
@@ -332,6 +339,7 @@ const riskFundFixture = async (): Promise<void> => {
     beaconAddress: vTokenBeacon.address,
     initialSupply,
     supplyCap: initialSupply,
+    borrowCap: initialSupply,
   });
 
   await USDT.faucet(initialSupply);
@@ -355,6 +363,7 @@ const riskFundFixture = async (): Promise<void> => {
     beaconAddress: vTokenBeacon.address,
     initialSupply,
     supplyCap: initialSupply,
+    borrowCap: initialSupply,
   });
 
   await USDC.faucet(initialSupply);
@@ -378,6 +387,7 @@ const riskFundFixture = async (): Promise<void> => {
     beaconAddress: vTokenBeacon.address,
     initialSupply,
     supplyCap: initialSupply,
+    borrowCap: initialSupply,
   });
 
   await USDT.faucet(initialSupply);
@@ -401,6 +411,7 @@ const riskFundFixture = async (): Promise<void> => {
     beaconAddress: vTokenBeacon.address,
     initialSupply,
     supplyCap: initialSupply,
+    borrowCap: initialSupply,
   });
 
   await BUSD.faucet(initialSupply);
@@ -424,6 +435,7 @@ const riskFundFixture = async (): Promise<void> => {
     beaconAddress: vTokenBeacon.address,
     initialSupply,
     supplyCap: initialSupply,
+    borrowCap: initialSupply,
   });
 
   const cUSDT1Address = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, USDT.address);

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -311,7 +311,7 @@ const riskFundFixture = async (): Promise<void> => {
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
     initialSupply,
-    supplyCap: initialSupply
+    supplyCap: initialSupply,
   });
 
   await poolRegistry.addMarket({
@@ -331,7 +331,7 @@ const riskFundFixture = async (): Promise<void> => {
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
     initialSupply,
-    supplyCap: initialSupply
+    supplyCap: initialSupply,
   });
 
   await USDT.faucet(initialSupply);
@@ -354,7 +354,7 @@ const riskFundFixture = async (): Promise<void> => {
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
     initialSupply,
-    supplyCap: initialSupply
+    supplyCap: initialSupply,
   });
 
   await USDC.faucet(initialSupply);
@@ -377,7 +377,7 @@ const riskFundFixture = async (): Promise<void> => {
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
     initialSupply,
-    supplyCap: initialSupply
+    supplyCap: initialSupply,
   });
 
   await USDT.faucet(initialSupply);
@@ -400,7 +400,7 @@ const riskFundFixture = async (): Promise<void> => {
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
     initialSupply,
-    supplyCap: initialSupply
+    supplyCap: initialSupply,
   });
 
   await BUSD.faucet(initialSupply);
@@ -423,7 +423,7 @@ const riskFundFixture = async (): Promise<void> => {
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
     initialSupply,
-    supplyCap: initialSupply
+    supplyCap: initialSupply,
   });
 
   const cUSDT1Address = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, USDT.address);

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -280,6 +280,13 @@ const riskFundFixture = async (): Promise<void> => {
   const tokenImplementation = await VToken.deploy();
   await tokenImplementation.deployed();
 
+  const initialSupply = convertToUnit(1000, 18);
+  await USDT.faucet(initialSupply);
+  await USDT.approve(poolRegistry.address, initialSupply);
+
+  await USDC.faucet(initialSupply);
+  await USDC.approve(poolRegistry.address, initialSupply);
+
   // Deploy CTokens
   await poolRegistry.addMarket({
     comptroller: comptroller1Proxy.address,
@@ -297,6 +304,7 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
+    initialSupply
   });
 
   await poolRegistry.addMarket({
@@ -315,7 +323,11 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
+    initialSupply
   });
+
+  await USDT.faucet(initialSupply);
+  await USDT.approve(poolRegistry.address, initialSupply);
 
   await poolRegistry.addMarket({
     comptroller: comptroller2Proxy.address,
@@ -333,7 +345,11 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
+    initialSupply
   });
+
+  await USDC.faucet(initialSupply);
+  await USDC.approve(poolRegistry.address, initialSupply);
 
   await poolRegistry.addMarket({
     comptroller: comptroller2Proxy.address,
@@ -351,7 +367,11 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
+    initialSupply
   });
+
+  await USDT.faucet(initialSupply);
+  await USDT.approve(poolRegistry.address, initialSupply);
 
   await poolRegistry.addMarket({
     comptroller: comptroller3Proxy.address,
@@ -369,7 +389,11 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
+    initialSupply
   });
+
+  await BUSD.faucet(initialSupply);
+  await BUSD.approve(poolRegistry.address, initialSupply);
 
   await poolRegistry.addMarket({
     comptroller: comptroller3Proxy.address,
@@ -387,6 +411,7 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
+    initialSupply
   });
 
   const cUSDT1Address = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, USDT.address);

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -173,6 +173,12 @@ const riskFundFixture = async (): Promise<void> => {
 
   await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
+    "setMarketSupplyCaps(address[],uint256[])",
+    poolRegistry.address,
+  );
+
+  await accessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
     "setLiquidationIncentive(uint256)",
     poolRegistry.address,
   );
@@ -304,7 +310,8 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
-    initialSupply
+    initialSupply,
+    supplyCap: initialSupply
   });
 
   await poolRegistry.addMarket({
@@ -323,7 +330,8 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
-    initialSupply
+    initialSupply,
+    supplyCap: initialSupply
   });
 
   await USDT.faucet(initialSupply);
@@ -345,7 +353,8 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
-    initialSupply
+    initialSupply,
+    supplyCap: initialSupply
   });
 
   await USDC.faucet(initialSupply);
@@ -367,7 +376,8 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
-    initialSupply
+    initialSupply,
+    supplyCap: initialSupply
   });
 
   await USDT.faucet(initialSupply);
@@ -389,7 +399,8 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
-    initialSupply
+    initialSupply,
+    supplyCap: initialSupply
   });
 
   await BUSD.faucet(initialSupply);
@@ -411,7 +422,8 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: accessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
-    initialSupply
+    initialSupply,
+    supplyCap: initialSupply
   });
 
   const cUSDT1Address = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, USDT.address);

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -5,6 +5,7 @@ import { expect } from "chai";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
+import { convertToUnit } from "../../../helpers/utils";
 import {
   AccessControlManager,
   Beacon,

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -202,6 +202,13 @@ const riskFundFixture = async (): Promise<void> => {
   const tokenImplementation = await VToken.deploy();
   await tokenImplementation.deployed();
 
+  const initialSupply = convertToUnit(1000, 18);
+  await USDT.faucet(initialSupply);
+  await USDT.approve(poolRegistry.address, initialSupply);
+
+  await BUSD.faucet(initialSupply);
+  await BUSD.approve(poolRegistry.address, initialSupply);
+
   // Deploy CTokens
   await poolRegistry.addMarket({
     comptroller: comptroller1Proxy.address,
@@ -219,6 +226,9 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: fakeAccessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
+    initialSupply,
+    supplyCap: initialSupply,
+    borrowCap: initialSupply,
   });
 
   await poolRegistry.addMarket({
@@ -237,6 +247,9 @@ const riskFundFixture = async (): Promise<void> => {
     accessControlManager: fakeAccessControlManager.address,
     vTokenProxyAdmin: proxyAdmin.address,
     beaconAddress: vTokenBeacon.address,
+    initialSupply,
+    supplyCap: initialSupply,
+    borrowCap: initialSupply,
   });
 
   const vUSDTAddress = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, USDT.address);

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -91,6 +91,7 @@ describe("PoolRegistry: Tests", function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply: INITIAL_SUPPLY,
       supplyCap: INITIAL_SUPPLY,
+      borrowCap: INITIAL_SUPPLY,
     };
     return { ...defaults, ...overwrites };
   };
@@ -223,6 +224,7 @@ describe("PoolRegistry: Tests", function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply: INITIAL_SUPPLY,
       supplyCap: INITIAL_SUPPLY,
+      borrowCap: INITIAL_SUPPLY,
     });
 
     await poolRegistry.addMarket({
@@ -243,6 +245,7 @@ describe("PoolRegistry: Tests", function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply: INITIAL_SUPPLY,
       supplyCap: INITIAL_SUPPLY,
+      borrowCap: INITIAL_SUPPLY,
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, mockWBTC.address);

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -90,7 +90,7 @@ describe("PoolRegistry: Tests", function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply: INITIAL_SUPPLY,
-      supplyCap: INITIAL_SUPPLY
+      supplyCap: INITIAL_SUPPLY,
     };
     return { ...defaults, ...overwrites };
   };
@@ -222,7 +222,7 @@ describe("PoolRegistry: Tests", function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply: INITIAL_SUPPLY,
-      supplyCap: INITIAL_SUPPLY
+      supplyCap: INITIAL_SUPPLY,
     });
 
     await poolRegistry.addMarket({
@@ -242,7 +242,7 @@ describe("PoolRegistry: Tests", function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply: INITIAL_SUPPLY,
-      supplyCap: INITIAL_SUPPLY
+      supplyCap: INITIAL_SUPPLY,
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, mockWBTC.address);
@@ -299,7 +299,7 @@ describe("PoolRegistry: Tests", function () {
 
       await mockToken.faucet(INITIAL_SUPPLY);
       await mockToken.approve(poolRegistry.address, INITIAL_SUPPLY);
-      
+
       await poolRegistry.addMarket(await withDefaultMarketParameters());
       const vTokenAddress = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, mockToken.address);
       expect(vTokenAddress).to.be.a.properAddress;

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -89,7 +89,8 @@ describe("PoolRegistry: Tests", function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply: INITIAL_SUPPLY
+      initialSupply: INITIAL_SUPPLY,
+      supplyCap: INITIAL_SUPPLY
     };
     return { ...defaults, ...overwrites };
   };
@@ -220,7 +221,8 @@ describe("PoolRegistry: Tests", function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply: INITIAL_SUPPLY
+      initialSupply: INITIAL_SUPPLY,
+      supplyCap: INITIAL_SUPPLY
     });
 
     await poolRegistry.addMarket({
@@ -239,7 +241,8 @@ describe("PoolRegistry: Tests", function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply: INITIAL_SUPPLY
+      initialSupply: INITIAL_SUPPLY,
+      supplyCap: INITIAL_SUPPLY
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, mockWBTC.address);

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -170,7 +170,7 @@ describe("Rewards: Tests", async function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply,
-      supplyCap: initialSupply
+      supplyCap: initialSupply,
     });
 
     await poolRegistry.addMarket({
@@ -190,7 +190,7 @@ describe("Rewards: Tests", async function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply,
-      supplyCap: initialSupply
+      supplyCap: initialSupply,
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(comptrollerProxy.address, mockWBTC.address);

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -145,6 +145,13 @@ describe("Rewards: Tests", async function () {
     const tokenImplementation = await VToken.deploy();
     await tokenImplementation.deployed();
 
+    const initialSupply = convertToUnit(1000, 18);
+    await mockWBTC.faucet(initialSupply);
+    await mockWBTC.approve(poolRegistry.address, initialSupply);
+
+    await mockDAI.faucet(initialSupply);
+    await mockDAI.approve(poolRegistry.address, initialSupply);
+
     //Deploy VTokens
     await poolRegistry.addMarket({
       comptroller: comptrollerProxy.address,
@@ -162,6 +169,7 @@ describe("Rewards: Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
+      initialSupply
     });
 
     await poolRegistry.addMarket({
@@ -180,6 +188,7 @@ describe("Rewards: Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
+      initialSupply
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(comptrollerProxy.address, mockWBTC.address);

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -169,7 +169,8 @@ describe("Rewards: Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply
+      initialSupply,
+      supplyCap: initialSupply
     });
 
     await poolRegistry.addMarket({
@@ -188,7 +189,8 @@ describe("Rewards: Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply
+      initialSupply,
+      supplyCap: initialSupply
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(comptrollerProxy.address, mockWBTC.address);

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -171,6 +171,7 @@ describe("Rewards: Tests", async function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply,
       supplyCap: initialSupply,
+      borrowCap: initialSupply,
     });
 
     await poolRegistry.addMarket({
@@ -191,6 +192,7 @@ describe("Rewards: Tests", async function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply,
       supplyCap: initialSupply,
+      borrowCap: initialSupply,
     });
 
     const vWBTCAddress = await poolRegistry.getVTokenForAsset(comptrollerProxy.address, mockWBTC.address);

--- a/tests/hardhat/UpgradedVToken.ts
+++ b/tests/hardhat/UpgradedVToken.ts
@@ -131,7 +131,8 @@ describe("UpgradedVToken: Tests", function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply
+      initialSupply,
+      supplyCap: initialSupply
     });
   });
 

--- a/tests/hardhat/UpgradedVToken.ts
+++ b/tests/hardhat/UpgradedVToken.ts
@@ -132,7 +132,7 @@ describe("UpgradedVToken: Tests", function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply,
-      supplyCap: initialSupply
+      supplyCap: initialSupply,
     });
   });
 

--- a/tests/hardhat/UpgradedVToken.ts
+++ b/tests/hardhat/UpgradedVToken.ts
@@ -133,6 +133,7 @@ describe("UpgradedVToken: Tests", function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply,
       supplyCap: initialSupply,
+      borrowCap: initialSupply,
     });
   });
 

--- a/tests/hardhat/UpgradedVToken.ts
+++ b/tests/hardhat/UpgradedVToken.ts
@@ -110,6 +110,10 @@ describe("UpgradedVToken: Tests", function () {
     const tokenImplementation = await VToken.deploy();
     await tokenImplementation.deployed();
 
+    const initialSupply = convertToUnit(1000, 18);
+    await mockWBTC.faucet(initialSupply);
+    await mockWBTC.approve(poolRegistry.address, initialSupply);
+
     // Deploy VTokens
     await poolRegistry.addMarket({
       comptroller: pools[0].comptroller,
@@ -127,6 +131,7 @@ describe("UpgradedVToken: Tests", function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
+      initialSupply
     });
   });
 

--- a/tests/hardhat/lens/PoolLens.ts
+++ b/tests/hardhat/lens/PoolLens.ts
@@ -184,6 +184,7 @@ describe("PoolLens - PoolView Tests", async function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply,
       supplyCap: initialSupply,
+      borrowCap: initialSupply,
     });
 
     await poolRegistry.addMarket({
@@ -204,6 +205,7 @@ describe("PoolLens - PoolView Tests", async function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply,
       supplyCap: initialSupply,
+      borrowCap: initialSupply,
     });
 
     await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {
@@ -436,6 +438,7 @@ describe("PoolLens - VTokens Query Tests", async function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply,
       supplyCap: initialSupply,
+      borrowCap: initialSupply,
     });
 
     initialSupply = convertToUnit(1, 18);
@@ -460,6 +463,7 @@ describe("PoolLens - VTokens Query Tests", async function () {
       beaconAddress: vTokenBeacon.address,
       initialSupply,
       supplyCap: initialSupply,
+      borrowCap: initialSupply,
     });
 
     await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {

--- a/tests/hardhat/lens/PoolLens.ts
+++ b/tests/hardhat/lens/PoolLens.ts
@@ -159,6 +159,13 @@ describe("PoolLens - PoolView Tests", async function () {
     comptroller2Proxy = await ethers.getContractAt("Comptroller", pools[1].comptroller);
     await comptroller2Proxy.acceptOwnership();
 
+    const initialSupply = convertToUnit(1000, 18);
+    await mockWBTC.faucet(initialSupply);
+    await mockWBTC.approve(poolRegistry.address, initialSupply);
+
+    await mockDAI.faucet(initialSupply);
+    await mockDAI.approve(poolRegistry.address, initialSupply);
+
     await poolRegistry.addMarket({
       comptroller: comptroller1Proxy.address,
       asset: mockWBTC.address,
@@ -175,6 +182,7 @@ describe("PoolLens - PoolView Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
+      initialSupply
     });
 
     await poolRegistry.addMarket({
@@ -193,6 +201,7 @@ describe("PoolLens - PoolView Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
+      initialSupply
     });
 
     await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {
@@ -403,6 +412,13 @@ describe("PoolLens - VTokens Query Tests", async function () {
     comptroller2Proxy = await ethers.getContractAt("Comptroller", pools[1].comptroller);
     await comptroller2Proxy.acceptOwnership();
 
+    const initialSupply = convertToUnit(1000, 18);
+    await mockWBTC.faucet(initialSupply);
+    await mockWBTC.approve(poolRegistry.address, initialSupply);
+
+    await mockDAI.faucet(initialSupply);
+    await mockDAI.approve(poolRegistry.address, initialSupply);
+
     await poolRegistry.addMarket({
       comptroller: comptroller1Proxy.address,
       asset: mockWBTC.address,
@@ -419,6 +435,7 @@ describe("PoolLens - VTokens Query Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
+      initialSupply
     });
 
     await poolRegistry.addMarket({
@@ -437,6 +454,7 @@ describe("PoolLens - VTokens Query Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
+      initialSupply
     });
 
     await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {

--- a/tests/hardhat/lens/PoolLens.ts
+++ b/tests/hardhat/lens/PoolLens.ts
@@ -183,7 +183,7 @@ describe("PoolLens - PoolView Tests", async function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply,
-      supplyCap: initialSupply
+      supplyCap: initialSupply,
     });
 
     await poolRegistry.addMarket({
@@ -203,7 +203,7 @@ describe("PoolLens - PoolView Tests", async function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply,
-      supplyCap: initialSupply
+      supplyCap: initialSupply,
     });
 
     await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {
@@ -435,7 +435,7 @@ describe("PoolLens - VTokens Query Tests", async function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply,
-      supplyCap: initialSupply
+      supplyCap: initialSupply,
     });
 
     initialSupply = convertToUnit(1, 18);
@@ -459,7 +459,7 @@ describe("PoolLens - VTokens Query Tests", async function () {
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
       initialSupply,
-      supplyCap: initialSupply
+      supplyCap: initialSupply,
     });
 
     await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {

--- a/tests/hardhat/lens/PoolLens.ts
+++ b/tests/hardhat/lens/PoolLens.ts
@@ -182,7 +182,8 @@ describe("PoolLens - PoolView Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply
+      initialSupply,
+      supplyCap: initialSupply
     });
 
     await poolRegistry.addMarket({
@@ -201,7 +202,8 @@ describe("PoolLens - PoolView Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply
+      initialSupply,
+      supplyCap: initialSupply
     });
 
     await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {
@@ -412,12 +414,9 @@ describe("PoolLens - VTokens Query Tests", async function () {
     comptroller2Proxy = await ethers.getContractAt("Comptroller", pools[1].comptroller);
     await comptroller2Proxy.acceptOwnership();
 
-    const initialSupply = convertToUnit(1000, 18);
+    let initialSupply = convertToUnit(1, 8);
     await mockWBTC.faucet(initialSupply);
     await mockWBTC.approve(poolRegistry.address, initialSupply);
-
-    await mockDAI.faucet(initialSupply);
-    await mockDAI.approve(poolRegistry.address, initialSupply);
 
     await poolRegistry.addMarket({
       comptroller: comptroller1Proxy.address,
@@ -435,8 +434,13 @@ describe("PoolLens - VTokens Query Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply
+      initialSupply,
+      supplyCap: initialSupply
     });
+
+    initialSupply = convertToUnit(1, 18);
+    await mockDAI.faucet(initialSupply);
+    await mockDAI.approve(poolRegistry.address, initialSupply);
 
     await poolRegistry.addMarket({
       comptroller: comptroller1Proxy.address,
@@ -454,7 +458,8 @@ describe("PoolLens - VTokens Query Tests", async function () {
       accessControlManager: fakeAccessControlManager.address,
       vTokenProxyAdmin: proxyAdmin.address,
       beaconAddress: vTokenBeacon.address,
-      initialSupply
+      initialSupply,
+      supplyCap: initialSupply
     });
 
     await poolRegistry.updatePoolMetadata(comptroller1Proxy.address, {
@@ -488,8 +493,8 @@ describe("PoolLens - VTokens Query Tests", async function () {
     expect(vTokenMetadata_Actual_Parsed["reserveFactorMantissa"]).equal("0");
     expect(vTokenMetadata_Actual_Parsed["totalBorrows"]).equal("0");
     expect(vTokenMetadata_Actual_Parsed["totalReserves"]).equal("0");
-    expect(vTokenMetadata_Actual_Parsed["totalSupply"]).equal("0");
-    expect(vTokenMetadata_Actual_Parsed["totalCash"]).equal("0");
+    expect(vTokenMetadata_Actual_Parsed["totalSupply"]).equal(convertToUnit(1, 18));
+    expect(vTokenMetadata_Actual_Parsed["totalCash"]).equal(convertToUnit(1, 8));
     expect(vTokenMetadata_Actual_Parsed["isListed"]).equal("true");
     expect(vTokenMetadata_Actual_Parsed["collateralFactorMantissa"]).equal("700000000000000000");
     expect(vTokenMetadata_Actual_Parsed["underlyingAssetAddress"]).equal(mockWBTC.address);

--- a/tests/hardhat/lens/PoolLens.ts
+++ b/tests/hardhat/lens/PoolLens.ts
@@ -501,6 +501,13 @@ describe("PoolLens - VTokens Query Tests", async function () {
     expect(vTokenMetadata_Actual_Parsed["vTokenDecimals"]).equal("8");
     expect(vTokenMetadata_Actual_Parsed["underlyingDecimals"]).equal("8");
   });
+
+  it("is correct minted for user", async () => {
+    const vTokenAddress_WBTC = await poolRegistry.getVTokenForAsset(comptroller1Proxy.address, mockWBTC.address);
+    const vTokenBalance = await poolLens.callStatic.vTokenBalances(vTokenAddress_WBTC, ownerAddress);
+    expect(vTokenBalance["balanceOfUnderlying"]).equal(convertToUnit(1, 8));
+    expect(vTokenBalance["balanceOf"]).equal(convertToUnit(1, 18));
+  });
 });
 
 const assertVTokenMetadata = (vTokenMetadata_Actual: any, vTokenMetadata_Expected: any) => {


### PR DESCRIPTION
## Description

When calling `addMarket` we need to provide `initialSupply`, `borrowCap` and `supplyCap`. The caller should approve `initialSupply` amount to the `PoolRegistry` before calling `addMarket`.


## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
