### PR TITLE
[VEN-1092] import ERC20 abit from openzeppelin build

### DIFF
--- a/deploy/006-riskfund-protocolshare.ts
+++ b/deploy/006-riskfund-protocolshare.ts
@@ -1,10 +1,10 @@
+import * as ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
 import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { getConfig, getTokenConfig } from "../helpers/deploymentConfig";
 import { convertToUnit } from "../helpers/utils";
-import { ERC20__factory } from "../typechain/factories/ERC20__factory";
 
 const MIN_AMOUNT_TO_CONVERT = convertToUnit(10, 18);
 const MIN_POOL_BAD_DEBT = convertToUnit(1000, 18);
@@ -21,7 +21,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (busdConfig.isMock) {
     BUSD = await ethers.getContract("MockBUSD");
   } else {
-    BUSD = await ethers.getContractAt(ERC20__factory.abi, busdConfig.tokenAddress);
+    BUSD = await ethers.getContractAt(ERC20.abi, busdConfig.tokenAddress);
   }
 
   const swapRouter = await ethers.getContract("SwapRouter");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "strict": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true
   },
   "include": ["./typechain", "./deploy", "./helpers"],
   "files": ["./hardhat.config.ts"]


### PR DESCRIPTION
## Description

This PR replaces the ERC20 artifact to not use typechain, but the prebuilt contract of OZ, thus increasing usability of the deployment scripts from other packages.

Resolves #[VEN-1092]

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
