### PR TITLE
feat: add event for new rewards distributor

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -101,6 +101,9 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
     /// @notice Emitted when supply cap for a vToken is changed
     event NewSupplyCap(VToken indexed vToken, uint256 newSupplyCap);
 
+    /// @notice Emitted when a rewards distributor is added
+    event NewRewardsDistributor(address indexed rewardsDistributor);
+
     /// @notice Thrown when collateral factor exceeds the upper bound
     error InvalidCollateralFactor();
 
@@ -923,6 +926,7 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
      * @dev Only callable by the admin
      * @param _rewardsDistributor Address of the RewardDistributor contract to add
      * @custom:access Only Governance
+     * @custom:event Emits NewRewardsDistributor with distributor address
      */
     function addRewardsDistributor(RewardsDistributor _rewardsDistributor) external onlyOwner {
         require(rewardsDistributorExists[address(_rewardsDistributor)] == false, "already exists");
@@ -943,6 +947,8 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
         for (uint256 i; i < marketsCount; ++i) {
             _rewardsDistributor.initializeMarket(address(allMarkets[i]));
         }
+
+        emit NewRewardsDistributor(address(_rewardsDistributor));
     }
 
     /*** Assets You Are In ***/

--- a/tests/hardhat/Comptroller/setters.ts
+++ b/tests/hardhat/Comptroller/setters.ts
@@ -88,7 +88,7 @@ describe("setters", async () => {
     });
 
     it("reverts if called by a non-owner", async () => {
-      await expect(comptroller.connect(user).setPriceOracle(newRewardsDistributor.address)).to.be.revertedWith(
+      await expect(comptroller.connect(user).addRewardsDistributor(newRewardsDistributor.address)).to.be.revertedWith(
         "Ownable: caller is not the owner",
       );
     });

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -39,6 +39,7 @@ let fakePriceOracle: FakeContract<PriceOracle>;
 let fakeAccessControlManager: FakeContract<AccessControlManager>;
 
 describe("Rewards: Tests", async function () {
+  const RewardsDistributor = await ethers.getContractFactory("RewardsDistributor");
   /**
    * Deploying required contracts along with the poolRegistry.
    */
@@ -275,7 +276,6 @@ describe("Rewards: Tests", async function () {
   });
 
   it("Cannot add reward distributors with duplicate reward tokens", async function () {
-    const RewardsDistributor = await ethers.getContractFactory("RewardsDistributor");
     rewardsDistributor = await RewardsDistributor.deploy();
 
     const rewardsDistributorDuplicate = await RewardsDistributor.deploy();
@@ -284,6 +284,15 @@ describe("Rewards: Tests", async function () {
     await await expect(comptrollerProxy.addRewardsDistributor(rewardsDistributorDuplicate.address)).to.be.revertedWith(
       "distributor already exists with this reward",
     );
+  });
+
+  it("Emits event correctly", async () => {
+    rewardsDistributor = await RewardsDistributor.deploy();
+    await rewardsDistributor.initialize(comptrollerProxy.address, mockWBTC.address);
+
+    await expect(comptrollerProxy.addRewardsDistributor(rewardsDistributor.address))
+      .to.emit(comptrollerProxy, "NewRewardsDistributor")
+      .withArgs(rewardsDistributor.address);
   });
 
   // TODO: Test reward accruals. This test used to pass before, but it


### PR DESCRIPTION
## Description

This event is required to listen to Reward Distributor events such as `DistributedSupplierRewardToken`  and `DistributedBorrowerRewardToken`