### PR TITLE
Certik Audit Fixes

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -104,6 +104,9 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
     /// @notice Emitted when a rewards distributor is added
     event NewRewardsDistributor(address indexed rewardsDistributor);
 
+    /// @notice Emitted when a market is supported
+    event MarketSupported(VToken vToken);
+
     /// @notice Thrown when collateral factor exceeds the upper bound
     error InvalidCollateralFactor();
 
@@ -836,6 +839,8 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
         for (uint256 i; i < rewardDistributorsCount; ++i) {
             rewardsDistributors[i].initializeMarket(address(vToken));
         }
+
+        emit MarketSupported(vToken);
     }
 
     /**

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -92,9 +92,6 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
     /// @notice Emitted when borrow cap for a vToken is changed
     event NewBorrowCap(VToken indexed vToken, uint256 newBorrowCap);
 
-    /// @notice Emitted when borrow cap guardian is changed
-    event NewBorrowCapGuardian(address oldBorrowCapGuardian, address newBorrowCapGuardian);
-
     /// @notice Emitted when the collateral threshold (in USD) for non-batch liquidations is changed
     event NewMinLiquidatableCollateral(uint256 oldMinLiquidatableCollateral, uint256 newMinLiquidatableCollateral);
 

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -165,6 +165,10 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
     constructor(address poolRegistry_, address accessControl_) {
         // Note that the contract is upgradeable. We only initialize immutables in the
         // constructor. Use initialize() or reinitializers to set the state variables.
+
+        require(poolRegistry_ != address(0), "invalid pool registry address");
+        require(accessControl_ != address(0), "invalid access control address");
+
         poolRegistry = poolRegistry_;
         accessControl = accessControl_;
         _disableInitializers();
@@ -1044,6 +1048,8 @@ contract Comptroller is Ownable2StepUpgradeable, ComptrollerV1Storage, Comptroll
      * @custom:event Emits NewPriceOracle on success
      */
     function setPriceOracle(PriceOracle newOracle) public onlyOwner {
+        require(address(newOracle) != address(0), "invalid price oracle address");
+
         PriceOracle oldOracle = oracle;
         oracle = newOracle;
         emit NewPriceOracle(oldOracle, newOracle);

--- a/contracts/Factories/VTokenProxyFactory.sol
+++ b/contracts/Factories/VTokenProxyFactory.sol
@@ -8,6 +8,7 @@ import "../Governance/AccessControlManager.sol";
 import "../VTokenInterfaces.sol";
 
 contract VTokenProxyFactory {
+
     struct VTokenArgs {
         address underlying_;
         ComptrollerInterface comptroller_;
@@ -22,6 +23,8 @@ contract VTokenProxyFactory {
         address vTokenProxyAdmin_;
         address beaconAddress;
     }
+
+    event VTokenProxyDeployed(VTokenArgs args);
 
     function deployVTokenProxy(VTokenArgs memory input) external returns (VToken) {
         BeaconProxy proxy = new BeaconProxy(
@@ -40,6 +43,8 @@ contract VTokenProxyFactory {
                 input.riskManagement
             )
         );
+
+        emit VTokenProxyDeployed(input);
 
         return VToken(address(proxy));
     }

--- a/contracts/Factories/VTokenProxyFactory.sol
+++ b/contracts/Factories/VTokenProxyFactory.sol
@@ -8,7 +8,6 @@ import "../Governance/AccessControlManager.sol";
 import "../VTokenInterfaces.sol";
 
 contract VTokenProxyFactory {
-
     struct VTokenArgs {
         address underlying_;
         ComptrollerInterface comptroller_;

--- a/contracts/Factories/VTokenProxyFactory.sol
+++ b/contracts/Factories/VTokenProxyFactory.sol
@@ -16,7 +16,7 @@ contract VTokenProxyFactory {
         string name_;
         string symbol_;
         uint8 decimals_;
-        address payable admin_;
+        address admin_;
         AccessControlManager accessControlManager_;
         VTokenInterface.RiskManagementInit riskManagement;
         address vTokenProxyAdmin_;

--- a/contracts/JumpRateModelV2.sol
+++ b/contracts/JumpRateModelV2.sol
@@ -2,14 +2,13 @@
 pragma solidity ^0.8.10;
 
 import "./BaseJumpRateModelV2.sol";
-import "./InterestRateModel.sol";
 
 /**
  * @title Compound's JumpRateModel Contract V2 for V2 vTokens
  * @author Arr00
  * @notice Supports only for V2 vTokens
  */
-contract JumpRateModelV2 is InterestRateModel, BaseJumpRateModelV2 {
+contract JumpRateModelV2 is BaseJumpRateModelV2 {
     /**
      * @notice Calculates the current borrow rate per block
      * @param cash The amount of cash in the market

--- a/contracts/Lens/PoolLens.sol
+++ b/contracts/Lens/PoolLens.sol
@@ -76,7 +76,7 @@ contract PoolLens is ExponentialNoError {
      * @param account The user Account.
      * @notice Returns the BalanceInfo of all VTokens.
      */
-    function vTokenBalancesAll(VToken[] calldata vTokens, address payable account)
+    function vTokenBalancesAll(VToken[] calldata vTokens, address account)
         external
         returns (VTokenBalances[] memory)
     {
@@ -174,7 +174,7 @@ contract PoolLens is ExponentialNoError {
      * @param account The user Account.
      * @notice Returns the BalanceInfo of VToken.
      */
-    function vTokenBalances(VToken vToken, address payable account) public returns (VTokenBalances memory) {
+    function vTokenBalances(VToken vToken, address account) public returns (VTokenBalances memory) {
         uint256 balanceOf = vToken.balanceOf(account);
         uint256 borrowBalanceCurrent = vToken.borrowBalanceCurrent(account);
         uint256 balanceOfUnderlying = vToken.balanceOfUnderlying(account);

--- a/contracts/Lens/PoolLens.sol
+++ b/contracts/Lens/PoolLens.sol
@@ -76,10 +76,7 @@ contract PoolLens is ExponentialNoError {
      * @param account The user Account.
      * @notice Returns the BalanceInfo of all VTokens.
      */
-    function vTokenBalancesAll(VToken[] calldata vTokens, address account)
-        external
-        returns (VTokenBalances[] memory)
-    {
+    function vTokenBalancesAll(VToken[] calldata vTokens, address account) external returns (VTokenBalances[] memory) {
         uint256 vTokenCount = vTokens.length;
         VTokenBalances[] memory res = new VTokenBalances[](vTokenCount);
         for (uint256 i; i < vTokenCount; ++i) {

--- a/contracts/Lens/PoolLens.sol
+++ b/contracts/Lens/PoolLens.sol
@@ -143,7 +143,7 @@ contract PoolLens is ExponentialNoError {
     function getPoolsSupportedByAsset(address poolRegistryAddress, address asset)
         external
         view
-        returns (uint256[] memory)
+        returns (address[] memory)
     {
         PoolRegistryInterface poolRegistryInterface = PoolRegistryInterface(poolRegistryAddress);
         return poolRegistryInterface.getPoolsSupportedByAsset(asset);

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -26,7 +26,7 @@ import "./PoolRegistryInterface.sol";
  */
 contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
     using SafeERC20Upgradeable for IERC20Upgradeable;
-    
+
     enum InterestRateModels {
         WhitePaper,
         JumpRate
@@ -279,7 +279,7 @@ contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
      * @notice Returns arrays of all Venus pools' data.
      * @dev This function is not designed to be called in a transaction: it is too gas-intensive.
      */
-    function getAllPools() override external view returns (VenusPool[] memory) {
+    function getAllPools() external view override returns (VenusPool[] memory) {
         VenusPool[] memory _pools = new VenusPool[](_numberOfPools);
         for (uint256 i = 1; i <= _numberOfPools; ++i) {
             address comptroller = _poolsByID[i];
@@ -292,7 +292,7 @@ contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
      * @param comptroller The Comptroller implementation address.
      * @notice Returns Venus pool.
      */
-    function getPoolByComptroller(address comptroller) override external view returns (VenusPool memory) {
+    function getPoolByComptroller(address comptroller) external view override returns (VenusPool memory) {
         return _poolByComptroller[comptroller];
     }
 
@@ -300,15 +300,15 @@ contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
      * @param comptroller comptroller of Venus pool.
      * @notice Returns Metadata of Venus pool.
      */
-    function getVenusPoolMetadata(address comptroller) override external view returns (VenusPoolMetaData memory) {
+    function getVenusPoolMetadata(address comptroller) external view override returns (VenusPoolMetaData memory) {
         return metadata[comptroller];
     }
 
-    function getVTokenForAsset(address comptroller, address asset) override external view returns (address) {
+    function getVTokenForAsset(address comptroller, address asset) external view override returns (address) {
         return _vTokens[comptroller][asset];
     }
 
-    function getPoolsSupportedByAsset(address asset) override external view returns (address[] memory) {
+    function getPoolsSupportedByAsset(address asset) external view override returns (address[] memory) {
         return _supportedPools[asset];
     }
 

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -18,46 +18,15 @@ import "../Governance/AccessControlManager.sol";
 import "../Shortfall/Shortfall.sol";
 import "../ComptrollerInterface.sol";
 import "../VTokenInterfaces.sol";
+import "./PoolRegistryInterface.sol";
 
 /**
  * @title PoolRegistry
  * @notice PoolRegistry is a registry for Venus interest rate pools.
  */
-contract PoolRegistry is Ownable2StepUpgradeable {
+contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
     using SafeERC20Upgradeable for IERC20Upgradeable;
-
-    /**
-     * @dev Struct for a Venus interest rate pool.
-     */
-    struct VenusPool {
-        string name;
-        address creator;
-        address comptroller;
-        uint256 blockPosted;
-        uint256 timestampPosted;
-    }
-
-    /**
-     * @dev Enum for risk rating of Venus interest rate pool.
-     */
-    enum RiskRating {
-        VERY_HIGH_RISK,
-        HIGH_RISK,
-        MEDIUM_RISK,
-        LOW_RISK,
-        MINIMAL_RISK
-    }
-
-    /**
-     * @dev Struct for a Venus interest rate pool metadata.
-     */
-    struct VenusPoolMetaData {
-        RiskRating riskRating;
-        string category;
-        string logoURL;
-        string description;
-    }
-
+    
     enum InterestRateModels {
         WhitePaper,
         JumpRate
@@ -310,7 +279,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
      * @notice Returns arrays of all Venus pools' data.
      * @dev This function is not designed to be called in a transaction: it is too gas-intensive.
      */
-    function getAllPools() external view returns (VenusPool[] memory) {
+    function getAllPools() override external view returns (VenusPool[] memory) {
         VenusPool[] memory _pools = new VenusPool[](_numberOfPools);
         for (uint256 i = 1; i <= _numberOfPools; ++i) {
             address comptroller = _poolsByID[i];
@@ -323,7 +292,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
      * @param comptroller The Comptroller implementation address.
      * @notice Returns Venus pool.
      */
-    function getPoolByComptroller(address comptroller) external view returns (VenusPool memory) {
+    function getPoolByComptroller(address comptroller) override external view returns (VenusPool memory) {
         return _poolByComptroller[comptroller];
     }
 
@@ -331,15 +300,15 @@ contract PoolRegistry is Ownable2StepUpgradeable {
      * @param comptroller comptroller of Venus pool.
      * @notice Returns Metadata of Venus pool.
      */
-    function getVenusPoolMetadata(address comptroller) external view returns (VenusPoolMetaData memory) {
+    function getVenusPoolMetadata(address comptroller) override external view returns (VenusPoolMetaData memory) {
         return metadata[comptroller];
     }
 
-    function getVTokenForAsset(address comptroller, address asset) external view returns (address) {
+    function getVTokenForAsset(address comptroller, address asset) override external view returns (address) {
         return _vTokens[comptroller][asset];
     }
 
-    function getPoolsSupportedByAsset(address asset) external view returns (address[] memory) {
+    function getPoolsSupportedByAsset(address asset) override external view returns (address[] memory) {
         return _supportedPools[asset];
     }
 

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -253,7 +253,7 @@ contract PoolRegistry is Ownable2StepUpgradeable {
             input.name,
             input.symbol,
             input.decimals,
-            payable(msg.sender),
+            msg.sender,
             input.accessControlManager,
             VTokenInterface.RiskManagementInit(address(shortfall), riskFund, protocolShareReserve),
             input.vTokenProxyAdmin,

--- a/contracts/Pool/PoolRegistryInterface.sol
+++ b/contracts/Pool/PoolRegistryInterface.sol
@@ -1,28 +1,56 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 
-import "./PoolRegistry.sol";
-
 abstract contract PoolRegistryInterface {
+
+    /**
+     * @dev Struct for a Venus interest rate pool.
+     */
+    struct VenusPool {
+        string name;
+        address creator;
+        address comptroller;
+        uint256 blockPosted;
+        uint256 timestampPosted;
+    }
+    
+    /**
+     * @dev Enum for risk rating of Venus interest rate pool.
+     */
+    enum RiskRating {
+        VERY_HIGH_RISK,
+        HIGH_RISK,
+        MEDIUM_RISK,
+        LOW_RISK,
+        MINIMAL_RISK
+    }
+
+    /**
+     * @dev Struct for a Venus interest rate pool metadata.
+     */
+    struct VenusPoolMetaData {
+        RiskRating riskRating;
+        string category;
+        string logoURL;
+        string description;
+    }
+
     /*** get All Pools in PoolRegistry ***/
-    function getAllPools() external view virtual returns (PoolRegistry.VenusPool[] memory);
+    function getAllPools() external view virtual returns (VenusPool[] memory);
 
     /*** get a Pool by comptrollerAddress ***/
-    function getPoolByComptroller(address comptroller) external view virtual returns (PoolRegistry.VenusPool memory);
-
-    /*** get all Bookmarks made by an account ***/
-    function getBookmarks(address account) external view virtual returns (address[] memory);
+    function getPoolByComptroller(address comptroller) external view virtual returns (VenusPool memory);
 
     /*** get VToken in the Pool for an Asset ***/
     function getVTokenForAsset(address comptroller, address asset) external view virtual returns (address);
 
     /*** get Pools supported by Asset ***/
-    function getPoolsSupportedByAsset(address asset) external view virtual returns (uint256[] memory);
+    function getPoolsSupportedByAsset(address asset) external view virtual returns (address[] memory);
 
     /*** get metadata of a Pool by comptroller ***/
     function getVenusPoolMetadata(address comptroller)
         external
         view
         virtual
-        returns (PoolRegistry.VenusPoolMetaData memory);
+        returns (VenusPoolMetaData memory);
 }

--- a/contracts/Pool/PoolRegistryInterface.sol
+++ b/contracts/Pool/PoolRegistryInterface.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.13;
 
 abstract contract PoolRegistryInterface {
-
     /**
      * @dev Struct for a Venus interest rate pool.
      */
@@ -13,7 +12,7 @@ abstract contract PoolRegistryInterface {
         uint256 blockPosted;
         uint256 timestampPosted;
     }
-    
+
     /**
      * @dev Enum for risk rating of Venus interest rate pool.
      */
@@ -48,9 +47,5 @@ abstract contract PoolRegistryInterface {
     function getPoolsSupportedByAsset(address asset) external view virtual returns (address[] memory);
 
     /*** get metadata of a Pool by comptroller ***/
-    function getVenusPoolMetadata(address comptroller)
-        external
-        view
-        virtual
-        returns (VenusPoolMetaData memory);
+    function getVenusPoolMetadata(address comptroller) external view virtual returns (VenusPoolMetaData memory);
 }

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -77,6 +77,15 @@ contract RewardsDistributor is ExponentialNoError, Ownable2StepUpgradeable {
     /// @notice Emitted when a new REWARD TOKEN speed is set for a contributor
     event ContributorRewardTokenSpeedUpdated(address indexed contributor, uint256 newSpeed);
 
+    /// @notice Emitted when a market is initialized
+    event MarketInitialized(address vToken);
+
+    /// @notice Emitted when a reward token supply index is updated
+    event RewardTokenSupplyIndexUpdated(address vToken);
+
+    /// @notice Emitted when a reward token borrow index is updated
+    event RewardTokenBorrowIndexUpdated(address vToken, Exp marketBorrowIndex);
+
     /// @notice The REWARD TOKEN borrow index for each market for each borrower as of the last time they accrued REWARD TOKEN
     mapping(address => mapping(address => uint256)) public rewardTokenBorrowerIndex;
 
@@ -118,6 +127,8 @@ contract RewardsDistributor is ExponentialNoError, Ownable2StepUpgradeable {
          * Update market state block numbers
          */
         supplyState.block = borrowState.block = blockNumber;
+
+        emit MarketInitialized(vToken);
     }
 
     /*** Reward Token Distribution ***/
@@ -355,6 +366,8 @@ contract RewardsDistributor is ExponentialNoError, Ownable2StepUpgradeable {
         } else if (deltaBlocks > 0) {
             supplyState.block = blockNumber;
         }
+
+        emit RewardTokenSupplyIndexUpdated(vToken);
     }
 
     function updateRewardTokenBorrowIndex(address vToken, Exp memory marketBorrowIndex) external onlyComptroller {
@@ -385,6 +398,8 @@ contract RewardsDistributor is ExponentialNoError, Ownable2StepUpgradeable {
         } else if (deltaBlocks > 0) {
             borrowState.block = blockNumber;
         }
+
+        emit RewardTokenBorrowIndexUpdated(vToken, marketBorrowIndex);
     }
 
     /*** Reward Token Distribution Admin ***/

--- a/contracts/RiskFund/IRiskFund.sol
+++ b/contracts/RiskFund/IRiskFund.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.13;
 
 interface IRiskFund {
-    function swapPoolsAssets() external returns (uint256);
+   function swapPoolsAssets(address[] calldata underlyingAssets, uint256[] calldata amountsOutMin) external returns (uint256);
 
     function getPoolReserve(address comptroller) external view returns (uint256);
 

--- a/contracts/RiskFund/IRiskFund.sol
+++ b/contracts/RiskFund/IRiskFund.sol
@@ -2,7 +2,9 @@
 pragma solidity 0.8.13;
 
 interface IRiskFund {
-   function swapPoolsAssets(address[] calldata underlyingAssets, uint256[] calldata amountsOutMin) external returns (uint256);
+    function swapPoolsAssets(address[] calldata underlyingAssets, uint256[] calldata amountsOutMin)
+        external
+        returns (uint256);
 
     function getPoolReserve(address comptroller) external view returns (uint256);
 

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -7,8 +7,9 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 import "../ExponentialNoError.sol";
 import "./IRiskFund.sol";
 import "./ReserveHelpers.sol";
+import "./IProtocolShareReserve.sol";
 
-contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers {
+contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers, IProtocolShareReserve {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     address private protocolIncome;
@@ -81,5 +82,14 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
         emit FundsReleased(comptroller, asset, amount);
 
         return amount;
+    }
+
+    /**
+     * @dev Update the reserve of the asset for the specific pool after transferring to risk fund.
+     * @param comptroller  Comptroller address(pool).
+     * @param asset Asset address.
+     */
+    function updateAssetsState(address comptroller, address asset) public override(IProtocolShareReserve, ReserveHelpers) {
+        super.updateAssetsState(comptroller, asset);
     }
 }

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -14,12 +14,8 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
     address private protocolIncome;
     address private riskFund;
 
-    /// @notice Emitted when funds are released 
-    event FundsReleased (
-        address comptroller,
-        address asset,
-        uint256 amount
-    );
+    /// @notice Emitted when funds are released
+    event FundsReleased(address comptroller, address asset, uint256 amount);
 
     /// @notice Emitted when pool registry address is updated
     event PoolRegistryUpdated(address indexed oldPoolRegistry, address indexed newPoolRegistry);

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -14,6 +14,13 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
     address private protocolIncome;
     address private riskFund;
 
+    /// @notice Emitted when funds are released 
+    event FundsReleased (
+        address comptroller,
+        address asset,
+        uint256 amount
+    );
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         // Note that the contract is upgradeable. Use initialize() or reinitializers
@@ -60,6 +67,8 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
 
         // Update the pool asset's state in the risk fund for the above transfer.
         IRiskFund(riskFund).updateAssetsState(comptroller, asset);
+
+        emit FundsReleased(comptroller, asset, amount);
 
         return amount;
     }

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -89,7 +89,10 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
      * @param comptroller  Comptroller address(pool).
      * @param asset Asset address.
      */
-    function updateAssetsState(address comptroller, address asset) public override(IProtocolShareReserve, ReserveHelpers) {
+    function updateAssetsState(address comptroller, address asset)
+        public
+        override(IProtocolShareReserve, ReserveHelpers)
+    {
         super.updateAssetsState(comptroller, asset);
     }
 }

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -21,6 +21,9 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
         uint256 amount
     );
 
+    /// @notice Emitted when pool registry address is updated
+    event PoolRegistryUpdated(address indexed oldPoolRegistry, address indexed newPoolRegistry);
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         // Note that the contract is upgradeable. Use initialize() or reinitializers
@@ -41,6 +44,17 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
 
         protocolIncome = _protocolIncome;
         riskFund = _riskFund;
+    }
+
+    /**
+     * @dev Pool registry setter
+     * @param _poolRegistry Address of the pool registry.
+     */
+    function setPoolRegistry(address _poolRegistry) external onlyOwner {
+        require(_poolRegistry != address(0), "ProtocolShareReserve: Pool registry address invalid");
+        address oldPoolRegistry = poolRegistry;
+        poolRegistry = _poolRegistry;
+        emit PoolRegistryUpdated(oldPoolRegistry, _poolRegistry);
     }
 
     /**

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.13;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
 import "../ComptrollerInterface.sol";
+import "../Pool/PoolRegistryInterface.sol";
 
 contract ReserveHelpers {
     using SafeERC20Upgradeable for IERC20Upgradeable;
@@ -14,6 +15,9 @@ contract ReserveHelpers {
     // Store the asset's reserve per pool in the ProtocolShareReserve.
     // Comptroller(pool) -> Asset -> amount
     mapping(address => mapping(address => uint256)) internal poolsAssetsReserves;
+
+    // Address of pool registry contract
+    address public poolRegistry;
 
     // Event emitted after the updation of the assets reserves.
     // amount -> reserve increased by amount.
@@ -27,6 +31,9 @@ contract ReserveHelpers {
     function updateAssetsState(address comptroller, address asset) external {
         require(ComptrollerInterface(comptroller).isComptroller(), "ReserveHelpers: Comptroller address invalid");
         require(asset != address(0), "ReserveHelpers: Asset address invalid");
+        require(poolRegistry != address(0), "ReserveHelpers: Pool Registry address is not set");
+        require(PoolRegistryInterface(poolRegistry).getVTokenForAsset(comptroller, asset) != address(0), "ReserveHelpers: The pool doesn't support the asset");
+
         uint256 currentBalance = IERC20Upgradeable(asset).balanceOf(address(this));
         uint256 assetReserve = assetsReserves[asset];
         if (currentBalance > assetReserve) {

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -32,7 +32,10 @@ contract ReserveHelpers {
         require(ComptrollerInterface(comptroller).isComptroller(), "ReserveHelpers: Comptroller address invalid");
         require(asset != address(0), "ReserveHelpers: Asset address invalid");
         require(poolRegistry != address(0), "ReserveHelpers: Pool Registry address is not set");
-        require(PoolRegistryInterface(poolRegistry).getVTokenForAsset(comptroller, asset) != address(0), "ReserveHelpers: The pool doesn't support the asset");
+        require(
+            PoolRegistryInterface(poolRegistry).getVTokenForAsset(comptroller, asset) != address(0),
+            "ReserveHelpers: The pool doesn't support the asset"
+        );
 
         uint256 currentBalance = IERC20Upgradeable(asset).balanceOf(address(this));
         uint256 assetReserve = assetsReserves[asset];

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -28,7 +28,7 @@ contract ReserveHelpers {
      * @param comptroller  Comptroller address(pool).
      * @param asset Asset address.
      */
-    function updateAssetsState(address comptroller, address asset) external {
+    function updateAssetsState(address comptroller, address asset) virtual public {
         require(ComptrollerInterface(comptroller).isComptroller(), "ReserveHelpers: Comptroller address invalid");
         require(asset != address(0), "ReserveHelpers: Asset address invalid");
         require(poolRegistry != address(0), "ReserveHelpers: Pool Registry address is not set");

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -28,7 +28,7 @@ contract ReserveHelpers {
      * @param comptroller  Comptroller address(pool).
      * @param asset Asset address.
      */
-    function updateAssetsState(address comptroller, address asset) virtual public {
+    function updateAssetsState(address comptroller, address asset) public virtual {
         require(ComptrollerInterface(comptroller).isComptroller(), "ReserveHelpers: Comptroller address invalid");
         require(asset != address(0), "ReserveHelpers: Asset address invalid");
         require(poolRegistry != address(0), "ReserveHelpers: Pool Registry address is not set");

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -17,7 +17,7 @@ contract ReserveHelpers {
     mapping(address => mapping(address => uint256)) internal poolsAssetsReserves;
 
     // Address of pool registry contract
-    address public poolRegistry;
+    address internal poolRegistry;
 
     // Event emitted after the updation of the assets reserves.
     // amount -> reserve increased by amount.

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -17,7 +17,6 @@ import "./ReserveHelpers.sol";
 contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
-    address private poolRegistry;
     address private pancakeSwapRouter;
     uint256 private minAmountToConvert;
     address private convertibleBaseAsset;

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -11,6 +11,7 @@ import "../IPancakeswapV2Router.sol";
 import "../Pool/PoolRegistry.sol";
 import "./ReserveHelpers.sol";
 import "./IRiskFund.sol";
+import "../Shortfall/IShortfall.sol";
 
 /**
  * @dev This contract does not support BNB.
@@ -89,22 +90,13 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
     }
 
     /**
-     * @dev Convertible base asset setter
-     * @param _convertibleBaseAsset Address of the asset.
-     */
-    function setConvertableBaseAsset(address _convertibleBaseAsset) external onlyOwner {
-        require(_convertibleBaseAsset != address(0), "Risk Fund: Asset address invalid");
-        address oldBaseAsset = convertibleBaseAsset;
-        convertibleBaseAsset = _convertibleBaseAsset;
-        emit ConvertableBaseAssetUpdated(oldBaseAsset, _convertibleBaseAsset);
-    }
-
-    /**
      * @dev Shortfall contract address setter
      * @param _shortfallContractAddress Address of the auction contract.
      */
     function setShortfallContractAddress(address _shortfallContractAddress) external onlyOwner {
         require(_shortfallContractAddress != address(0), "Risk Fund: Shortfall contract address invalid");
+        require(IShortfall(_shortfallContractAddress).convertibleBaseAsset() != address(0), "Risk Fund: Base asset doesn't match");
+
         address oldShortfallContractAddress = shortfall;
         shortfall = _shortfallContractAddress;
         emit ShortfallContractUpdated(oldShortfallContractAddress, _shortfallContractAddress);

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -31,9 +31,6 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
     /// @notice Emitted when pool registry address is updated
     event PoolRegistryUpdated(address indexed oldPoolRegistry, address indexed newPoolRegistry);
 
-    /// @notice Emitted when convertible base asset address is updated
-    event ConvertableBaseAssetUpdated(address indexed oldBaseAsset, address indexed newBaseAsset);
-
     /// @notice Emitted when shortfall contract address is updated
     event ShortfallContractUpdated(address indexed oldShortfallContract, address indexed newShortfallContract);
 
@@ -96,7 +93,7 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
     function setShortfallContractAddress(address _shortfallContractAddress) external onlyOwner {
         require(_shortfallContractAddress != address(0), "Risk Fund: Shortfall contract address invalid");
         require(
-            IShortfall(_shortfallContractAddress).convertibleBaseAsset() != address(0),
+            IShortfall(_shortfallContractAddress).convertibleBaseAsset() == convertibleBaseAsset,
             "Risk Fund: Base asset doesn't match"
         );
 

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -95,7 +95,10 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
      */
     function setShortfallContractAddress(address _shortfallContractAddress) external onlyOwner {
         require(_shortfallContractAddress != address(0), "Risk Fund: Shortfall contract address invalid");
-        require(IShortfall(_shortfallContractAddress).convertibleBaseAsset() != address(0), "Risk Fund: Base asset doesn't match");
+        require(
+            IShortfall(_shortfallContractAddress).convertibleBaseAsset() != address(0),
+            "Risk Fund: Base asset doesn't match"
+        );
 
         address oldShortfallContractAddress = shortfall;
         shortfall = _shortfallContractAddress;
@@ -131,7 +134,8 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
      * @return Number of swapped tokens.
      */
     function swapPoolsAssets(address[] calldata underlyingAssets, uint256[] calldata amountsOutMin)
-        override external
+        external
+        override
         returns (uint256)
     {
         bool canSwapPoolsAsset = AccessControlManager(accessControl).isAllowedToCall(
@@ -164,7 +168,7 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
      * @param amount Amount to be transferred to auction contract.
      * @return Number reserved tokens.
      */
-    function transferReserveForAuction(address comptroller, uint256 amount) override external returns (uint256) {
+    function transferReserveForAuction(address comptroller, uint256 amount) external override returns (uint256) {
         require(msg.sender == shortfall, "Risk fund: Only callable by Shortfall contract");
         require(amount <= poolReserves[comptroller], "Risk Fund: Insufficient pool reserve.");
         poolReserves[comptroller] = poolReserves[comptroller] - amount;
@@ -177,7 +181,7 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
      * @param comptroller Comptroller address of the pool.
      * @return Number of reserved tokens.
      */
-    function getPoolReserve(address comptroller) override external view returns (uint256) {
+    function getPoolReserve(address comptroller) external view override returns (uint256) {
         return poolReserves[comptroller];
     }
 

--- a/contracts/Shortfall/IShortfall.sol
+++ b/contracts/Shortfall/IShortfall.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+
+interface IShortfall {
+    function convertibleBaseAsset() external returns (address);
+}

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -9,8 +9,9 @@ import "@venusprotocol/oracle/contracts/PriceOracle.sol";
 import "../VToken.sol";
 import "../ComptrollerInterface.sol";
 import "../RiskFund/IRiskFund.sol";
+import "./IShortfall.sol";
 
-contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
+contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, IShortfall {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     /// @notice Type of auction
@@ -62,7 +63,7 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     uint256 public constant waitForFirstBidder = 100;
 
     /// @notice base asset contract address
-    address private convertibleBaseAsset;
+    address public convertibleBaseAsset;
 
     /// @notice Auctions for each pool
     mapping(address => Auction) public auctions;
@@ -100,9 +101,6 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     /// @notice Emitted when minimum pool bad debt is updated
     event MinimumPoolBadDebtUpdated(uint256 oldMinimumPoolBadDebt, uint256 newMinimumPoolBadDebt);
 
-    /// @notice Emitted when convertible base asset address is updated
-    event ConvertableBaseAssetUpdated(address indexed oldBaseAsset, address indexed newBaseAsset);
-
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         // Note that the contract is upgradeable. Use initialize() or reinitializers
@@ -127,17 +125,6 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
         minimumPoolBadDebt = _minimumPoolBadDebt;
         convertibleBaseAsset = _convertibleBaseAsset;
         riskFund = _riskFund;
-    }
-
-    /**
-     * @dev Convertible base asset setter
-     * @param _convertibleBaseAsset Address of the asset.
-     */
-    function setConvertableBaseAsset(address _convertibleBaseAsset) external onlyOwner {
-        require(_convertibleBaseAsset != address(0), "Shortfall: Asset address invalid");
-        address oldBaseAsset = convertibleBaseAsset;
-        convertibleBaseAsset = _convertibleBaseAsset;
-        emit ConvertableBaseAssetUpdated(oldBaseAsset, _convertibleBaseAsset);
     }
 
     /**

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -119,6 +119,9 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
         IRiskFund _riskFund,
         uint256 _minimumPoolBadDebt
     ) external initializer {
+        require(_convertibleBaseAsset != address(0), "invalid base asset address");
+        require(address(_riskFund) != address(0), "invalid risk fund address");
+
         __Ownable2Step_init();
         __ReentrancyGuard_init();
         minimumPoolBadDebt = _minimumPoolBadDebt;

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -534,6 +534,8 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @custom:access Not restricted
      */
     function mintBehalf(address minter, uint256 mintAmount) external override nonReentrant returns (uint256) {
+        require(minter != address(0), "invalid minter address");
+
         accrueInterest();
         // _mintFresh emits the actual Mint event if successful and logs on errors, so we don't need to
         _mintFresh(msg.sender, minter, mintAmount);

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -50,6 +50,12 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         AccessControlManager accessControlManager_,
         RiskManagementInit memory riskManagement
     ) public initializer {
+        require(admin_ != address(0), "invalid admin address");
+        require(address(accessControlManager_) != address(0), "invalid access control manager address");
+        require(riskManagement.shortfall != address(0), "invalid shortfall address");
+        require(riskManagement.riskFund != address(0), "invalid riskfund address");
+        require(riskManagement.protocolShareReserve != address(0), "invalid protocol share reserve address");
+
         // Initialize the market
         _initialize(
             underlying_,
@@ -216,6 +222,8 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @custom:access Not restricted
      */
     function approve(address spender, uint256 amount) external override returns (bool) {
+        require(spender != address(0), "invalid spender address");
+
         address src = msg.sender;
         transferAllowances[src][spender] = amount;
         emit Approval(src, spender, amount);
@@ -231,8 +239,9 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @custom:access Not restricted
      */
     function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
-        address src = msg.sender;
+        require(spender != address(0), "invalid spender address");
 
+        address src = msg.sender;
         uint256 allowance = transferAllowances[src][spender];
         allowance += addedValue;
         transferAllowances[src][spender] = allowance;
@@ -250,6 +259,8 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @custom:access Not restricted
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        require(spender != address(0), "invalid spender address");
+
         address src = msg.sender;
         uint256 currentAllowance = transferAllowances[src][spender];
         require(currentAllowance >= subtractedValue, "decreased allowance below zero");
@@ -1385,6 +1396,8 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      */
     function setAccessControlAddress(AccessControlManager newAccessControlManager) external {
         require(msg.sender == owner(), "only admin can set ACL address");
+        require(address(newAccessControlManager) != address(0), "invalid acess control manager address");
+
         _setAccessControlAddress(newAccessControlManager);
     }
 

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -223,6 +223,47 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     }
 
     /**
+     * @notice Increase approval for `spender`
+     * @param spender The address of the account which may transfer tokens
+     * @param addedValue The number of tokens additional tokens spender can transfer
+     * @return success Whether or not the approval succeeded
+     * @custom:event Emits Approval event
+     * @custom:access Not restricted
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public returns (bool) {
+        address src = msg.sender;
+
+        uint256 allowance = transferAllowances[src][spender];
+        allowance += addedValue;
+        transferAllowances[src][spender] = allowance;
+
+        emit Approval(src, spender, allowance);
+        return true;
+    }
+
+    /**
+     * @notice Decreases approval for `spender`
+     * @param spender The address of the account which may transfer tokens
+     * @param subtractedValue The number of tokens tokens to remove from total approval
+     * @return success Whether or not the approval succeeded
+     * @custom:event Emits Approval event
+     * @custom:access Not restricted
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        address src = msg.sender;
+        uint256 currentAllowance = transferAllowances[src][spender];
+        require(currentAllowance >= subtractedValue, "decreased allowance below zero");
+        unchecked {
+            currentAllowance -= subtractedValue;
+        }
+
+        transferAllowances[src][spender] = currentAllowance;
+
+         emit Approval(src, spender, currentAllowance);
+        return true;
+    }
+
+    /**
      * @notice Get the current allowance from `owner` for `spender`
      * @param owner The address of the account which owns the tokens to be spent
      * @param spender The address of the account which may transfer tokens

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -46,7 +46,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
-        address payable admin_,
+        address admin_,
         AccessControlManager accessControlManager_,
         RiskManagementInit memory riskManagement
     ) public initializer {
@@ -83,7 +83,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
-        address payable admin_,
+        address admin_,
         AccessControlManager accessControlManager_,
         VTokenInterface.RiskManagementInit memory riskManagement
     ) internal onlyInitializing {
@@ -569,7 +569,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     function redeem(uint256 redeemTokens) external override nonReentrant returns (uint256) {
         accrueInterest();
         // _redeemFresh emits redeem-specific logs on errors, so we don't need to
-        _redeemFresh(payable(msg.sender), redeemTokens, 0);
+        _redeemFresh(msg.sender, redeemTokens, 0);
         return NO_ERROR;
     }
 
@@ -582,7 +582,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     function redeemUnderlying(uint256 redeemAmount) external override nonReentrant returns (uint256) {
         accrueInterest();
         // _redeemFresh emits redeem-specific logs on errors, so we don't need to
-        _redeemFresh(payable(msg.sender), 0, redeemAmount);
+        _redeemFresh(msg.sender, 0, redeemAmount);
         return NO_ERROR;
     }
 
@@ -594,7 +594,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @param redeemAmountIn The number of underlying tokens to receive from redeeming vTokens (only one of redeemTokensIn or redeemAmountIn may be non-zero)
      */
     function _redeemFresh(
-        address payable redeemer,
+        address redeemer,
         uint256 redeemTokensIn,
         uint256 redeemAmountIn
     ) internal {
@@ -678,7 +678,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     function borrow(uint256 borrowAmount) external override nonReentrant returns (uint256) {
         accrueInterest();
         // borrowFresh emits borrow-specific logs on errors, so we don't need to
-        _borrowFresh(payable(msg.sender), borrowAmount);
+        _borrowFresh(msg.sender, borrowAmount);
         return NO_ERROR;
     }
 
@@ -686,7 +686,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @notice Users borrow assets from the protocol to their own address
      * @param borrowAmount The amount of the underlying asset to borrow
      */
-    function _borrowFresh(address payable borrower, uint256 borrowAmount) internal {
+    function _borrowFresh(address borrower, uint256 borrowAmount) internal {
         /* Fail if borrow not allowed */
         comptroller.preBorrowHook(address(this), borrower, borrowAmount);
 
@@ -1429,7 +1429,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
     /**
      * @dev Just a regular ERC-20 transfer, reverts on failure
      */
-    function _doTransferOut(address payable to, uint256 amount) internal virtual {
+    function _doTransferOut(address to, uint256 amount) internal virtual {
         IERC20Upgradeable token = IERC20Upgradeable(underlying);
         token.safeTransfer(to, amount);
     }

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -259,7 +259,7 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
 
         transferAllowances[src][spender] = currentAllowance;
 
-         emit Approval(src, spender, currentAllowance);
+        emit Approval(src, spender, currentAllowance);
         return true;
     }
 

--- a/contracts/test/VTokenHarness.sol
+++ b/contracts/test/VTokenHarness.sol
@@ -39,7 +39,7 @@ contract VTokenHarness is VToken {
         );
     }
 
-    function _doTransferOut(address payable to, uint256 amount) internal override {
+    function _doTransferOut(address to, uint256 amount) internal override {
         require(failTransferToAddresses[to] == false, "HARNESS_TOKEN_TRANSFER_OUT_FAILED");
         return super._doTransferOut(to, amount);
     }

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -21,5 +21,4 @@ export const scaleDownBy = (amount: string | number, decimals: number) => {
   return new BigNumber(amount).dividedBy(new BigNumber(10).pow(decimals)).toString();
 };
 
-
-export const AddressOne = "0x0000000000000000000000000000000000000001"
+export const AddressOne = "0x0000000000000000000000000000000000000001";

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -20,3 +20,6 @@ export const convertToUnit = (amount: string | number, decimals: number) => {
 export const scaleDownBy = (amount: string | number, decimals: number) => {
   return new BigNumber(amount).dividedBy(new BigNumber(10).pow(decimals)).toString();
 };
+
+
+export const AddressOne = "0x0000000000000000000000000000000000000001"

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -138,7 +138,7 @@ const riskFundFixture = async (): Promise<void> => {
     to: shortfall.address,
     value: ethers.utils.parseEther("1"), // 1 ether
   });
-  await shortfall.convertibleBaseAsset.returns(BUSD.address)
+  await shortfall.convertibleBaseAsset.returns(BUSD.address);
 
   const RiskFund = await ethers.getContractFactory("RiskFund");
   riskFund = await upgrades.deployProxy(RiskFund, [
@@ -524,9 +524,11 @@ describe("Risk Fund: Tests", function () {
 
       it("emits ShortfallContractUpdated event", async function () {
         const newShortfall = await smock.fake<Shortfall>("Shortfall");
-        await newShortfall.convertibleBaseAsset.returns(BUSD.address)
+        await newShortfall.convertibleBaseAsset.returns(BUSD.address);
         const tx = riskFund.setShortfallContractAddress(newShortfall.address);
-        await expect(tx).to.emit(riskFund, "ShortfallContractUpdated").withArgs(shortfall.address, newShortfall.address);
+        await expect(tx)
+          .to.emit(riskFund, "ShortfallContractUpdated")
+          .withArgs(shortfall.address, newShortfall.address);
       });
     });
 
@@ -778,8 +780,8 @@ describe("Risk Fund: Tests", function () {
 
     it("Should revert the transfer to auction transaction", async function () {
       const [admin] = await ethers.getSigners();
-      const auctionContract = await smock.fake<Shortfall>("Shortfall");;
-      await auctionContract.convertibleBaseAsset.returns(BUSD.address)
+      const auctionContract = await smock.fake<Shortfall>("Shortfall");
+      await auctionContract.convertibleBaseAsset.returns(BUSD.address);
       await riskFund.setShortfallContractAddress(auctionContract.address);
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
@@ -823,9 +825,9 @@ describe("Risk Fund: Tests", function () {
     });
 
     it("Transfer single asset from multiple pools to riskFund.", async function () {
-      const auctionContract = await smock.fake<Shortfall>("Shortfall");;
-      await auctionContract.convertibleBaseAsset.returns(BUSD.address)
-      
+      const auctionContract = await smock.fake<Shortfall>("Shortfall");
+      await auctionContract.convertibleBaseAsset.returns(BUSD.address);
+
       await riskFund.setShortfallContractAddress(auctionContract.address);
 
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -153,7 +153,7 @@ const riskFundFixture = async (): Promise<void> => {
   const ProtocolShareReserve = await ethers.getContractFactory("ProtocolShareReserve");
   protocolShareReserve = await upgrades.deployProxy(ProtocolShareReserve, [
     fakeProtocolIncome.address,
-    riskFund.address,
+    riskFund.address
   ]);
 
   const PoolRegistry = await ethers.getContractFactory("PoolRegistry");
@@ -165,6 +165,8 @@ const riskFundFixture = async (): Promise<void> => {
     riskFund.address,
     protocolShareReserve.address,
   ]);
+
+  await protocolShareReserve.setPoolRegistry(poolRegistry.address);
 
   await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
@@ -631,6 +633,7 @@ describe("Risk Fund: Tests", function () {
     });
 
     it("Below min threshold amount", async function () {
+
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
       await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -153,7 +153,7 @@ const riskFundFixture = async (): Promise<void> => {
   const ProtocolShareReserve = await ethers.getContractFactory("ProtocolShareReserve");
   protocolShareReserve = await upgrades.deployProxy(ProtocolShareReserve, [
     fakeProtocolIncome.address,
-    riskFund.address
+    riskFund.address,
   ]);
 
   const PoolRegistry = await ethers.getContractFactory("PoolRegistry");
@@ -633,7 +633,6 @@ describe("Risk Fund: Tests", function () {
     });
 
     it("Below min threshold amount", async function () {
-
       await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
 
       await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -120,11 +120,7 @@ const riskFundFixture = async (): Promise<void> => {
   fakeAccessControlManager.isAllowedToCall.returns(true);
 
   const Shortfall = await ethers.getContractFactory("Shortfall");
-  const shortfall = await upgrades.deployProxy(Shortfall, [
-    BUSD.address,
-    AddressOne,
-    parseUnits("10000", 18),
-  ]);
+  const shortfall = await upgrades.deployProxy(Shortfall, [BUSD.address, AddressOne, parseUnits("10000", 18)]);
 
   const RiskFund = await ethers.getContractFactory("RiskFund");
   riskFund = await upgrades.deployProxy(RiskFund, [

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -153,6 +153,8 @@ const riskFundFixture = async (): Promise<void> => {
     protocolShareReserve.address,
   ]);
 
+  await protocolShareReserve.setPoolRegistry(poolRegistry.address)
+
   await shortfall.setPoolRegistry(poolRegistry.address);
 
   const Comptroller = await ethers.getContractFactory("Comptroller");

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -121,7 +121,7 @@ const riskFundFixture = async (): Promise<void> => {
 
   const Shortfall = await ethers.getContractFactory("Shortfall");
   const shortfall = await upgrades.deployProxy(Shortfall, [
-    AddressOne,
+    BUSD.address,
     AddressOne,
     parseUnits("10000", 18),
   ]);

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
-import { convertToUnit } from "../../../helpers/utils";
+import { AddressOne, convertToUnit } from "../../../helpers/utils";
 import {
   AccessControlManager,
   Beacon,
@@ -121,8 +121,8 @@ const riskFundFixture = async (): Promise<void> => {
 
   const Shortfall = await ethers.getContractFactory("Shortfall");
   const shortfall = await upgrades.deployProxy(Shortfall, [
-    ethers.constants.AddressZero,
-    ethers.constants.AddressZero,
+    AddressOne,
+    AddressOne,
     parseUnits("10000", 18),
   ]);
 

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -153,7 +153,7 @@ const riskFundFixture = async (): Promise<void> => {
     protocolShareReserve.address,
   ]);
 
-  await protocolShareReserve.setPoolRegistry(poolRegistry.address)
+  await protocolShareReserve.setPoolRegistry(poolRegistry.address);
 
   await shortfall.setPoolRegistry(poolRegistry.address);
 

--- a/tests/hardhat/ProtocolShareReserve.ts
+++ b/tests/hardhat/ProtocolShareReserve.ts
@@ -20,7 +20,7 @@ const fixture = async (): Promise<void> => {
 
   // Fake contracts
   fakeRiskFund = await smock.fake<RiskFund>("RiskFund");
-  fakeRiskFund.updateAssetsState(() => {})
+  await fakeRiskFund.updateAssetsState.returns();
 
   poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
   poolRegistry.getVTokenForAsset.returns("0x0000000000000000000000000000000000000001");

--- a/tests/hardhat/ProtocolShareReserve.ts
+++ b/tests/hardhat/ProtocolShareReserve.ts
@@ -4,10 +4,11 @@ import { expect } from "chai";
 import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../helpers/utils";
-import { Comptroller, MockToken, ProtocolShareReserve, RiskFund } from "../../typechain";
+import { Comptroller, MockToken, PoolRegistry, ProtocolShareReserve, RiskFund } from "../../typechain";
 
 let mockDAI: MockToken;
 let fakeRiskFund: FakeContract<RiskFund>;
+let poolRegistry: FakeContract<PoolRegistry>;
 let fakeProtocolIncome: FakeContract<RiskFund>;
 let fakeComptroller: FakeContract<Comptroller>;
 let protocolShareReserve: ProtocolShareReserve;
@@ -19,6 +20,11 @@ const fixture = async (): Promise<void> => {
 
   // Fake contracts
   fakeRiskFund = await smock.fake<RiskFund>("RiskFund");
+  fakeRiskFund.updateAssetsState(() => {})
+
+  poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
+  poolRegistry.getVTokenForAsset.returns("0x0000000000000000000000000000000000000001");
+
   fakeProtocolIncome = await smock.fake<RiskFund>("RiskFund");
   fakeComptroller = await smock.fake<Comptroller>("Comptroller");
 
@@ -28,6 +34,8 @@ const fixture = async (): Promise<void> => {
     fakeProtocolIncome.address,
     fakeRiskFund.address,
   ]);
+
+  await protocolShareReserve.setPoolRegistry(poolRegistry.address);
 };
 
 describe("ProtocolShareReserve: Tests", function () {

--- a/tests/hardhat/Tokens/transferTest.ts
+++ b/tests/hardhat/Tokens/transferTest.ts
@@ -46,6 +46,26 @@ describe("VToken", function () {
       await expect(vToken.transfer(rootAddress, 50)).to.be.revertedWithCustomError(vToken, "TransferNotAllowed");
     });
 
+    it("approve and transfer", async () => {
+      await vToken.harnessSetBalance(rootAddress, 1000);
+      expect(await vToken.balanceOf(rootAddress)).to.equal(1000);
+      await vToken.approve(guyAddress, 100)
+
+      await expect(vToken.connect(guy).transferFrom(rootAddress, guyAddress, 120)).to.be.reverted;
+
+      await vToken.increaseAllowance(guy.getAddress(), 20)
+      await expect(vToken.connect(guy).transferFrom(rootAddress, guyAddress, 120)).to.be.not.reverted;
+      expect(await vToken.balanceOf(guyAddress)).to.equal(120);
+
+      await vToken.approve(guyAddress, 100)
+      await vToken.decreaseAllowance(guy.getAddress(), 20)
+
+      await expect(vToken.connect(guy).transferFrom(rootAddress, guyAddress, 100)).to.be.reverted;
+      await expect(vToken.connect(guy).transferFrom(rootAddress, guyAddress, 80)).to.be.not.reverted;
+
+      expect(await vToken.balanceOf(guyAddress)).to.equal(200);
+    });
+
     it("rejects transfer when not allowed", async () => {
       await vToken.harnessSetBalance(rootAddress, 100);
       expect(await vToken.balanceOf(rootAddress)).to.equal(100);
@@ -53,5 +73,7 @@ describe("VToken", function () {
       comptroller.preTransferHook.reverts();
       await expect(vToken.transfer(rootAddress, 50)).to.be.reverted;
     });
+
+    
   });
 });

--- a/tests/hardhat/Tokens/transferTest.ts
+++ b/tests/hardhat/Tokens/transferTest.ts
@@ -49,16 +49,16 @@ describe("VToken", function () {
     it("approve and transfer", async () => {
       await vToken.harnessSetBalance(rootAddress, 1000);
       expect(await vToken.balanceOf(rootAddress)).to.equal(1000);
-      await vToken.approve(guyAddress, 100)
+      await vToken.approve(guyAddress, 100);
 
       await expect(vToken.connect(guy).transferFrom(rootAddress, guyAddress, 120)).to.be.reverted;
 
-      await vToken.increaseAllowance(guy.getAddress(), 20)
+      await vToken.increaseAllowance(guy.getAddress(), 20);
       await expect(vToken.connect(guy).transferFrom(rootAddress, guyAddress, 120)).to.be.not.reverted;
       expect(await vToken.balanceOf(guyAddress)).to.equal(120);
 
-      await vToken.approve(guyAddress, 100)
-      await vToken.decreaseAllowance(guy.getAddress(), 20)
+      await vToken.approve(guyAddress, 100);
+      await vToken.decreaseAllowance(guy.getAddress(), 20);
 
       await expect(vToken.connect(guy).transferFrom(rootAddress, guyAddress, 100)).to.be.reverted;
       await expect(vToken.connect(guy).transferFrom(rootAddress, guyAddress, 80)).to.be.not.reverted;
@@ -73,7 +73,5 @@ describe("VToken", function () {
       comptroller.preTransferHook.reverts();
       await expect(vToken.transfer(rootAddress, 50)).to.be.reverted;
     });
-
-    
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

Resolves the following Certik report fixes:

- VEN-962 VTV-03 | Approval Race Condition
- VEN-965 VPB-15 | Unneccessary Use of Payable Casting
- VEN-972 VPB-12 | Missing Access Restriction
- VEN-971 VPB-11 | Missing or Unused Emit Events
- VEN-968 JRM-01 | Unnecessary Inheritance
- VEN-955 VPB-04 | Interfaces Not Inherited And Improper/Missing Implementation
- VEN-916 VTV-02 | `mintBehalf()` Can Mint Tokens to the Zero Address
- VEN-958 VPB-06 | Missing Zero Address Validation
- VEN-960 VPB-08 | Changing `convertibleBaseAsset` Can Cause Issues

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
