### PR TITLE
feat: Mint and Redeem events emit the updated account balance

### DIFF
--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -552,7 +552,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         accountTokens[minter] = accountTokens[minter] + mintTokens;
 
         /* We emit a Mint event, and a Transfer event */
-        emit Mint(minter, actualMintAmount, mintTokens);
+        emit Mint(minter, actualMintAmount, mintTokens, accountTokens[minter]);
         emit Transfer(address(0), minter, mintTokens);
     }
 
@@ -662,7 +662,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
 
         /* We emit a Transfer event, and a Redeem event */
         emit Transfer(redeemer, address(this), redeemTokens);
-        emit Redeem(redeemer, redeemAmount, redeemTokens);
+        emit Redeem(redeemer, redeemAmount, redeemTokens, accountTokens[redeemer]);
     }
 
     /**

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -549,10 +549,11 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
          * And write them into storage
          */
         totalSupply = totalSupply + mintTokens;
-        accountTokens[minter] = accountTokens[minter] + mintTokens;
+        uint256 balanceAfter = accountTokens[minter] + mintTokens;
+        accountTokens[minter] = balanceAfter;
 
         /* We emit a Mint event, and a Transfer event */
-        emit Mint(minter, actualMintAmount, mintTokens, accountTokens[minter]);
+        emit Mint(minter, actualMintAmount, mintTokens, balanceAfter);
         emit Transfer(address(0), minter, mintTokens);
     }
 
@@ -650,7 +651,8 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
          *  Note: Avoid token reentrancy attacks by writing reduced supply before external transfer.
          */
         totalSupply = totalSupply - redeemTokens;
-        accountTokens[redeemer] = accountTokens[redeemer] - redeemTokens;
+        uint256 balanceAfter = accountTokens[redeemer] - redeemTokens;
+        accountTokens[redeemer] = balanceAfter;
 
         /*
          * We invoke _doTransferOut for the redeemer and the redeemAmount.
@@ -662,7 +664,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
 
         /* We emit a Transfer event, and a Redeem event */
         emit Transfer(redeemer, address(this), redeemTokens);
-        emit Redeem(redeemer, redeemAmount, redeemTokens, accountTokens[redeemer]);
+        emit Redeem(redeemer, redeemAmount, redeemTokens, balanceAfter);
     }
 
     /**

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -155,12 +155,12 @@ abstract contract VTokenInterface is VTokenStorage {
     /**
      * @notice Event emitted when tokens are minted
      */
-    event Mint(address minter, uint256 mintAmount, uint256 mintTokens);
+    event Mint(address minter, uint256 mintAmount, uint256 mintTokens, uint256 accountBalance);
 
     /**
      * @notice Event emitted when tokens are redeemed
      */
