### PR TITLE
[VEN-967] Moved variables from comptroller to comptroller storage.

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -21,12 +21,6 @@ contract Comptroller is
     ExponentialNoError,
     MaxLoopsLimitHelper
 {
-    // List of Reward Distributors added
-    RewardsDistributor[] private rewardsDistributors;
-
-    // Used to check if rewards distributor is added
-    mapping(address => bool) private rewardsDistributorExists;
-
     /// @notice Emitted when an account enters a market
     event MarketEntered(VToken vToken, address account);
 

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -94,6 +94,12 @@ contract ComptrollerStorage {
     /// @notice True if a certain action is paused on a certain market
     mapping(address => mapping(Action => bool)) internal _actionPaused;
 
+    // List of Reward Distributors added
+    RewardsDistributor[] internal rewardsDistributors;
+
+    // Used to check if rewards distributor is added
+    mapping(address => bool) internal rewardsDistributorExists;
+
     uint256 internal constant NO_ERROR = 0;
 
     // closeFactorMantissa must be strictly greater than this value


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

Resolves:
- CVP-05 | Storage Variables Declared Outside of `ComptrollerV1Storage

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
