### PR TITLE
remove shortfall parameter from RiskFund initializer

### DIFF
--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -58,14 +58,12 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
      * @param _minAmountToConvert Asset should be worth of min amount to convert into base asset
      * @param _convertibleBaseAsset Address of the base asset
      * @param _accessControl Address of the access control contract.
-     * @param _shortfall Address of the shortfall contract.
      */
     function initialize(
         address _pancakeSwapRouter,
         uint256 _minAmountToConvert,
         address _convertibleBaseAsset,
-        address _accessControl,
-        address _shortfall
+        address _accessControl
     ) external initializer {
         require(_pancakeSwapRouter != address(0), "Risk Fund: Pancake swap address invalid");
         require(_convertibleBaseAsset != address(0), "Risk Fund: Base asset address invalid");
@@ -77,7 +75,6 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
         minAmountToConvert = _minAmountToConvert;
         convertibleBaseAsset = _convertibleBaseAsset;
         accessControl = _accessControl;
-        shortfall = _shortfall;
     }
 
     /**

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -145,8 +145,9 @@ const riskFundFixture = async (): Promise<void> => {
     convertToUnit(10, 18),
     BUSD.address,
     accessControlManager.address,
-    shortfall.address,
   ]);
+
+  await riskFund.setShortfallContractAddress(shortfall.address);
 
   const fakeProtocolIncome = await smock.fake<RiskFund>("RiskFund");
   const ProtocolShareReserve = await ethers.getContractFactory("ProtocolShareReserve");

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -132,8 +132,9 @@ const riskFundFixture = async (): Promise<void> => {
     parseUnits("10", 18),
     BUSD.address,
     fakeAccessControlManager.address,
-    shortfall.address,
   ]);
+
+  await riskFund.setShortfallContractAddress(shortfall.address);
 
   const fakeProtocolIncome = await smock.fake<RiskFund>("RiskFund");
   const ProtocolShareReserve = await ethers.getContractFactory("ProtocolShareReserve");


### PR DESCRIPTION
## Description
This PR remove `shortfall` parameter from `RiskFund` contract  `initializer` function. With that we cut a circular dependency between `RiskFund` and `Shortfall` contracts.

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
