### PR TITLE
Integration test for [VEN-884] Liquidation and [VEN-885] Heal Account scenarios

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,5 +34,20 @@ module.exports = {
         varsIgnorePattern: "_",
       },
     ],
+    "spaced-comment": [
+      "error",
+      "always",
+      {
+        line: {
+          exceptions: ["-", "+"],
+          markers: ["=", "!", "/"],
+        },
+        block: {
+          exceptions: ["-", "+"],
+          markers: ["=", "!", ":", "::"],
+          balanced: true,
+        },
+      },
+    ],
   },
 };

--- a/deploy/001-deploy-mock-tokens.ts
+++ b/deploy/001-deploy-mock-tokens.ts
@@ -6,9 +6,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts }: any = hre;
   const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
-  //=======================
+  // =======================
   // DEPLOY MOCK TOKENS
-  //========================
+  // =======================
   await deploy("MockBNX", {
     from: deployer,
     contract: "MockToken",

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -16,3 +16,7 @@ BigNumber.config({
 export const convertToUnit = (amount: string | number, decimals: number) => {
   return new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toString();
 };
+
+export const scaleDownBy = (amount: string | number, decimals: number) => {
+  return new BigNumber(amount).dividedBy(new BigNumber(10).pow(decimals)).toString();
+};

--- a/tests/hardhat/Comptroller/accountLiquidityTest.ts
+++ b/tests/hardhat/Comptroller/accountLiquidityTest.ts
@@ -160,7 +160,7 @@ describe("Comptroller", () => {
       expect(shortfall).to.equal(0);
 
       await comptroller.connect(user).enterMarkets([vToken.address]);
-      //await quickMint(vToken, user, amount);
+      // await quickMint(vToken, user, amount);
       vToken.getAccountSnapshot.whenCalledWith(await user.getAddress()).returns([0, amount, 0, convertToUnit("1", 18)]);
 
       // total account liquidity after supplying `amount`
@@ -237,9 +237,9 @@ describe("Comptroller", () => {
       });
 
       await comptroller.connect(user).enterMarkets([vToken1.address, vToken2.address, vToken3.address]);
-      //await quickMint(vToken1, user, amount1);
+      // pretend user mints amount1 of vToken1
       vToken1.getAccountSnapshot.whenCalledWith(userAddress).returns([0, amount1, 0, convertToUnit("1", 18)]);
-      //await quickMint(vToken2, user, amount2);
+      // pretend user mints amount2 of vToken2
       vToken2.getAccountSnapshot.whenCalledWith(userAddress).returns([0, amount2, 0, convertToUnit("1", 18)]);
 
       let error, liquidity, shortfall;

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -89,7 +89,7 @@ const initMockToken = async (name: string, symbol: string, user: SignerWithAddre
 const riskFundFixture = async (): Promise<void> => {
   const [admin, user, proxyAdmin, ...signers] = await ethers.getSigners();
   if (FORK_MAINNET) {
-    //MAINNET USER WITH BALANCE
+    // MAINNET USER WITH BALANCE
     busdUser = await initMainnetUser("0xf977814e90da44bfa03b6295a0616a897441acec");
     usdtUser = await initMainnetUser("0xf977814e90da44bfa03b6295a0616a897441acec");
 

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -101,7 +101,7 @@ describe("Rewards: Tests", async function () {
     await mockWBTC.deployed();
     await mockWBTC.faucet(convertToUnit(1000, 8));
 
-    //Deploy Mock Price Oracle
+    // Deploy Mock Price Oracle
     fakePriceOracle = await smock.fake<PriceOracle>(PriceOracle__factory.abi);
 
     const btcPrice = "21000.34";
@@ -119,7 +119,7 @@ describe("Rewards: Tests", async function () {
       return 1;
     });
 
-    //Register Pools to the protocol
+    // Register Pools to the protocol
     const _closeFactor = convertToUnit(0.05, 18);
     const _liquidationIncentive = convertToUnit(1, 18);
     const _minLiquidatableCollateral = convertToUnit(100, 18);
@@ -152,7 +152,7 @@ describe("Rewards: Tests", async function () {
     await mockDAI.faucet(initialSupply);
     await mockDAI.approve(poolRegistry.address, initialSupply);
 
-    //Deploy VTokens
+    // Deploy VTokens
     await poolRegistry.addMarket({
       comptroller: comptrollerProxy.address,
       asset: mockWBTC.address,
@@ -203,12 +203,12 @@ describe("Rewards: Tests", async function () {
 
     const [, , user] = await ethers.getSigners();
 
-    //Enter Markets
+    // Enter Markets
     await comptrollerProxy.enterMarkets([vDAI.address, vWBTC.address]);
     await comptrollerProxy.enterMarkets([vDAI.address, vWBTC.address]);
     await comptrollerProxy.connect(user).enterMarkets([vDAI.address, vWBTC.address]);
 
-    //Configure rewards for pool
+    // Configure rewards for pool
     const RewardsDistributor = await ethers.getContractFactory("RewardsDistributor");
     rewardsDistributor = await RewardsDistributor.deploy();
 
@@ -286,7 +286,7 @@ describe("Rewards: Tests", async function () {
     );
   });
 
-  //TODO: Test reward accruals. This test used to pass before, but it
+  // TODO: Test reward accruals. This test used to pass before, but it
   //      was a false-positive. The correct test would need to mint or
   //      borrow some assets (or pretend to do so, using smock).
   it.skip("Claim XVS", async function () {
@@ -301,7 +301,7 @@ describe("Rewards: Tests", async function () {
     console.log(test);
     console.log(test1);
 
-    //expect((await xvs.balanceOf(user1.address)).toString()).not.equal("0")
+    // expect((await xvs.balanceOf(user1.address)).toString()).not.equal("0")
     expect((await xvs.balanceOf(user2.address)).toString()).not.equal("0");
   });
 });

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -64,7 +64,7 @@ async function shortfallFixture() {
   [owner, poolRegistry, someone, bidder1, bidder2] = await ethers.getSigners();
   await shortfall.setPoolRegistry(poolRegistry.address);
 
-  //Deploy Mock Tokens
+  // Deploy Mock Tokens
   const MockDAI = await ethers.getContractFactory("MockToken");
   mockDAI = await MockDAI.deploy("MakerDAO", "DAI", 18);
   await mockDAI.faucet(convertToUnit(1000000000, 18));
@@ -311,7 +311,7 @@ describe("Shortfall: Tests", async function () {
       const originalBalance = await mockBUSD.balanceOf(bidder2.address);
       await mine((await shortfall.nextBidderBlockLimit()).toNumber() + 2);
 
-      //simulate transferReserveForAuction
+      // simulate transferReserveForAuction
       await mockBUSD.transfer(shortfall.address, parseUnits(riskFundBalance, 18));
       await expect(shortfall.closeAuction(poolAddress))
         .to.emit(shortfall, "AuctionClosed")
@@ -425,7 +425,7 @@ describe("Shortfall: Tests", async function () {
 
       await mine((await shortfall.nextBidderBlockLimit()).toNumber() + 2);
 
-      //simulate transferReserveForAuction
+      // simulate transferReserveForAuction
       await mockBUSD.transfer(shortfall.address, auction.seizedRiskFund);
 
       await expect(shortfall.closeAuction(poolAddress))

--- a/tests/hardhat/Tokens/accrueInterestTest.ts
+++ b/tests/hardhat/Tokens/accrueInterestTest.ts
@@ -63,7 +63,7 @@ describe("VToken", () => {
     it("fails if new borrow rate calculation fails", async () => {
       await pretendBlock(vToken, blockNumber, 1);
       interestRateModel.getBorrowRate.reverts("Oups");
-      await expect(vToken.accrueInterest()).to.be.reverted; //With("INTEREST_RATE_MODEL_ERROR");
+      await expect(vToken.accrueInterest()).to.be.reverted; // With("INTEREST_RATE_MODEL_ERROR");
     });
 
     it("fails if simple interest factor calculation fails", async () => {

--- a/tests/hardhat/Tokens/borrowAndRepayTest.ts
+++ b/tests/hardhat/Tokens/borrowAndRepayTest.ts
@@ -110,9 +110,9 @@ describe("VToken", function () {
     });
 
     it("proceeds if comptroller tells it to", async () => {
-      //await expect(
+      // await expect(
       await borrowFresh(vToken, borrower, borrowAmount);
-      //).toSucceed();
+      // ).toSucceed();
     });
 
     it("fails if market not fresh", async () => {
@@ -124,12 +124,12 @@ describe("VToken", function () {
     });
 
     it("continues if fresh", async () => {
-      //await expect(
+      // await expect(
       await vToken.accrueInterest();
-      //).toSucceed();
-      //await expect(
+      // ).toSucceed();
+      // await expect(
       await borrowFresh(vToken, borrower, borrowAmount);
-      //).toSucceed();
+      // ).toSucceed();
     });
 
     it("fails if error if protocol has less than borrowAmount of underlying", async () => {
@@ -167,7 +167,7 @@ describe("VToken", function () {
       const beforeProtocolBorrows = await vToken.totalBorrows();
       const beforeAccountCash = await underlying.balanceOf(borrowerAddress);
       const result = await borrowFresh(vToken, borrower, borrowAmount);
-      //expect(result).toSucceed();
+      // expect(result).toSucceed();
       expect(await underlying.balanceOf(borrowerAddress)).to.equal(beforeAccountCash.add(borrowAmount));
       expect(await underlying.balanceOf(vToken.address)).to.equal(beforeProtocolCash.sub(borrowAmount));
       expect(await vToken.totalBorrows()).to.equal(beforeProtocolBorrows.add(borrowAmount));
@@ -194,7 +194,7 @@ describe("VToken", function () {
 
     it("emits a borrow failure if interest accrual fails", async () => {
       interestRateModel.getBorrowRate.reverts("Oups");
-      await expect(borrow(vToken, borrower, borrowAmount)).to.be.reverted; //With("INTEREST_RATE_MODEL_ERROR");
+      await expect(borrow(vToken, borrower, borrowAmount)).to.be.reverted; // With("INTEREST_RATE_MODEL_ERROR");
     });
 
     it("returns error from borrowFresh without emitting any extra logs", async () => {
@@ -206,9 +206,9 @@ describe("VToken", function () {
     it("returns success from borrowFresh and transfers the correct amount", async () => {
       const beforeAccountCash = await underlying.balanceOf(borrowerAddress);
       await vToken.harnessFastForward(5);
-      //expect(
+      // expect(
       await borrow(vToken, borrower, borrowAmount);
-      //).toSucceed();
+      // ).toSucceed();
       expect(await underlying.balanceOf(borrowerAddress)).to.equal(beforeAccountCash.add(borrowAmount));
     });
   });
@@ -279,9 +279,9 @@ describe("VToken", function () {
         it("stores new borrow principal and interest index", async () => {
           const beforeProtocolBorrows = await vToken.totalBorrows();
           const beforeAccountBorrowSnap = await vToken.harnessAccountBorrows(borrowerAddress);
-          //expect(
+          // expect(
           await repayBorrowFresh(vToken, payer, borrower, repayAmount);
-          //).toSucceed();
+          // ).toSucceed();
           const afterAccountBorrows = await vToken.harnessAccountBorrows(borrowerAddress);
           expect(afterAccountBorrows.principal).to.equal(beforeAccountBorrowSnap.principal.sub(repayAmount));
           expect(afterAccountBorrows.interestIndex).to.equal(convertToUnit("1", 18));
@@ -298,7 +298,7 @@ describe("VToken", function () {
 
     it("emits a repay borrow failure if interest accrual fails", async () => {
       interestRateModel.getBorrowRate.reverts("Oups");
-      await expect(repayBorrow(vToken, borrower, repayAmount)).to.be.reverted; //With("INTEREST_RATE_MODEL_ERROR");
+      await expect(repayBorrow(vToken, borrower, repayAmount)).to.be.reverted; // With("INTEREST_RATE_MODEL_ERROR");
     });
 
     it("returns error from repayBorrowFresh without emitting any extra logs", async () => {
@@ -309,18 +309,18 @@ describe("VToken", function () {
     it("returns success from repayBorrowFresh and repays the right amount", async () => {
       await vToken.harnessFastForward(5);
       const beforeAccountBorrowSnap = await vToken.harnessAccountBorrows(borrowerAddress);
-      //expect(
+      // expect(
       await repayBorrow(vToken, borrower, repayAmount);
-      //).toSucceed();
+      // ).toSucceed();
       const afterAccountBorrowSnap = await vToken.harnessAccountBorrows(borrowerAddress);
       expect(afterAccountBorrowSnap.principal).to.equal(beforeAccountBorrowSnap.principal.sub(repayAmount));
     });
 
     it("repays the full amount owed if payer has enough", async () => {
       await vToken.harnessFastForward(5);
-      //expect(
+      // expect(
       await repayBorrow(vToken, borrower, constants.MaxUint256);
-      //).toSucceed();
+      // ).toSucceed();
       const afterAccountBorrowSnap = await vToken.harnessAccountBorrows(borrowerAddress);
       expect(afterAccountBorrowSnap.principal).to.equal(0);
     });
@@ -344,7 +344,7 @@ describe("VToken", function () {
 
     it("emits a repay borrow failure if interest accrual fails", async () => {
       interestRateModel.getBorrowRate.reverts("Oups");
-      await expect(repayBorrowBehalf(vToken, payer, borrower, repayAmount)).to.be.reverted; //With("INTEREST_RATE_MODEL_ERROR");
+      await expect(repayBorrowBehalf(vToken, payer, borrower, repayAmount)).to.be.reverted; // With("INTEREST_RATE_MODEL_ERROR");
     });
 
     it("returns error from repayBorrowFresh without emitting any extra logs", async () => {
@@ -355,9 +355,9 @@ describe("VToken", function () {
     it("returns success from repayBorrowFresh and repays the right amount", async () => {
       await vToken.harnessFastForward(5);
       const beforeAccountBorrowSnap = await vToken.harnessAccountBorrows(borrowerAddress);
-      //expect(
+      // expect(
       await repayBorrowBehalf(vToken, payer, borrower, repayAmount);
-      //).toSucceed();
+      // ).toSucceed();
       const afterAccountBorrowSnap = await vToken.harnessAccountBorrows(borrowerAddress);
       expect(afterAccountBorrowSnap.principal).to.equal(beforeAccountBorrowSnap.principal.sub(repayAmount));
     });

--- a/tests/hardhat/Tokens/liquidateTest.ts
+++ b/tests/hardhat/Tokens/liquidateTest.ts
@@ -192,7 +192,7 @@ describe("VToken", function () {
       comptroller.liquidateCalculateSeizeTokens.reverts("Oups");
 
       await expect(liquidateFresh(borrowed.vToken, liquidator, borrower, repayAmount, collateral.vToken)).to.be
-        .reverted; //With('LIQUIDATE_COMPTROLLER_CALCULATE_AMOUNT_SEIZE_FAILED');
+        .reverted; // With('LIQUIDATE_COMPTROLLER_CALCULATE_AMOUNT_SEIZE_FAILED');
       const afterBalances = await getBalances(
         [borrowed.vToken, collateral.vToken],
         [liquidatorAddress, borrowerAddress],
@@ -261,12 +261,12 @@ describe("VToken", function () {
   describe("liquidateBorrow", () => {
     it("emits a liquidation failure if borrowed asset interest accrual fails", async () => {
       borrowed.interestRateModel.getBorrowRate.reverts("Oups");
-      await expect(liquidate(borrowed.vToken, liquidator, borrower, repayAmount, collateral.vToken)).to.be.reverted; //With("INTEREST_RATE_MODEL_ERROR");
+      await expect(liquidate(borrowed.vToken, liquidator, borrower, repayAmount, collateral.vToken)).to.be.reverted; // With("INTEREST_RATE_MODEL_ERROR");
     });
 
     it("emits a liquidation failure if collateral asset interest accrual fails", async () => {
       collateral.interestRateModel.getBorrowRate.reverts("Oups");
-      await expect(liquidate(borrowed.vToken, liquidator, borrower, repayAmount, collateral.vToken)).to.be.reverted; //With("INTEREST_RATE_MODEL_ERROR");
+      await expect(liquidate(borrowed.vToken, liquidator, borrower, repayAmount, collateral.vToken)).to.be.reverted; // With("INTEREST_RATE_MODEL_ERROR");
     });
 
     it("returns error from liquidateBorrowFresh without emitting any extra logs", async () => {
@@ -289,7 +289,7 @@ describe("VToken", function () {
         [borrowed.vToken, collateral.vToken],
         [liquidatorAddress, borrowerAddress],
       );
-      //expect(result).toSucceed();
+      // expect(result).toSucceed();
       expect(afterBalances).to.deep.equal(
         adjustBalances(beforeBalances, [
           [borrowed.vToken, "cash", repayAmount],
@@ -361,7 +361,7 @@ describe("VToken", function () {
   });
 });
 
-/*describe('Comptroller', () => {
+/* describe('Comptroller', () => {
   it('liquidateBorrowAllowed allows deprecated markets to be liquidated', async () => {
     let [root, liquidator, borrower] = saddle.accounts;
     let collatAmount = 10;
@@ -397,4 +397,4 @@ describe("VToken", function () {
     // even if deprecated, cant over repay
     await expect(send(comptroller, 'liquidateBorrowAllowed', [vTokenBorrow._address, vTokenCollat._address, liquidator, borrower, borrowAmount * 2])).rejects.toRevert('revert Can not repay more than the total borrow');
   });
-})*/
+}) */

--- a/tests/hardhat/Tokens/mintAndRedeemTest.ts
+++ b/tests/hardhat/Tokens/mintAndRedeemTest.ts
@@ -190,7 +190,7 @@ describe("VToken", function () {
     });
 
     it("continues if fresh", async () => {
-      //await expect(
+      // await expect(
       await vToken.accrueInterest();
 
       await mintFresh(vToken, minter, mintAmount);
@@ -255,7 +255,7 @@ describe("VToken", function () {
 
     it("emits a mint failure if interest accrual fails", async () => {
       interestRateModel.getBorrowRate.reverts("Oups");
-      await expect(quickMint(underlying, vToken, minter, mintAmount)).to.be.reverted; //With("INTEREST_RATE_MODEL_ERROR");
+      await expect(quickMint(underlying, vToken, minter, mintAmount)).to.be.reverted;
     });
 
     it("returns error from mintFresh without emitting any extra logs", async () => {
@@ -297,7 +297,6 @@ describe("VToken", function () {
       });
 
       it("continues if fresh", async () => {
-        //await expect(
         await vToken.accrueInterest();
 
         await redeemFresh(vToken, redeemer, redeemTokens, redeemAmount);
@@ -379,7 +378,7 @@ describe("VToken", function () {
 
     it("emits a redeem failure if interest accrual fails", async () => {
       interestRateModel.getBorrowRate.reverts("Oups");
-      await expect(quickRedeem(vToken, redeemer, redeemTokens)).to.be.reverted; //With("INTEREST_RATE_MODEL_ERROR");
+      await expect(quickRedeem(vToken, redeemer, redeemTokens)).to.be.reverted;
     });
 
     it("returns error from redeemFresh without emitting any extra logs", async () => {

--- a/tests/hardhat/lens/PoolLens.ts
+++ b/tests/hardhat/lens/PoolLens.ts
@@ -117,7 +117,7 @@ describe("PoolLens - PoolView Tests", async function () {
     closeFactor2 = convertToUnit(0.05, 18);
     liquidationIncentive2 = convertToUnit(1, 18);
 
-    //Registering the second pool
+    // Registering the second pool
     await poolRegistry.createRegistryPool(
       "Pool 2",
       comptrollerBeacon.address,
@@ -232,7 +232,7 @@ describe("PoolLens - PoolView Tests", async function () {
     await comptroller1Proxy.enterMarkets([vDAI.address, vWBTC.address]);
     await comptroller1Proxy.connect(owner).enterMarkets([vDAI.address, vWBTC.address]);
 
-    //Set Oracle
+    // Set Oracle
     await comptroller1Proxy.setPriceOracle(priceOracle.address);
 
     const PoolLens = await ethers.getContractFactory("PoolLens");
@@ -374,7 +374,7 @@ describe("PoolLens - VTokens Query Tests", async function () {
     closeFactor2 = convertToUnit(0.05, 18);
     liquidationIncentive2 = convertToUnit(1, 18);
 
-    //Registering the second pool
+    // Registering the second pool
     await poolRegistry.createRegistryPool(
       "Pool 2",
       comptrollerBeacon.address,

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -1,6 +1,7 @@
 import { smock } from "@defi-wonderland/smock";
+import BigNumber from "bignumber.js";
 import chai from "chai";
-import { BigNumber, Signer } from "ethers";
+import { Signer } from "ethers";
 import { ethers } from "hardhat";
 import { deployments } from "hardhat";
 
@@ -63,6 +64,13 @@ const setupTest = deployments.createFixture(async ({ deployments, getNamedAccoun
   const borrowCap = convertToUnit(10, 18);
   await Comptroller.setMarketBorrowCaps([vBNX.address, vBSW.address], [borrowCap, borrowCap]);
 
+  const vBNXPrice: BigNumber = new BigNumber((await PriceOracle.getUnderlyingPrice(vBNX.address)).toString())
+    .dividedBy(convertToUnit("1", 18))
+    .toFixed(3);
+  const vBSWPrice: BigNumber = new BigNumber((await PriceOracle.getUnderlyingPrice(vBSW.address)).toString())
+    .dividedBy(convertToUnit("1", 18))
+    .toFixed(3);
+
   return {
     fixture: {
       PoolRegistry,
@@ -81,6 +89,8 @@ const setupTest = deployments.createFixture(async ({ deployments, getNamedAccoun
       deployer,
       acc1,
       acc2,
+      vBNXPrice,
+      vBSWPrice,
     },
   };
 });
@@ -96,11 +106,13 @@ describe("Positive Cases", () => {
   let BSW: MockToken;
   let acc1: string;
   let acc2: string;
-  let PriceOracle: PriceOracle;
+  let vBNXPrice: BigNumber;
+  let vBSWPrice: BigNumber;
 
   beforeEach(async () => {
     ({ fixture } = await setupTest());
-    ({ PoolRegistry, AccessControlManager, Comptroller, vBNX, vBSW, BNX, BSW, acc1, acc2, PriceOracle } = fixture);
+    ({ PoolRegistry, AccessControlManager, Comptroller, vBNX, vBSW, BNX, BSW, acc1, acc2, vBNXPrice, vBSWPrice } =
+      fixture);
   });
   describe("Setup", () => {
     it("PoolRegistry should be initialized properly", async function () {
@@ -115,6 +127,7 @@ describe("Positive Cases", () => {
         ),
       ).to.be.revertedWith("Initializable: contract is already initialized");
     });
+
     it("PoolRegistry has the required permissions ", async function () {
       let canCall = await AccessControlManager.connect(Comptroller.address).isAllowedToCall(
         PoolRegistry.address,
@@ -135,6 +148,7 @@ describe("Positive Cases", () => {
       expect(canCall).to.be.true;
     });
   });
+
   describe("Main Operations", () => {
     const mintAmount: number = 1e6;
     const collateralFactor: number = 0.7;
@@ -152,14 +166,13 @@ describe("Positive Cases", () => {
       await BSW.connect(acc1Signer).faucet(mintAmount * 100);
       await BSW.connect(acc1Signer).approve(vBSW.address, mintAmount * 100);
     });
+
     it("Mint, Redeem, Borrow, Repay", async function () {
       let error: BigNumber;
       let liquidity: BigNumber;
       let shortfall: BigNumber;
       let balance: BigNumber;
       let borrowBalance: BigNumber;
-      const vBNXPrice = Number(await PriceOracle.getUnderlyingPrice(vBNX.address)) / 10 ** 18;
-      const vBSWPrice = Number(await PriceOracle.getUnderlyingPrice(vBSW.address)) / 10 ** 18;
       ////////////
       /// MINT ///
       ////////////
@@ -172,7 +185,7 @@ describe("Positive Cases", () => {
       expect(borrowBalance).to.equal(0);
       [error, liquidity, shortfall] = await Comptroller.connect(acc2Signer).getAccountLiquidity(acc2);
       expect(error).to.equal(Error.NO_ERROR);
-      expect(liquidity).to.equal(mintAmount * collateralFactor * vBNXPrice);
+      expect(liquidity).to.equal(new BigNumber(mintAmount * collateralFactor).multipliedBy(vBNXPrice));
       expect(shortfall).to.equal(0);
       ////////////
       // Borrow //
@@ -191,7 +204,7 @@ describe("Positive Cases", () => {
 
       [error, liquidity, shortfall] = await Comptroller.connect(acc1Signer).getAccountLiquidity(acc1);
       expect(error).to.equal(Error.NO_ERROR);
-      expect(liquidity).to.equal(mintAmount * collateralFactor * vBSWPrice);
+      expect(liquidity).to.equal(new BigNumber(mintAmount * collateralFactor).multipliedBy(vBSWPrice));
       expect(shortfall).to.equal(0);
 
       const bswBorrowAmount = 1e4;
@@ -252,14 +265,14 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
   let BSW: MockToken;
   let acc1: string;
   let acc2: string;
-  let PriceOracle: PriceOracle;
-  let vBSWPrice;
-  let vBNXPrice;
+  let vBSWPrice: BigNumber;
+  let vBNXPrice: BigNumber;
 
   beforeEach(async () => {
     ({ fixture } = await setupTest());
-    ({ Comptroller, vBNX, vBSW, BNX, BSW, acc1, acc2, PriceOracle } = fixture);
+    ({ Comptroller, vBNX, vBSW, BNX, BSW, acc1, acc2, vBNXPrice, vBSWPrice } = fixture);
   });
+
   describe("Force Liquidation of user via Comptroller", () => {
     const mintAmount = convertToUnit("1", 8);
     let acc1Signer: Signer;
@@ -295,13 +308,11 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
         .to.emit(vBSW, "Borrow")
         .withArgs(acc2, bswBorrowAmount, bswBorrowAmount, bswBorrowAmount);
 
-      vBNXPrice = Number(await PriceOracle.getUnderlyingPrice(vBNX.address)) / 10 ** 18;
-      vBSWPrice = Number(await PriceOracle.getUnderlyingPrice(vBSW.address)) / 10 ** 18;
-
       //Approve more assets for liquidation
       await BSW.connect(acc1Signer).faucet(bswBorrowAmount);
       await BSW.connect(acc1Signer).approve(vBSW.address, bswBorrowAmount);
     });
+
     it("Should revert when repay amount on liquidation is not equal to borrow amount", async function () {
       //Repay amount does not make borrower principal to zero
       const repayAmount = bswBorrowAmount / 2;
@@ -314,6 +325,7 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
         "Nonzero borrow balance after liquidation",
       );
     });
+
     it("Should success on liquidation when repayamount is equal to borrowing", async function () {
       const param = {
         vTokenCollateral: vBNX.address,
@@ -331,6 +343,7 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
       expect(liquidatorBalance).to.equal(seizeTokens.toFixed(0));
     });
   });
+
   describe("Liquidation of user via Vtoken", () => {
     let mintAmount = convertToUnit("1", 8);
     let acc1Signer: Signer;
@@ -360,20 +373,19 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
         .to.emit(vBSW, "Borrow")
         .withArgs(acc2, bswBorrowAmount, bswBorrowAmount, bswBorrowAmount);
 
-      vBNXPrice = Number(await PriceOracle.getUnderlyingPrice(vBNX.address)) / 10 ** 18;
-      vBSWPrice = Number(await PriceOracle.getUnderlyingPrice(vBSW.address)) / 10 ** 18;
-
-      //Approve more assets for liquidation
+      // Approve more assets for liquidation
       await BSW.connect(acc1Signer).faucet(convertToUnit("1", 18));
       await BSW.connect(acc1Signer).approve(vBSW.address, convertToUnit("1", 18));
     });
+
     it("Should revert when liquidation is called through vToken and does not met minCollateral Criteria", async function () {
       await expect(vBSW.connect(acc1Signer).liquidateBorrow(acc2, bswBorrowAmount, vBSW.address))
         .to.be.revertedWithCustomError(Comptroller, "MinimalCollateralViolated")
         .withArgs("100000000000000000000", "15999000000");
     });
+
     it("Should revert when liquidation is called through vToken and no shortfall", async function () {
-      //Mint and Incrrease collateral of the user
+      // Mint and Increase collateral of the user
       mintAmount = convertToUnit("1", 18);
       await BNX.connect(acc2Signer).faucet(mintAmount);
       await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
@@ -381,13 +393,14 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
         .withArgs(acc2, mintAmount, mintAmount);
-      //Liquidation
+      // Liquidation
       await expect(
         vBSW.connect(acc1Signer).liquidateBorrow(acc2, bswBorrowAmount, vBSW.address),
       ).to.be.revertedWithCustomError(Comptroller, "InsufficientShortfall");
     });
+
     it("Should revert when liquidation is called through vToken and trying to seize more tokens", async function () {
-      //Mint and Incrrease collateral of the user
+      // Mint and Incrrease collateral of the user
       mintAmount = convertToUnit("1", 18);
       await BNX.connect(acc2Signer).faucet(mintAmount);
       await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
@@ -395,20 +408,21 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
         .withArgs(acc2, mintAmount, mintAmount);
-      //price manipulation and borrow to overcome insufficient shortfall
+      // price manipulation and borrow to overcome insufficient shortfall
       bswBorrowAmount = convertToUnit("1", 18);
       await vBSW.connect(acc2Signer).borrow(bswBorrowAmount);
       const dummyPriceOracle = await smock.fake<PriceOracle>("PriceOracle");
       dummyPriceOracle.getUnderlyingPrice.whenCalledWith(vBSW.address).returns(convertToUnit("100", 40));
       dummyPriceOracle.getUnderlyingPrice.whenCalledWith(vBNX.address).returns(convertToUnit("100", 18));
       await Comptroller.setPriceOracle(dummyPriceOracle.address);
-      //Liquidation
+      // Liquidation
       await expect(vBSW.connect(acc1Signer).liquidateBorrow(acc2, 201, vBNX.address)).to.be.revertedWith(
         "LIQUIDATE_SEIZE_TOO_MUCH",
       );
     });
-    it("Should revert when liquidation is called through vToken and trying to pay tooMuch", async function () {
-      //Mint and Incrrease collateral of the user
+
+    it("Should revert when liquidation is called through vToken and trying to pay too much", async function () {
+      // Mint and Incrrease collateral of the user
       mintAmount = convertToUnit("1", 18);
       await BNX.connect(acc2Signer).faucet(mintAmount);
       await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
@@ -416,20 +430,21 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
         .withArgs(acc2, mintAmount, mintAmount);
-      //price manipulation and borrow to overcome insufficient shortfall
+      // price manipulation and borrow to overcome insufficient shortfall
       bswBorrowAmount = convertToUnit("1", 18);
       await vBSW.connect(acc2Signer).borrow(bswBorrowAmount);
       const dummyPriceOracle = await smock.fake<PriceOracle>("PriceOracle");
       dummyPriceOracle.getUnderlyingPrice.whenCalledWith(vBSW.address).returns(convertToUnit("1", 20));
       dummyPriceOracle.getUnderlyingPrice.whenCalledWith(vBNX.address).returns(convertToUnit("100", 18));
       await Comptroller.setPriceOracle(dummyPriceOracle.address);
-      //Liquidation
+      // Liquidation
       await expect(
         vBSW.connect(acc1Signer).liquidateBorrow(acc2, convertToUnit("1", 18), vBNX.address),
       ).to.be.revertedWithCustomError(Comptroller, "TooMuchRepay");
     });
+
     it("Should success when liquidation is called through vToken", async function () {
-      //Mint and Incrrease collateral of the user
+      // Mint and Incrrease collateral of the user
       mintAmount = convertToUnit("1", 18);
       await BNX.connect(acc2Signer).faucet(mintAmount);
       await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
@@ -438,7 +453,7 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
         .to.emit(vBNX, "Mint")
         .withArgs(acc2, mintAmount, mintAmount);
 
-      //price manipulation and borrow to overcome insufficient shortfall
+      // price manipulation and borrow to overcome insufficient shortfall
       bswBorrowAmount = convertToUnit("1", 18);
       await vBSW.connect(acc2Signer).borrow(bswBorrowAmount);
       const dummyPriceOracle = await smock.fake<PriceOracle>("PriceOracle");
@@ -446,7 +461,7 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
       dummyPriceOracle.getUnderlyingPrice.whenCalledWith(vBNX.address).returns(convertToUnit("100", 18));
       await Comptroller.setPriceOracle(dummyPriceOracle.address);
       const repayAmount = convertToUnit("1", 9);
-      //Liquidation
+      // Liquidation
       await expect(vBSW.connect(acc1Signer).liquidateBorrow(acc2, repayAmount, vBNX.address))
         .to.emit(vBSW, "LiquidateBorrow")
         .withArgs(acc1, acc2, repayAmount, vBNX.address, repayAmount);
@@ -457,6 +472,7 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
       expect(liquidatorBalance).to.equal((repayAmount - protocolShareTokens).toString());
     });
   });
+
   describe("Heal Borrow and Forgive account", () => {
     const mintAmount = convertToUnit("1", 8);
     let acc1Signer: Signer;
@@ -478,42 +494,42 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
         .withArgs(acc2, mintAmount, mintAmount);
-      //borrow
-      //Supply WBTC to market from 2nd account
+      // borrow
+      // Supply WBTC to market from 2nd account
       await expect(vBSW.connect(acc1Signer).mint(mintAmount))
         .to.emit(vBSW, "Mint")
         .withArgs(acc1, mintAmount, mintAmount);
-      //It should revert when try to borrow more than liquidity
+      // It should revert when try to borrow more than liquidity
       await expect(vBSW.connect(acc2Signer).borrow(bswBorrowAmount))
         .to.emit(vBSW, "Borrow")
         .withArgs(acc2, bswBorrowAmount, bswBorrowAmount, bswBorrowAmount);
 
-      vBNXPrice = Number(await PriceOracle.getUnderlyingPrice(vBNX.address)) / 10 ** 18;
-      vBSWPrice = Number(await PriceOracle.getUnderlyingPrice(vBSW.address)) / 10 ** 18;
-
-      //Approve more assets for liquidation
+      // Approve more assets for liquidation
       await BSW.connect(acc1Signer).faucet(bswBorrowAmount);
       await BSW.connect(acc1Signer).approve(vBSW.address, bswBorrowAmount);
     });
+
     it("Should revert when total collateral is greater then minLiquidation threshold", async function () {
-      //Increase mint to make collateral large then min threshold liquidation
+      // Increase mint to make collateral large then min threshold liquidation
       await BNX.connect(acc2Signer).faucet(convertToUnit("1", 18));
       await BNX.connect(acc2Signer).approve(vBNX.address, convertToUnit("1", 18));
       await expect(vBNX.connect(acc2Signer).mint(convertToUnit("1", 18)))
         .to.emit(vBNX, "Mint")
         .withArgs(acc2, convertToUnit("1", 18), convertToUnit("1", 18));
-      //heal
+      // heal
       await expect(Comptroller.connect(acc1Signer).healAccount(acc2))
         .to.be.revertedWithCustomError(Comptroller, "CollateralExceedsThreshold")
         .withArgs("100000000000000000000", "159990000015999000000");
     });
+
     it("Should revert on healing if borrow is less then collateral amount", async function () {
       await expect(Comptroller.connect(acc1Signer).healAccount(acc2))
         .to.be.revertedWithCustomError(Comptroller, "CollateralExceedsThreshold")
         .withArgs(bswBorrowAmount * vBSWPrice, vBNXPrice * mintAmount);
     });
+
     it("Should success on healing and forgive borrow account", async function () {
-      //Increase price of borrowed underlying tokens to surpass available collateral
+      // Increase price of borrowed underlying tokens to surpass available collateral
       const dummyPriceOracle = await smock.fake<PriceOracle>("PriceOracle");
       dummyPriceOracle.getUnderlyingPrice.whenCalledWith(vBSW.address).returns(convertToUnit("1", 20));
       dummyPriceOracle.getUnderlyingPrice.whenCalledWith(vBNX.address).returns(convertToUnit("1", 15));
@@ -538,7 +554,7 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
         .to.emit(vBSW, "BadDebtIncreased")
         .withArgs(acc2, bswBorrowAmount - repayAmount, 0, badDebt);
 
-      //Forgive Account
+      // Forgive Account
       result = await vBSW.connect(acc2Signer).getAccountSnapshot(acc2);
       expect(result.error).to.equal(Error.NO_ERROR);
       expect(result.vTokenBalance).to.equal(0);


### PR DESCRIPTION
It includes :

**Liquidation scenario on straight path:** (VEN-884)
- via Comptroller
- via vToken

**Heal Account Scenario:** (VEN-885)
- Revert scenarios
- Success Scenarios

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
