### PR TITLE
Riskfund auction_contract updated with shortfall_contract

### DIFF
--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -104,13 +104,13 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
 
     /**
      * @dev Auction contract address setter
-     * @param _auctionContractAddress Address of the auction contract.
+     * @param _shortfallContractAddress Address of the auction contract.
      */
-    function setAuctionContractAddress(address _auctionContractAddress) external onlyOwner {
-        require(_auctionContractAddress != address(0), "Risk Fund: Auction contract address invalid");
+    function setShortfallContractAddress(address _shortfallContractAddress) external onlyOwner {
+        require(_shortfallContractAddress != address(0), "Risk Fund: Auction contract address invalid");
         address oldAuctionContractAddress = shortfall;
-        shortfall = _auctionContractAddress;
-        emit AuctionContractUpdated(oldAuctionContractAddress, _auctionContractAddress);
+        shortfall = _shortfallContractAddress;
+        emit AuctionContractUpdated(oldAuctionContractAddress, _shortfallContractAddress);
     }
 
     /**

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -33,8 +33,8 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
     /// @notice Emitted when convertible base asset address is updated
     event ConvertableBaseAssetUpdated(address indexed oldBaseAsset, address indexed newBaseAsset);
 
-    /// @notice Emitted when auction contract address is updated
-    event AuctionContractUpdated(address indexed oldAuctionContract, address indexed newAuctionContract);
+    /// @notice Emitted when shortfall contract address is updated
+    event ShortfallContractUpdated(address indexed oldShortfallContract, address indexed newShortfallContract);
 
     /// @notice Emitted when PancakeSwap router contract address is updated
     event PancakeSwapRouterUpdated(address indexed oldPancakeSwapRouter, address indexed newPancakeSwapRouter);
@@ -103,14 +103,14 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
     }
 
     /**
-     * @dev Auction contract address setter
+     * @dev Shortfall contract address setter
      * @param _shortfallContractAddress Address of the auction contract.
      */
     function setShortfallContractAddress(address _shortfallContractAddress) external onlyOwner {
-        require(_shortfallContractAddress != address(0), "Risk Fund: Auction contract address invalid");
-        address oldAuctionContractAddress = shortfall;
+        require(_shortfallContractAddress != address(0), "Risk Fund: Shortfall contract address invalid");
+        address oldShortfallContractAddress = shortfall;
         shortfall = _shortfallContractAddress;
-        emit AuctionContractUpdated(oldAuctionContractAddress, _shortfallContractAddress);
+        emit ShortfallContractUpdated(oldShortfallContractAddress, _shortfallContractAddress);
     }
 
     /**

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -21,7 +21,6 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
     address private pancakeSwapRouter;
     uint256 private minAmountToConvert;
     address private convertibleBaseAsset;
-    address private auctionContractAddress;
     address private accessControl;
     address private shortfall;
 
@@ -109,8 +108,8 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
      */
     function setAuctionContractAddress(address _auctionContractAddress) external onlyOwner {
         require(_auctionContractAddress != address(0), "Risk Fund: Auction contract address invalid");
-        address oldAuctionContractAddress = auctionContractAddress;
-        auctionContractAddress = _auctionContractAddress;
+        address oldAuctionContractAddress = shortfall;
+        shortfall = _auctionContractAddress;
         emit AuctionContractUpdated(oldAuctionContractAddress, _auctionContractAddress);
     }
 
@@ -178,11 +177,9 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
      */
     function transferReserveForAuction(address comptroller, uint256 amount) external returns (uint256) {
         require(msg.sender == shortfall, "Risk fund: Only callable by Shortfall contract");
-
-        require(auctionContractAddress != address(0), "Risk Fund: Auction contract invalid address.");
         require(amount <= poolReserves[comptroller], "Risk Fund: Insufficient pool reserve.");
         poolReserves[comptroller] = poolReserves[comptroller] - amount;
-        IERC20Upgradeable(convertibleBaseAsset).safeTransfer(auctionContractAddress, amount);
+        IERC20Upgradeable(convertibleBaseAsset).safeTransfer(shortfall, amount);
         return amount;
     }
 

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -528,7 +528,7 @@ describe("Risk Fund: Tests", function () {
     describe("setShortfallContractAddress", async function () {
       it("Reverts on invalid Auction contract address", async function () {
         await expect(riskFund.setShortfallContractAddress(constants.AddressZero)).to.be.rejectedWith(
-          "Risk Fund: Auction contract address invalid",
+          "Risk Fund: Shortfall contract address invalid",
         );
       });
 
@@ -538,9 +538,9 @@ describe("Risk Fund: Tests", function () {
         );
       });
 
-      it("emits AuctionContractUpdated event", async function () {
+      it("emits ShortfallContractUpdated event", async function () {
         const tx = riskFund.setShortfallContractAddress(someNonzeroAddress);
-        await expect(tx).to.emit(riskFund, "AuctionContractUpdated").withArgs(shortfall.address, someNonzeroAddress);
+        await expect(tx).to.emit(riskFund, "ShortfallContractUpdated").withArgs(shortfall.address, someNonzeroAddress);
       });
     });
 

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -540,9 +540,7 @@ describe("Risk Fund: Tests", function () {
 
       it("emits AuctionContractUpdated event", async function () {
         const tx = riskFund.setAuctionContractAddress(someNonzeroAddress);
-        await expect(tx)
-          .to.emit(riskFund, "AuctionContractUpdated")
-          .withArgs(constants.AddressZero, someNonzeroAddress);
+        await expect(tx).to.emit(riskFund, "AuctionContractUpdated").withArgs(shortfall.address, someNonzeroAddress);
       });
     });
 
@@ -736,10 +734,10 @@ describe("Risk Fund: Tests", function () {
   describe("Transfer to Auction contract", async function () {
     it("Revert while transfering funds to Auction contract", async function () {
       await expect(
-        riskFund.connect(shortfall.wallet).transferReserveForAuction(comptroller1Proxy.address, convertToUnit(30, 18)),
-      ).to.be.rejectedWith("Risk Fund: Auction contract invalid address.");
+        riskFund.connect(busdUser).transferReserveForAuction(comptroller1Proxy.address, convertToUnit(30, 18)),
+      ).to.be.rejectedWith("Risk fund: Only callable by Shortfall contract");
 
-      const auctionContract = "0x0000000000000000000000000000000000000001";
+      const auctionContract = shortfall.address;
       await riskFund.setAuctionContractAddress(auctionContract);
 
       await expect(
@@ -748,8 +746,8 @@ describe("Risk Fund: Tests", function () {
     });
 
     it("Transfer funds to auction contact", async function () {
-      const auctionContract = "0x0000000000000000000000000000000000000001";
-      await riskFund.setAuctionContractAddress(auctionContract);
+      // const auctionContract = "0x0000000000000000000000000000000000000001";
+      await riskFund.setAuctionContractAddress(shortfall.address);
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
@@ -780,11 +778,11 @@ describe("Risk Fund: Tests", function () {
         ],
       );
 
-      const beforeTransfer = await BUSD.balanceOf(auctionContract);
+      const beforeTransfer = await BUSD.balanceOf(shortfall.address);
       await riskFund
         .connect(shortfall.wallet)
         .transferReserveForAuction(comptroller1Proxy.address, convertToUnit(20, 18));
-      const afterTransfer = await BUSD.balanceOf(auctionContract);
+      const afterTransfer = await BUSD.balanceOf(shortfall.address);
       const remainingBalance = await BUSD.balanceOf(riskFund.address);
       const poolReserve = await riskFund.getPoolReserve(comptroller1Proxy.address);
 

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -525,21 +525,21 @@ describe("Risk Fund: Tests", function () {
       });
     });
 
-    describe("setAuctionContractAddress", async function () {
+    describe("setShortfallContractAddress", async function () {
       it("Reverts on invalid Auction contract address", async function () {
-        await expect(riskFund.setAuctionContractAddress(constants.AddressZero)).to.be.rejectedWith(
+        await expect(riskFund.setShortfallContractAddress(constants.AddressZero)).to.be.rejectedWith(
           "Risk Fund: Auction contract address invalid",
         );
       });
 
       it("fails if called by a non-owner", async function () {
-        await expect(riskFund.connect(usdcUser).setAuctionContractAddress(someNonzeroAddress)).to.be.rejectedWith(
+        await expect(riskFund.connect(usdcUser).setShortfallContractAddress(someNonzeroAddress)).to.be.rejectedWith(
           "Ownable: caller is not the owner",
         );
       });
 
       it("emits AuctionContractUpdated event", async function () {
-        const tx = riskFund.setAuctionContractAddress(someNonzeroAddress);
+        const tx = riskFund.setShortfallContractAddress(someNonzeroAddress);
         await expect(tx).to.emit(riskFund, "AuctionContractUpdated").withArgs(shortfall.address, someNonzeroAddress);
       });
     });
@@ -738,7 +738,7 @@ describe("Risk Fund: Tests", function () {
       ).to.be.rejectedWith("Risk fund: Only callable by Shortfall contract");
 
       const auctionContract = shortfall.address;
-      await riskFund.setAuctionContractAddress(auctionContract);
+      await riskFund.setShortfallContractAddress(auctionContract);
 
       await expect(
         riskFund.connect(shortfall.wallet).transferReserveForAuction(comptroller1Proxy.address, convertToUnit(100, 18)),
@@ -747,7 +747,7 @@ describe("Risk Fund: Tests", function () {
 
     it("Transfer funds to auction contact", async function () {
       // const auctionContract = "0x0000000000000000000000000000000000000001";
-      await riskFund.setAuctionContractAddress(shortfall.address);
+      await riskFund.setShortfallContractAddress(shortfall.address);
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
@@ -794,7 +794,7 @@ describe("Risk Fund: Tests", function () {
     it("Should revert the transfer to auction transaction", async function () {
       const [admin] = await ethers.getSigners();
       const auctionContract = "0x0000000000000000000000000000000000000001";
-      await riskFund.setAuctionContractAddress(auctionContract);
+      await riskFund.setShortfallContractAddress(auctionContract);
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
@@ -838,7 +838,7 @@ describe("Risk Fund: Tests", function () {
 
     it("Transfer single asset from multiple pools to riskFund.", async function () {
       const auctionContract = "0x0000000000000000000000000000000000000001";
-      await riskFund.setAuctionContractAddress(auctionContract);
+      await riskFund.setShortfallContractAddress(auctionContract);
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -746,7 +746,6 @@ describe("Risk Fund: Tests", function () {
     });
 
     it("Transfer funds to auction contact", async function () {
-      // const auctionContract = "0x0000000000000000000000000000000000000001";
       await riskFund.setShortfallContractAddress(shortfall.address);
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));


### PR DESCRIPTION
Riskfund Contract and Shortfall Contract both need the other's address to be set in order for them to be deployed, but neither contract has a setter to do so. As a result, deployment of both contracts became impossible. Shortfall Contract has a setter named setAuctionContrcatAddress rather than setShortfallContractAddress.

Shortfall contract use transferReserveForAuction function internally it transfers fund to auctionContract instead of shortfall contract, It should be a shortfall contract rather than an auction contract.

Because we are using smock, we have been unable to detect this serious problem until now in tests, which are conducted separately for the two contracts.


- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
