### PR TITLE
[VEN-893] Update doc template with custom tags

### DIFF
--- a/.eslint-tsconfig
+++ b/.eslint-tsconfig
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["jest.config.js", ".eslintrc.js", "tests", "scenario", "deploy"]
+  "include": ["jest.config.js", ".eslintrc.js", "tests", "scenario", "deploy", "docgen-templates"]
 }

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -175,7 +175,7 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
      * @notice Add assets to be included in account liquidity calculation; enabling them to be used as collateral
      * @param vTokens The list of addresses of the vToken markets to be enabled
      * @return errors An array of NO_ERROR for compatibility with Venus core tooling
-     * @custom:events MarketEntered is emitted for each market on success
+     * @custom:event MarketEntered is emitted for each market on success
      * @custom:error ActionPaused error is thrown if entering any of the markets is paused
      * @custom:error MarketNotListed error is thrown if any of the markets is not listed
      * @custom:access Not restricted
@@ -200,7 +200,7 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
      *  or be providing necessary collateral for an outstanding borrow.
      * @param vTokenAddress The address of the asset to be removed
      * @return error Always NO_ERROR for compatibility with Venus core tooling
-     * @custom:events MarketExited is emitted on success
+     * @custom:event MarketExited is emitted on success
      * @custom:error ActionPaused error is thrown if exiting the market is paused
      * @custom:error NonzeroBorrowBalance error is thrown if the user has an outstanding borrow in this market
      * @custom:error MarketNotListed error is thrown when the market is not listed
