### PR TITLE
fix: prevent decimals underflow in exchange rate computation

### DIFF
--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -223,7 +223,7 @@ contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
             input.asset,
             comptroller,
             rate,
-            10**(underlyingDecimals - 8 + 18),
+            10**(underlyingDecimals + 18 - input.decimals),
             input.name,
             input.symbol,
             input.decimals,


### PR DESCRIPTION
**Problem:** The code fails for tokens with underlying decimals < 8. Additionally, the code assumes that vTokens always have 8 decimals, and although it's a correct assumption, we should have a protection in case someone configures input.decimals to be a different number.

**Solution:** Change the order of operations and replace 8 with the provided decimals value.