-    event Redeem(address redeemer, uint256 redeemAmount, uint256 redeemTokens);
+    event Redeem(address redeemer, uint256 redeemAmount, uint256 redeemTokens, uint256 accountBalance);
 
     /**
      * @notice Event emitted when underlying is borrowed

--- a/contracts/test/Mocks/MockPancakeSwap.sol
+++ b/contracts/test/Mocks/MockPancakeSwap.sol
@@ -357,7 +357,7 @@ interface IPancakePair {
         bytes32 s
     ) external;
 
-    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1, uint256 amount2);
     event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
     event Swap(
         address indexed sender,

--- a/tests/hardhat/Tokens/mintAndRedeemTest.ts
+++ b/tests/hardhat/Tokens/mintAndRedeemTest.ts
@@ -228,14 +228,14 @@ describe("VToken", function () {
       const beforeBalances = await getBalances([vToken], [minterAddress]);
       const result = await mintFresh(vToken, minter, mintAmount);
       const afterBalances = await getBalances([vToken], [minterAddress]);
-
-      expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
+    
+      await expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
         .to.emit(vToken, "Mint")
-        .withArgs(minterAddress, mintAmount, mintTokens, mintAmount);
+        .withArgs(minterAddress, mintAmount, mintTokens, mintTokens);
 
-      expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
+      await expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
         .to.emit(vToken, "Transfer")
-        .withArgs(vToken.address, minterAddress, mintTokens);
+        .withArgs(ethers.constants.AddressZero, minterAddress, mintTokens);
 
       expect(afterBalances).to.deep.equal(
         adjustBalances(beforeBalances, [
@@ -271,7 +271,7 @@ describe("VToken", function () {
     });
 
     it("emits an AccrueInterest event", async () => {
-      expect(await quickMint(underlying, vToken, minter, mintAmount)) // eslint-disable-line @typescript-eslint/no-floating-promises
+      await expect(await quickMint(underlying, vToken, minter, mintAmount)) // eslint-disable-line @typescript-eslint/no-floating-promises
         .to.emit(vToken, "AccrueInterest")
         .withArgs("1000000000000000000", "0", "0", "0");
     });
@@ -351,11 +351,11 @@ describe("VToken", function () {
         const result = await redeemFresh(vToken, redeemer, redeemTokens, redeemAmount);
         const afterBalances = await getBalances([vToken], [redeemerAddress]);
 
-        expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
+        await expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
           .to.emit(vToken, "Redeem")
-          .withArgs(redeemAmount, redeemTokens);
+          .withArgs(redeemer.address, redeemAmount, redeemTokens, 0);
 
-        expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
+        await expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
           .to.emit(vToken, "Transfer")
           .withArgs(redeemerAddress, vToken.address, redeemTokens);
 
@@ -404,7 +404,7 @@ describe("VToken", function () {
     });
 
     it("emits an AccrueInterest event", async () => {
-      expect(await quickMint(underlying, vToken, minter, mintAmount)) // eslint-disable-line @typescript-eslint/no-floating-promises
+      await expect(await quickMint(underlying, vToken, minter, mintAmount)) // eslint-disable-line @typescript-eslint/no-floating-promises
         .to.emit(vToken, "AccrueInterest")
         .withArgs("1000000000000000000", "500000000", "0", "0");
     });

--- a/tests/hardhat/Tokens/mintAndRedeemTest.ts
+++ b/tests/hardhat/Tokens/mintAndRedeemTest.ts
@@ -229,11 +229,11 @@ describe("VToken", function () {
       const result = await mintFresh(vToken, minter, mintAmount);
       const afterBalances = await getBalances([vToken], [minterAddress]);
     
-      await expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
+      await expect(result)
         .to.emit(vToken, "Mint")
         .withArgs(minterAddress, mintAmount, mintTokens, mintTokens);
 
-      await expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
+      await expect(result)
         .to.emit(vToken, "Transfer")
         .withArgs(ethers.constants.AddressZero, minterAddress, mintTokens);
 
@@ -271,9 +271,13 @@ describe("VToken", function () {
     });
 
     it("emits an AccrueInterest event", async () => {
-      await expect(await quickMint(underlying, vToken, minter, mintAmount)) // eslint-disable-line @typescript-eslint/no-floating-promises
+      await expect(await quickMint(underlying, vToken, minter, mintAmount))
         .to.emit(vToken, "AccrueInterest")
-        .withArgs("1000000000000000000", "0", "0", "0");
+        .withArgs("0", "0", "1000000000000000000", "0");
+
+      await expect(await quickMint(underlying, vToken, minter, mintAmount))
+        .to.emit(vToken, "AccrueInterest")
+        .withArgs("10000000000000000000000", "0", "1000000000000000000", "0");
     });
   });
 
@@ -351,11 +355,11 @@ describe("VToken", function () {
         const result = await redeemFresh(vToken, redeemer, redeemTokens, redeemAmount);
         const afterBalances = await getBalances([vToken], [redeemerAddress]);
 
-        await expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
+        await expect(result)
           .to.emit(vToken, "Redeem")
           .withArgs(redeemer.address, redeemAmount, redeemTokens, 0);
 
-        await expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
+        await expect(result)
           .to.emit(vToken, "Transfer")
           .withArgs(redeemerAddress, vToken.address, redeemTokens);
 
@@ -404,9 +408,9 @@ describe("VToken", function () {
     });
 
     it("emits an AccrueInterest event", async () => {
-      await expect(await quickMint(underlying, vToken, minter, mintAmount)) // eslint-disable-line @typescript-eslint/no-floating-promises
+      await expect(await quickRedeem(vToken, redeemer, redeemTokens, { exchangeRate }))
         .to.emit(vToken, "AccrueInterest")
-        .withArgs("1000000000000000000", "500000000", "0", "0");
+        .withArgs("50000000000000000000000000", "0", "1000000000000000000", "0");
     });
   });
 });

--- a/tests/hardhat/Tokens/mintAndRedeemTest.ts
+++ b/tests/hardhat/Tokens/mintAndRedeemTest.ts
@@ -228,10 +228,8 @@ describe("VToken", function () {
       const beforeBalances = await getBalances([vToken], [minterAddress]);
       const result = await mintFresh(vToken, minter, mintAmount);
       const afterBalances = await getBalances([vToken], [minterAddress]);
-    
-      await expect(result)
-        .to.emit(vToken, "Mint")
-        .withArgs(minterAddress, mintAmount, mintTokens, mintTokens);
+
+      await expect(result).to.emit(vToken, "Mint").withArgs(minterAddress, mintAmount, mintTokens, mintTokens);
 
       await expect(result)
         .to.emit(vToken, "Transfer")
@@ -355,13 +353,9 @@ describe("VToken", function () {
         const result = await redeemFresh(vToken, redeemer, redeemTokens, redeemAmount);
         const afterBalances = await getBalances([vToken], [redeemerAddress]);
 
-        await expect(result)
-          .to.emit(vToken, "Redeem")
-          .withArgs(redeemer.address, redeemAmount, redeemTokens, 0);
+        await expect(result).to.emit(vToken, "Redeem").withArgs(redeemer.address, redeemAmount, redeemTokens, 0);
 
-        await expect(result)
-          .to.emit(vToken, "Transfer")
-          .withArgs(redeemerAddress, vToken.address, redeemTokens);
+        await expect(result).to.emit(vToken, "Transfer").withArgs(redeemerAddress, vToken.address, redeemTokens);
 
         expect(afterBalances).to.deep.equal(
           adjustBalances(beforeBalances, [

--- a/tests/hardhat/Tokens/mintAndRedeemTest.ts
+++ b/tests/hardhat/Tokens/mintAndRedeemTest.ts
@@ -231,7 +231,7 @@ describe("VToken", function () {
 
       expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
         .to.emit(vToken, "Mint")
-        .withArgs(minterAddress, mintAmount, mintTokens);
+        .withArgs(minterAddress, mintAmount, mintTokens, mintAmount);
 
       expect(result) // eslint-disable-line @typescript-eslint/no-floating-promises
         .to.emit(vToken, "Transfer")

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -178,7 +178,7 @@ describe("Positive Cases", () => {
       // //////////
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, mintAmount, mintAmount);
+        .withArgs(acc2, mintAmount, mintAmount, mintAmount);
       [error, balance, borrowBalance] = await vBNX.connect(acc2Signer).getAccountSnapshot(acc2);
       expect(error).to.equal(Error.NO_ERROR);
       expect(balance).to.equal(mintAmount);
@@ -193,7 +193,7 @@ describe("Positive Cases", () => {
       // Supply WBTC to market from 2nd account
       await expect(vBSW.connect(acc1Signer).mint(mintAmount))
         .to.emit(vBSW, "Mint")
-        .withArgs(await acc1Signer.getAddress(), mintAmount, mintAmount);
+        .withArgs(await acc1Signer.getAddress(), mintAmount, mintAmount, mintAmount);
 
       [error, balance, borrowBalance] = await vBSW
         .connect(acc2Signer)
@@ -223,7 +223,7 @@ describe("Positive Cases", () => {
       const redeemAmount = 10e3;
       await expect(vBNX.connect(acc2Signer).redeem(redeemAmount))
         .to.emit(vBNX, "Redeem")
-        .withArgs(acc2, redeemAmount, redeemAmount);
+        .withArgs(acc2, redeemAmount, redeemAmount, mintAmount - redeemAmount);
 
       [error, balance, borrowBalance] = await vBNX.connect(acc2Signer).getAccountSnapshot(acc2);
       expect(error).to.equal(Error.NO_ERROR);
@@ -293,12 +293,12 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
 
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, mintAmount, mintAmount);
+        .withArgs(acc2, mintAmount, mintAmount, mintAmount);
       // borrow
       // Supply WBTC to market from 2nd account
       await expect(vBSW.connect(acc1Signer).mint(mintAmount))
         .to.emit(vBSW, "Mint")
-        .withArgs(acc1, mintAmount, mintAmount);
+        .withArgs(acc1, mintAmount, mintAmount, mintAmount);
       // It should revert when try to borrow more than liquidity
       await expect(vBSW.connect(acc2Signer).borrow(8e10)).to.be.revertedWithCustomError(
         Comptroller,
@@ -363,12 +363,12 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
 
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, mintAmount, mintAmount);
+        .withArgs(acc2, mintAmount, mintAmount, mintAmount);
       // borrow
       // Supply WBTC to market from 2nd account
       await expect(vBSW.connect(acc1Signer).mint(mintAmount))
         .to.emit(vBSW, "Mint")
-        .withArgs(acc1, mintAmount, mintAmount);
+        .withArgs(acc1, mintAmount, mintAmount, mintAmount);
       await expect(vBSW.connect(acc2Signer).borrow(bswBorrowAmount))
         .to.emit(vBSW, "Borrow")
         .withArgs(acc2, bswBorrowAmount, bswBorrowAmount, bswBorrowAmount);
@@ -387,12 +387,13 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
     it("Should revert when liquidation is called through vToken and no shortfall", async function () {
       // Mint and Increase collateral of the user
       mintAmount = convertToUnit("1", 18);
+      const expectedTotalBalance = convertToUnit("1.0000000001", 18);
       await BNX.connect(acc2Signer).faucet(mintAmount);
       await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
 
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, mintAmount, mintAmount);
+        .withArgs(acc2, mintAmount, mintAmount, expectedTotalBalance);
       // Liquidation
       await expect(
         vBSW.connect(acc1Signer).liquidateBorrow(acc2, bswBorrowAmount, vBSW.address),
@@ -402,12 +403,13 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
     it("Should revert when liquidation is called through vToken and trying to seize more tokens", async function () {
       // Mint and Incrrease collateral of the user
       mintAmount = convertToUnit("1", 18);
+      const expectedTotalBalance = convertToUnit("2", 18);
       await BNX.connect(acc2Signer).faucet(mintAmount);
       await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
 
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, mintAmount, mintAmount);
+        .withArgs(acc2, mintAmount, mintAmount, expectedTotalBalance);
       // price manipulation and borrow to overcome insufficient shortfall
       bswBorrowAmount = convertToUnit("1", 18);
       await vBSW.connect(acc2Signer).borrow(bswBorrowAmount);
@@ -424,12 +426,13 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
     it("Should revert when liquidation is called through vToken and trying to pay too much", async function () {
       // Mint and Incrrease collateral of the user
       mintAmount = convertToUnit("1", 18);
+      const expectedTotalBalance = convertToUnit("2", 18);
       await BNX.connect(acc2Signer).faucet(mintAmount);
       await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
 
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, mintAmount, mintAmount);
+        .withArgs(acc2, mintAmount, mintAmount, expectedTotalBalance);
       // price manipulation and borrow to overcome insufficient shortfall
       bswBorrowAmount = convertToUnit("1", 18);
       await vBSW.connect(acc2Signer).borrow(bswBorrowAmount);
@@ -446,12 +449,13 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
     it("Should success when liquidation is called through vToken", async function () {
       // Mint and Incrrease collateral of the user
       mintAmount = convertToUnit("1", 18);
+      const expectedTotalBalance = convertToUnit("2", 18);
       await BNX.connect(acc2Signer).faucet(mintAmount);
       await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
 
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, mintAmount, mintAmount);
+        .withArgs(acc2, mintAmount, mintAmount, expectedTotalBalance);
 
       // price manipulation and borrow to overcome insufficient shortfall
       bswBorrowAmount = convertToUnit("1", 18);
@@ -493,12 +497,12 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
 
       await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, mintAmount, mintAmount);
+        .withArgs(acc2, mintAmount, mintAmount, mintAmount);
       // borrow
       // Supply WBTC to market from 2nd account
       await expect(vBSW.connect(acc1Signer).mint(mintAmount))
         .to.emit(vBSW, "Mint")
-        .withArgs(acc1, mintAmount, mintAmount);
+        .withArgs(acc1, mintAmount, mintAmount, mintAmount);
       // It should revert when try to borrow more than liquidity
       await expect(vBSW.connect(acc2Signer).borrow(bswBorrowAmount))
         .to.emit(vBSW, "Borrow")
@@ -511,11 +515,13 @@ describe("Straight Cases For Single User Liquidation and healing", () => {
 
     it("Should revert when total collateral is greater then minLiquidation threshold", async function () {
       // Increase mint to make collateral large then min threshold liquidation
-      await BNX.connect(acc2Signer).faucet(convertToUnit("1", 18));
-      await BNX.connect(acc2Signer).approve(vBNX.address, convertToUnit("1", 18));
-      await expect(vBNX.connect(acc2Signer).mint(convertToUnit("1", 18)))
+      const mintAmount = convertToUnit("1", 18);
+      const expectedTotalBalance = convertToUnit("1.0000000001", 18);
+      await BNX.connect(acc2Signer).faucet(mintAmount);
+      await BNX.connect(acc2Signer).approve(vBNX.address, mintAmount);
+      await expect(vBNX.connect(acc2Signer).mint(mintAmount))
         .to.emit(vBNX, "Mint")
-        .withArgs(acc2, convertToUnit("1", 18), convertToUnit("1", 18));
+        .withArgs(acc2, mintAmount, mintAmount, expectedTotalBalance);
       // heal
       await expect(Comptroller.connect(acc1Signer).healAccount(acc2))
         .to.be.revertedWithCustomError(Comptroller, "CollateralExceedsThreshold")


### PR DESCRIPTION
## Description

This PR aims to make the Mint and Redeem VToken events also return the updated value for the account balance. This can make the subgraph save calling the `balanceOf` function everytime it indexes these events.