@@ -722,7 +722,7 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
     /**
      * @notice Sets the closeFactor to use when liquidating borrows
      * @param newCloseFactorMantissa New close factor, scaled by 1e18
-     * @custom:events Emits NewCloseFactor on success
+     * @custom:event Emits NewCloseFactor on success
      * @custom:access Only Governance
      */
     function setCloseFactor(uint256 newCloseFactorMantissa) external onlyOwner {
@@ -737,7 +737,7 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
      * @param vToken The market to set the factor on
      * @param newCollateralFactorMantissa The new collateral factor, scaled by 1e18
      * @param newLiquidationThresholdMantissa The new liquidation threshold, scaled by 1e18
-     * @custom:events Emits NewCollateralFactor when collateral factor is updated
+     * @custom:event Emits NewCollateralFactor when collateral factor is updated
      *    and NewLiquidationThreshold when liquidation threshold is updated
      * @custom:error MarketNotListed error is thrown when the market is not listed
      * @custom:error InvalidCollateralFactor error is thrown when collateral factor is too high
@@ -790,7 +790,7 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
      * @notice Sets liquidationIncentive
      * @dev This function is restricted by the AccessControlManager
      * @param newLiquidationIncentiveMantissa New liquidationIncentive scaled by 1e18
-     * @custom:events Emits NewLiquidationIncentive on success
+     * @custom:event Emits NewLiquidationIncentive on success
      * @custom:access Controlled by AccessControlManager
      */
     function setLiquidationIncentive(uint256 newLiquidationIncentiveMantissa) external {
@@ -1033,7 +1033,7 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
      * @notice Sets a new PriceOracle for the Comptroller
      * @dev Only callable by the admin
      * @param newOracle Address of the new PriceOracle to set
-     * @custom:events Emits NewPriceOracle on success
+     * @custom:event Emits NewPriceOracle on success
      */
     function setPriceOracle(PriceOracle newOracle) public onlyOwner {
         PriceOracle oldOracle = oracle;

--- a/contracts/Governance/AccessControlManager.sol
+++ b/contracts/Governance/AccessControlManager.sol
@@ -68,7 +68,7 @@ contract AccessControlManager is AccessControl {
      *      on **any** contract managed by this ACL
      * @param functionSig signature e.g. "functionName(uint256,bool)"
      * @param accountToPermit account that will be given access to the contract function
-     * @custom:events Emits a {RoleGranted} and {PermissionGranted} events.
+     * @custom:event Emits a {RoleGranted} and {PermissionGranted} events.
      */
     function giveCallPermission(
         address contractAddress,
@@ -86,7 +86,7 @@ contract AccessControlManager is AccessControl {
      * 		May emit a {RoleRevoked} event.
      * @param contractAddress address of contract for which call permissions will be revoked
      * @param functionSig signature e.g. "functionName(uint256,bool)"
-     * @custom:events Emits {RoleRevoked} and {PermissionRevoked} events.
+     * @custom:event Emits {RoleRevoked} and {PermissionRevoked} events.
      */
     function revokeCallPermission(
         address contractAddress,

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -141,7 +141,7 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
      * @notice Place a bid greater than the previous in an ongoing auction
      * @param comptroller Comptroller address of the pool
      * @param bidBps The bid percent of the risk fund or bad debt depending on auction type
-     * @custom:events Emits BidPlaced event on success
+     * @custom:event Emits BidPlaced event on success
      */
     function placeBid(address comptroller, uint256 bidBps) external nonReentrant {
         Auction storage auction = auctions[comptroller];
@@ -191,7 +191,7 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /**
      * @notice Close an auction
      * @param comptroller Comptroller address of the pool
-     * @custom:events Emits AuctionClosed event on successful close
+     * @custom:event Emits AuctionClosed event on successful close
      */
     function closeAuction(address comptroller) external nonReentrant {
         Auction storage auction = auctions[comptroller];
@@ -247,7 +247,7 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /**
      * @notice Restart an auction
      * @param comptroller Address of the pool
-     * @custom:events Emits AuctionRestarted event on successful restart
+     * @custom:event Emits AuctionRestarted event on successful restart
      */
     function restartAuction(address comptroller) external {
         Auction storage auction = auctions[comptroller];
@@ -267,7 +267,7 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /**
      * @notice Update minimum pool bad debt to start auction
      * @param _minimumPoolBadDebt Minimum bad debt in BUSD for a pool to start auction
-     * @custom:events Emits MinimumPoolBadDebtUpdated on success
+     * @custom:event Emits MinimumPoolBadDebtUpdated on success
      * @custom:access Restricted to owner
      */
     function updateMinimumPoolBadDebt(uint256 _minimumPoolBadDebt) public onlyOwner {
@@ -280,7 +280,7 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
      * @notice Sets the pool registry this shortfall supports
      * @dev After Pool Registry is deployed we need to set the pool registry address
      * @param _poolRegistry Address of pool registry contract
-     * @custom:events Emits PoolRegistryUpdated on success
+     * @custom:event Emits PoolRegistryUpdated on success
      * @custom:access Restricted to owner
      */
     function setPoolRegistry(address _poolRegistry) public onlyOwner {
@@ -293,7 +293,7 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /**
      * @notice Start a auction when there is not currently one active
      * @param comptroller Comptroller address of the pool
-     * @custom:events Emits AuctionStarted event on success
+     * @custom:event Emits AuctionStarted event on success
      * @custom:access Restricted to owner
      */
     function startAuction(address comptroller) public onlyOwner {

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -177,7 +177,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param dst The address of the destination account
      * @param amount The number of tokens to transfer
      * @return success True if the transfer suceeded, reverts otherwise
-     * @custom:events Emits Transfer event on success
+     * @custom:event Emits Transfer event on success
      * @custom:error TransferNotAllowed is thrown if trying to transfer to self
      * @custom:access Not restricted
      */
@@ -192,7 +192,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param dst The address of the destination account
      * @param amount The number of tokens to transfer
      * @return success True if the transfer suceeded, reverts otherwise
-     * @custom:events Emits Transfer event on success
+     * @custom:event Emits Transfer event on success
      * @custom:error TransferNotAllowed is thrown if trying to transfer to self
      * @custom:access Not restricted
      */
@@ -212,7 +212,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param spender The address of the account which may transfer tokens
      * @param amount The number of tokens that are approved (uint256.max means infinite)
      * @return success Whether or not the approval succeeded
-     * @custom:events Emits Approval event
+     * @custom:event Emits Approval event
      * @custom:access Not restricted
      */
     function approve(address spender, uint256 amount) external override returns (bool) {
@@ -408,7 +408,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @dev This calculates interest accrued from the last checkpointed block
      *   up to the current block and writes new checkpoint to storage.
      * @return Always NO_ERROR
-     * @custom:events Emits AccrueInterest event on success
+     * @custom:event Emits AccrueInterest event on success
      * @custom:access Not restricted
      */
     function accrueInterest() public virtual override returns (uint256) {
@@ -474,7 +474,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @dev Accrues interest whether or not the operation succeeds, unless reverted
      * @param mintAmount The amount of the underlying asset to supply
      * @return error Always NO_ERROR for compatilibily with Venus core tooling
-     * @custom:events Emits Mint and Transfer events; may emit AccrueInterest
+     * @custom:event Emits Mint and Transfer events; may emit AccrueInterest
      * @custom:access Not restricted
      */
     function mint(uint256 mintAmount) external override nonReentrant returns (uint256) {
@@ -489,7 +489,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @dev Accrues interest whether or not the operation succeeds, unless reverted
      * @param mintAmount The amount of the underlying asset to supply
      * @return error Always NO_ERROR for compatilibily with Venus core tooling
-     * @custom:events Emits Mint and Transfer events; may emit AccrueInterest
+     * @custom:event Emits Mint and Transfer events; may emit AccrueInterest
      * @custom:access Not restricted
      */
     function mintBehalf(address minter, uint256 mintAmount) external override nonReentrant returns (uint256) {
@@ -561,7 +561,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @dev Accrues interest whether or not the operation succeeds, unless reverted
      * @param redeemTokens The number of vTokens to redeem into underlying
      * @return error Always NO_ERROR for compatilibily with Venus core tooling
-     * @custom:events Emits Redeem and Transfer events; may emit AccrueInterest
+     * @custom:event Emits Redeem and Transfer events; may emit AccrueInterest
      * @custom:error RedeemTransferOutNotPossible is thrown when the protocol has insufficient cash
      * @custom:access Not restricted
      */
@@ -669,7 +669,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @notice Sender borrows assets from the protocol to their own address
      * @param borrowAmount The amount of the underlying asset to borrow
      * @return error Always NO_ERROR for compatilibily with Venus core tooling
-     * @custom:events Emits Borrow event; may emit AccrueInterest
+     * @custom:event Emits Borrow event; may emit AccrueInterest
      * @custom:error BorrowCashNotAvailable is thrown when the protocol has insufficient cash
      * @custom:access Not restricted
      */
@@ -735,7 +735,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @notice Sender repays their own borrow
      * @param repayAmount The amount to repay, or -1 for the full outstanding amount
      * @return error Always NO_ERROR for compatilibily with Venus core tooling
-     * @custom:events Emits RepayBorrow event; may emit AccrueInterest
+     * @custom:event Emits RepayBorrow event; may emit AccrueInterest
      * @custom:access Not restricted
      */
     function repayBorrow(uint256 repayAmount) external override nonReentrant returns (uint256) {
@@ -750,7 +750,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param borrower the account with the debt being payed off
      * @param repayAmount The amount to repay, or -1 for the full outstanding amount
      * @return error Always NO_ERROR for compatilibily with Venus core tooling
-     * @custom:events Emits RepayBorrow event; may emit AccrueInterest
+     * @custom:event Emits RepayBorrow event; may emit AccrueInterest
      * @custom:access Not restricted
      */
     function repayBorrowBehalf(address borrower, uint256 repayAmount) external override nonReentrant returns (uint256) {
@@ -824,7 +824,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param repayAmount The amount of the underlying borrowed asset to repay
      * @param vTokenCollateral The market in which to seize collateral from the borrower
      * @return error Always NO_ERROR for compatilibily with Venus core tooling
-     * @custom:events Emits LiquidateBorrow event; may emit AccrueInterest
+     * @custom:event Emits LiquidateBorrow event; may emit AccrueInterest
      * @custom:error LiquidateAccrueCollateralInterestFailed is thrown when it is not possible to accrue interest on the collateral vToken
      * @custom:error LiquidateCollateralFreshnessCheck is thrown when interest has not been accrued on the collateral vToken
      * @custom:error LiquidateLiquidatorIsBorrower is thrown when trying to liquidate self
@@ -961,7 +961,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param payer account who repays the debt
      * @param borrower account to heal
      * @param repayAmount amount to repay
-     * @custom:events Emits RepayBorrow, BadDebtIncreased events; may emit AccrueInterest
+     * @custom:event Emits RepayBorrow, BadDebtIncreased events; may emit AccrueInterest
      * @custom:error HealBorrowUnauthorized is thrown when the request does not come from Comptroller
      * @custom:access Only Comptroller
      */
@@ -1013,7 +1013,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param vTokenCollateral The market in which to seize collateral from the borrower
      * @param skipLiquidityCheck If set to true, allows to liquidate up to 100% of the borrow
      *   regardless of the account liquidity
-     * @custom:events Emits LiquidateBorrow event; may emit AccrueInterest
+     * @custom:event Emits LiquidateBorrow event; may emit AccrueInterest
      * @custom:error ForceLiquidateBorrowUnauthorized is thrown when the request does not come from Comptroller
      * @custom:error LiquidateAccrueCollateralInterestFailed is thrown when it is not possible to accrue interest on the collateral vToken
      * @custom:error LiquidateCollateralFreshnessCheck is thrown when interest has not been accrued on the collateral vToken
@@ -1042,7 +1042,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param liquidator The account receiving seized collateral
      * @param borrower The account having collateral seized
      * @param seizeTokens The number of vTokens to seize
-     * @custom:events Emits Transfer, ReservesAdded events
+     * @custom:event Emits Transfer, ReservesAdded events
      * @custom:error LiquidateSeizeLiquidatorIsBorrower is thrown when trying to liquidate self
      * @custom:access Not restricted
      */
@@ -1122,7 +1122,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @notice sets protocol share accumulated from liquidations
      * @dev must be less than liquidation incentive - 1
      * @param newProtocolSeizeShareMantissa_ new protocol share mantissa
-     * @custom:events Emits NewProtocolSeizeShare event on success
+     * @custom:event Emits NewProtocolSeizeShare event on success
      * @custom:error SetProtocolSeizeShareUnauthorized is thrown when the call is not authorized by AccessControlManager
      * @custom:error ProtocolSeizeShareTooBig is thrown when the new seize share is too high
      * @custom:access Controlled by AccessControlManager
@@ -1150,7 +1150,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     /**
      * @notice accrues interest and sets a new reserve factor for the protocol using _setReserveFactorFresh
      * @dev Admin function to accrue interest and set a new reserve factor
-     * @custom:events Emits NewReserveFactor event; may emit AccrueInterest
+     * @custom:event Emits NewReserveFactor event; may emit AccrueInterest
      * @custom:error SetReserveFactorAdminCheck is thrown when the call is not authorized by AccessControlManager
      * @custom:error SetReserveFactorBoundsCheck is thrown when the new reserve factor is too high
      * @custom:access Controlled by AccessControlManager
@@ -1193,7 +1193,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     /**
      * @notice The sender adds to reserves.
      * @param addAmount The amount fo underlying token to add as reserves
-     * @custom:events Emits ReservesAdded event; may emit AccrueInterest
+     * @custom:event Emits ReservesAdded event; may emit AccrueInterest
      * @custom:access Not restricted
      */
     function addReserves(uint256 addAmount) external override nonReentrant {
@@ -1228,7 +1228,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     /**
      * @notice Accrues interest and reduces reserves by transferring to the protocol reserve contract
      * @param reduceAmount Amount of reduction to reserves
-     * @custom:events Emits ReservesReduced event; may emit AccrueInterest
+     * @custom:event Emits ReservesReduced event; may emit AccrueInterest
      * @custom:error ReduceReservesCashNotAvailable is thrown when the vToken does not have sufficient cash
      * @custom:error ReduceReservesCashValidation is thrown when trying to withdraw more cash than the reserves have
      * @custom:access Not restricted
@@ -1285,7 +1285,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @notice accrues interest and updates the interest rate model using _setInterestRateModelFresh
      * @dev Admin function to accrue interest and update the interest rate model
      * @param newInterestRateModel the new interest rate model to use
-     * @custom:events Emits NewMarketInterestRateModel event; may emit AccrueInterest
+     * @custom:event Emits NewMarketInterestRateModel event; may emit AccrueInterest
      * @custom:error SetInterestRateModelOwnerCheck is thrown when the call is not authorized by AccessControlManager
      * @custom:access Controlled by AccessControlManager
      */
@@ -1335,7 +1335,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @notice Sets the address of AccessControlManager
      * @dev Admin function to set address of AccessControlManager
      * @param newAccessControlManager The new address of the AccessControlManager
-     * @custom:events Emits NewAccessControlManager event
+     * @custom:event Emits NewAccessControlManager event
      * @custom:access Only Governance
      */
     function setAccessControlAddress(AccessControlManager newAccessControlManager) external {
@@ -1372,7 +1372,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @notice Updates bad debt
      * @dev Called only when bad debt is recovered from auction
      * @param recoveredAmount_ The amount of bad debt recovered
-     * @custom:events Emits BadDebtRecovered event
+     * @custom:event Emits BadDebtRecovered event
      * @custom:access Only Shortfall contract
      */
     function badDebtRecovered(uint256 recoveredAmount_) external {

--- a/docgen-templates/common.hbs
+++ b/docgen-templates/common.hbs
@@ -1,0 +1,48 @@
+{{#if (and visible natspec.notice) }}
+
+{{h}} {{name}}
+
+{{{natspec.notice}}}
+
+{{#if signature}}
+```solidity
+{{{signature}}}
+```
+{{/if}}
+
+{{#if natspec.params}}
+{{h 2}} Parameters
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+{{#each params}}
+| {{name}} | {{type}} | {{{joinLines natspec}}} |
+{{/each}}
+{{/if}}
+
+{{#if natspec.returns}}
+{{h 2}} Return Values
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+{{#each returns}}
+| {{#if name}}{{name}}{{else}}[{{@index}}]{{/if}} | {{type}} | {{{joinLines natspec}}} |
+{{/each}}
+{{/if}}
+
+{{#if natspec.custom.event}}
+{{h 2}} 📅 Events
+{{{ bullet natspec.custom.event }}}
+{{/if}}
+
+{{#if natspec.custom.access}}
+{{h 2}} ⛔️ Access Requirements
+{{{ bullet natspec.custom.access }}}
+{{/if}}
+
+{{#if natspec.custom.error}}
+{{h 2}} ❌ Errors
+{{{ bullet natspec.custom.error }}}
+{{/if}}
+
+- - -
+
+{{/if}}

--- a/docgen-templates/helpers.ts
+++ b/docgen-templates/helpers.ts
@@ -1,0 +1,10 @@
+export const and = (...args) => {
+  return args.every(Boolean);
+}
+
+export const  bullet= (docString: string) => docString.split('\n').map((elem: string) => {
+    if (elem) {
+      return `* ${elem}`
+    }
+    return elem
+  }).join('\n')

--- a/docgen-templates/helpers.ts
+++ b/docgen-templates/helpers.ts
@@ -1,10 +1,14 @@
 export const and = (...args) => {
   return args.every(Boolean);
-}
+};
 
-export const  bullet= (docString: string) => docString.split('\n').map((elem: string) => {
-    if (elem) {
-      return `* ${elem}`
-    }
-    return elem
-  }).join('\n')
+export const bullet = (docString: string) =>
+  docString
+    .split("\n")
+    .map((elem: string) => {
+      if (elem) {
+        return `* ${elem}`;
+      }
+      return elem;
+    })
+    .join("\n");

--- a/docgen-templates/properties.ts
+++ b/docgen-templates/properties.ts
@@ -1,6 +1,7 @@
-import { DocItemContext } from 'solidity-docgen/dist/site';
+import { DocItemContext } from "solidity-docgen/dist/site";
 
-export const visible = ({ item }: DocItemContext): boolean => {
-  // @ts-ignore
-  return item.visibility === 'public' || item.visibility === 'external';
-}
+export const visible = ({
+  item,
+}: DocItemContext & { item: { visibility: "public" | "external" | "private" | "internal" } }): boolean => {
+  return item.visibility === "public" || item.visibility === "external";
+};

--- a/docgen-templates/properties.ts
+++ b/docgen-templates/properties.ts
@@ -1,0 +1,6 @@
+import { DocItemContext } from 'solidity-docgen/dist/site';
+
+export const visible = ({ item }: DocItemContext): boolean => {
+  // @ts-ignore
+  return item.visibility === 'public' || item.visibility === 'external';
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -195,6 +195,7 @@ const config: HardhatUserConfig = {
   docgen: {
     outputDir: "./docs",
     pages: "files",
+    templates: './docgen-templates'
   },
   external: {
     contracts: [

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -195,7 +195,7 @@ const config: HardhatUserConfig = {
   docgen: {
     outputDir: "./docs",
     pages: "files",
-    templates: './docgen-templates'
+    templates: "./docgen-templates",
   },
   external: {
     contracts: [


### PR DESCRIPTION
## Description

This PR updates the docgen template for autogenerating documentation.

It will render custom event, access, and error tags as a list.
It only renders entities marked as external or public

### Example

```
### redeem

Sender redeems vTokens in exchange for the underlying asset

```solidity
function redeem(uint256 redeemTokens) external returns (uint256)
```

#### Parameters
| Name | Type | Description |
| ---- | ---- | ----------- |
| redeemTokens | uint256 | The number of vTokens to redeem into underlying |

#### Return Values
| Name | Type | Description |
| ---- | ---- | ----------- |
| [0] | uint256 | error Always NO_ERROR for compatilibily with Venus core tooling |

#### 📅 Events
* Emits Redeem and Transfer events; may emit AccrueInterest

#### ⛔️ Access Requirements
* Not restricted

#### ❌ Errors
* RedeemTransferOutNotPossible is thrown when the protocol has insufficient cash

- - -

```
