### PR TITLE
[VEN-953] Enhance access control mechanisms

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -715,7 +715,8 @@ contract Comptroller is
      * @custom:event Emits NewCloseFactor on success
      * @custom:access Only Governance
      */
-    function setCloseFactor(uint256 newCloseFactorMantissa) external onlyOwner {
+    function setCloseFactor(uint256 newCloseFactorMantissa) external {
+        _checkAccessAllowed("setCloseFactor(uint256)");
         require(closeFactorMaxMantissa >= newCloseFactorMantissa, "Close factor greater than maximum close factor");
         require(closeFactorMinMantissa <= newCloseFactorMantissa, "Close factor smaller than minimum close factor");
 

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -16,6 +16,7 @@ import "./MaxLoopsLimitHelper.sol";
  */
 contract Comptroller is
     Ownable2StepUpgradeable,
+    AccessControlled,
     ComptrollerStorage,
     ComptrollerInterface,
     ExponentialNoError,
@@ -70,9 +71,6 @@ contract Comptroller is
     /// @notice Thrown when liquidation threshold exceeds the collateral factor
     error InvalidLiquidationThreshold();
 
-    /// @notice Thrown when the action is prohibited by AccessControlManager
-    error Unauthorized(address sender, address calledContract, string methodSignature);
-
     /// @notice Thrown when the action is only available to specific sender, but the real sender was different
     error UnexpectedSender(address expectedSender, address actualSender);
 
@@ -122,19 +120,24 @@ contract Comptroller is
     error BorrowCapExceeded(address market, uint256 cap);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address poolRegistry_, address accessControl_) ComptrollerStorage(poolRegistry_, accessControl_) {
+    constructor(address poolRegistry_) ComptrollerStorage(poolRegistry_) {
         _disableInitializers();
     }
 
     /**
      * @param loopLimit Limit for the loops can iterate to avoid the DOS
+     * @param accessControlManager Access control manager contract address
      */
-    function initialize(uint256 loopLimit) external initializer {
+    function initialize(uint256 loopLimit, address accessControlManager) external initializer {
         __Ownable2Step_init();
+        __AccessControlled_init_unchained(accessControlManager);
 
         _setMaxLoopsLimit(loopLimit);
     }
 
+    /**
+     * @notice A marker method that returns true for a valid Comptroller contract
+     */
     function isComptroller() external pure override returns (bool) {
         return _isComptroller;
     }
@@ -1424,16 +1427,6 @@ contract Comptroller is
             revert SnapshotError(address(vToken), user);
         }
         return (vTokenBalance, borrowBalance, exchangeRateMantissa);
-    }
-
-    /// @notice Reverts if the call is not allowed by AccessControlManager
-    /// @param signature Method signature
-    function _checkAccessAllowed(string memory signature) internal view {
-        bool isAllowedToCall = AccessControlManager(accessControl).isAllowedToCall(msg.sender, signature);
-
-        if (!isAllowedToCall) {
-            revert Unauthorized(msg.sender, address(this), signature);
-        }
     }
 
     /// @notice Reverts if the call is not from expectedSender

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -118,10 +118,6 @@ contract ComptrollerStorage {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable poolRegistry;
 
-    // AccessControlManager, immutable to save on gas
-    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-    address public immutable accessControl;
-
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
@@ -130,14 +126,11 @@ contract ComptrollerStorage {
     uint256[50] private __gap;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address poolRegistry_, address accessControl_) {
+    constructor(address poolRegistry_) {
         // Note that the contract is upgradeable. We only initialize immutables in the
         // constructor. Use initialize() or reinitializers to set the state variables.
-
         require(poolRegistry_ != address(0), "invalid pool registry address");
-        require(accessControl_ != address(0), "invalid access control address");
 
         poolRegistry = poolRegistry_;
-        accessControl = accessControl_;
     }
 }

--- a/contracts/ErrorReporter.sol
+++ b/contracts/ErrorReporter.sol
@@ -41,10 +41,8 @@ contract TokenErrorReporter {
 
     error SetComptrollerOwnerCheck();
 
-    error SetProtocolSeizeShareUnauthorized();
     error ProtocolSeizeShareTooBig();
 
-    error SetReserveFactorAdminCheck();
     error SetReserveFactorFreshCheck();
     error SetReserveFactorBoundsCheck();
 
@@ -55,6 +53,5 @@ contract TokenErrorReporter {
     error ReduceReservesCashNotAvailable();
     error ReduceReservesCashValidation();
 
-    error SetInterestRateModelOwnerCheck();
     error SetInterestRateModelFreshCheck();
 }

--- a/contracts/Factories/JumpRateModelFactory.sol
+++ b/contracts/Factories/JumpRateModelFactory.sol
@@ -9,14 +9,14 @@ contract JumpRateModelFactory {
         uint256 multiplierPerYear,
         uint256 jumpMultiplierPerYear,
         uint256 kink_,
-        address owner_
+        IAccessControlManager accessControlManager_
     ) external returns (JumpRateModelV2) {
         JumpRateModelV2 rate = new JumpRateModelV2(
             baseRatePerYear,
             multiplierPerYear,
             jumpMultiplierPerYear,
             kink_,
-            owner_
+            accessControlManager_
         );
 
         return rate;

--- a/contracts/Governance/AccessControlManager.sol
+++ b/contracts/Governance/AccessControlManager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./IAccessControlManager.sol";
 
 /**
  * @title Venus Access Control Contract
@@ -9,7 +10,7 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
  *		extending it in a way to standartize access control
  *		within Venus Smart Contract Ecosystem
  */
-contract AccessControlManager is AccessControl {
+contract AccessControlManager is AccessControl, IAccessControlManager {
     /// @notice Emitted when an account is given a permission to a certain contract function
     /// @dev If contract address is 0x000..0 this means that the account is a default admin of this function and
     /// can call any contract function with this signature

--- a/contracts/Governance/AccessControlled.sol
+++ b/contracts/Governance/AccessControlled.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+
+import "./IAccessControlManager.sol";
+
+abstract contract AccessControlled is Initializable, Ownable2StepUpgradeable {
+    /// @notice Access control manager contract
+    IAccessControlManager private _accessControlManager;
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[49] private __gap;
+
+    /// @notice Emitted when access control manager contract address is changed
+    event NewAccessControlManager(address oldAccessControlManager, address newAccessControlManager);
+
+    /// @notice Thrown when the action is prohibited by AccessControlManager
+    error Unauthorized(address sender, address calledContract, string methodSignature);
+
+    function __AccessControlled_init(address accessControlManager_) internal onlyInitializing {
+        __Ownable2Step_init();
+        __AccessControlled_init_unchained(accessControlManager_);
+    }
+
+    function __AccessControlled_init_unchained(address accessControlManager_) internal onlyInitializing {
+        _setAccessControlManager(accessControlManager_);
+    }
+
+    /**
+     * @notice Sets the address of AccessControlManager
+     * @dev Admin function to set address of AccessControlManager
+     * @param accessControlManager_ The new address of the AccessControlManager
+     * @custom:event Emits NewAccessControlManager event
+     * @custom:access Only Governance
+     */
+    function setAccessControlManager(address accessControlManager_) external onlyOwner {
+        _setAccessControlManager(accessControlManager_);
+    }
+
+    /**
+     * @notice Returns the address of the access control manager contract
+     */
+    function accessControlManager() external view returns (IAccessControlManager) {
+        return _accessControlManager;
+    }
+
+    /**
+     * @dev Internal function to set address of AccessControlManager
+     * @param accessControlManager_ The new address of the AccessControlManager
+     */
+    function _setAccessControlManager(address accessControlManager_) internal {
+        require(address(accessControlManager_) != address(0), "invalid acess control manager address");
+        address oldAccessControlManager = address(_accessControlManager);
+        _accessControlManager = IAccessControlManager(accessControlManager_);
+        emit NewAccessControlManager(oldAccessControlManager, accessControlManager_);
+    }
+
+    /**
+     * @notice Reverts if the call is not allowed by AccessControlManager
+     * @param signature Method signature
+     */
+    function _checkAccessAllowed(string memory signature) internal view {
+        bool isAllowedToCall = _accessControlManager.isAllowedToCall(msg.sender, signature);
+
+        if (!isAllowedToCall) {
+            revert Unauthorized(msg.sender, address(this), signature);
+        }
+    }
+}

--- a/contracts/Governance/IAccessControlManager.sol
+++ b/contracts/Governance/IAccessControlManager.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+
+import "@openzeppelin/contracts/access/IAccessControl.sol";
+
+interface IAccessControlManager is IAccessControl {
+    function giveCallPermission(
+        address contractAddress,
+        string calldata functionSig,
+        address accountToPermit
+    ) external;
+
+    function revokeCallPermission(
+        address contractAddress,
+        string calldata functionSig,
+        address accountToRevoke
+    ) external;
+
+    function isAllowedToCall(address account, string calldata functionSig) external view returns (bool);
+
+    function hasPermission(
+        address account,
+        address contractAddress,
+        string calldata functionSig
+    ) external view returns (bool);
+}

--- a/contracts/JumpRateModelV2.sol
+++ b/contracts/JumpRateModelV2.sol
@@ -14,8 +14,8 @@ contract JumpRateModelV2 is BaseJumpRateModelV2 {
         uint256 multiplierPerYear,
         uint256 jumpMultiplierPerYear,
         uint256 kink_,
-        address owner_
-    ) BaseJumpRateModelV2(baseRatePerYear, multiplierPerYear, jumpMultiplierPerYear, kink_, owner_) {}
+        IAccessControlManager accessControlManager_
+    ) BaseJumpRateModelV2(baseRatePerYear, multiplierPerYear, jumpMultiplierPerYear, kink_, accessControlManager_) {}
 
     /**
      * @notice Calculates the current borrow rate per block
@@ -29,6 +29,6 @@ contract JumpRateModelV2 is BaseJumpRateModelV2 {
         uint256 borrows,
         uint256 reserves
     ) external view override returns (uint256) {
-        return getBorrowRateInternal(cash, borrows, reserves);
+        return _getBorrowRate(cash, borrows, reserves);
     }
 }

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -218,7 +218,7 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlled, PoolRegistry
                     input.multiplierPerYear,
                     input.jumpMultiplierPerYear,
                     input.kink_,
-                    msg.sender
+                    input.accessControlManager
                 )
             );
         } else {

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -163,7 +163,8 @@ contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
         uint256 liquidationIncentive,
         uint256 minLiquidatableCollateral,
         address priceOracle,
-        uint256 maxLoopsLimit
+        uint256 maxLoopsLimit,
+        address accessControlManager
     ) external virtual onlyOwner returns (uint256 index, address proxyAddress) {
         // Input validation
         require(beaconAddress != address(0), "RegistryPool: Invalid Comptroller beacon address.");
@@ -171,7 +172,7 @@ contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
 
         BeaconProxy proxy = new BeaconProxy(
             beaconAddress,
-            abi.encodeWithSelector(Comptroller.initialize.selector, maxLoopsLimit)
+            abi.encodeWithSelector(Comptroller.initialize.selector, maxLoopsLimit, accessControlManager)
         );
 
         proxyAddress = address(proxy);

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -22,7 +22,7 @@ import "./PoolRegistryInterface.sol";
  * @title PoolRegistry
  * @notice PoolRegistry is a registry for Venus interest rate pools.
  */
-contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
+contract PoolRegistry is Ownable2StepUpgradeable, AccessControlled, PoolRegistryInterface {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     enum InterestRateModels {
@@ -126,6 +126,7 @@ contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
      * @param _whitePaperFactory white paper factory address.
      * @param riskFund_ risk fund address.
      * @param protocolShareReserve_ protocol's shares reserve address.
+     * @param accessControlManager_ AccessControlManager contract address.
      */
     function initialize(
         VTokenProxyFactory _vTokenFactory,
@@ -133,9 +134,11 @@ contract PoolRegistry is Ownable2StepUpgradeable, PoolRegistryInterface {
         WhitePaperInterestRateModelFactory _whitePaperFactory,
         Shortfall _shortfall,
         address payable riskFund_,
-        address payable protocolShareReserve_
+        address payable protocolShareReserve_,
+        address accessControlManager_
     ) external initializer {
         __Ownable2Step_init();
+        __AccessControlled_init_unchained(accessControlManager_);
 
         vTokenFactory = _vTokenFactory;
         jumpRateFactory = _jumpRateFactory;

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -168,7 +168,8 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlled, PoolRegistry
         address priceOracle,
         uint256 maxLoopsLimit,
         address accessControlManager
-    ) external virtual onlyOwner returns (uint256 index, address proxyAddress) {
+    ) external virtual returns (uint256 index, address proxyAddress) {
+        _checkAccessAllowed("createRegistryPool(string,address,uint256,uint256,uint256,address,uint256,address)");
         // Input validation
         require(beaconAddress != address(0), "RegistryPool: Invalid Comptroller beacon address.");
         require(priceOracle != address(0), "RegistryPool: Invalid PriceOracle address.");
@@ -199,7 +200,8 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlled, PoolRegistry
     /**
      * @notice Add a market to an existing pool and then mint to provide initial supply.
      */
-    function addMarket(AddMarketInput memory input) external onlyOwner {
+    function addMarket(AddMarketInput memory input) external {
+        _checkAccessAllowed("addMarket(AddMarketInput)");
         require(input.comptroller != address(0), "RegistryPool: Invalid comptroller address");
         require(input.asset != address(0), "RegistryPool: Invalid asset address");
 
@@ -273,7 +275,8 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlled, PoolRegistry
     /**
      * @notice Modify existing Venus pool name.
      */
-    function setPoolName(address comptroller, string calldata name) external onlyOwner {
+    function setPoolName(address comptroller, string calldata name) external {
+        _checkAccessAllowed("setPoolName(address,string)");
         string memory oldName = _poolByComptroller[comptroller].name;
         _poolByComptroller[comptroller].name = name;
         emit PoolNameSet(comptroller, oldName, name);
@@ -282,7 +285,8 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlled, PoolRegistry
     /**
      * @notice Update metadata of an existing pool.
      */
-    function updatePoolMetadata(address comptroller, VenusPoolMetaData memory _metadata) external onlyOwner {
+    function updatePoolMetadata(address comptroller, VenusPoolMetaData memory _metadata) external {
+        _checkAccessAllowed("updatePoolMetadata(address,VenusPoolMetaData)");
         VenusPoolMetaData memory oldMetadata = metadata[comptroller];
         metadata[comptroller] = _metadata;
         emit PoolMetadataUpdated(comptroller, oldMetadata, _metadata);

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -198,7 +198,8 @@ contract RewardsDistributor is ExponentialNoError, Ownable2StepUpgradeable, Acce
         VToken[] memory vTokens,
         uint256[] memory supplySpeeds,
         uint256[] memory borrowSpeeds
-    ) external onlyOwner {
+    ) external {
+        _checkAccessAllowed("setRewardTokenSpeeds(address[],uint256[],uint256[])");
         uint256 numTokens = vTokens.length;
         require(
             numTokens == supplySpeeds.length && numTokens == borrowSpeeds.length,

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -7,8 +7,9 @@ import "../ExponentialNoError.sol";
 import "../VToken.sol";
 import "../Comptroller.sol";
 import "../MaxLoopsLimitHelper.sol";
+import "../Governance/AccessControlled.sol";
 
-contract RewardsDistributor is ExponentialNoError, Ownable2StepUpgradeable, MaxLoopsLimitHelper {
+contract RewardsDistributor is ExponentialNoError, Ownable2StepUpgradeable, AccessControlled, MaxLoopsLimitHelper {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     struct RewardToken {
@@ -108,15 +109,17 @@ contract RewardsDistributor is ExponentialNoError, Ownable2StepUpgradeable, MaxL
      * @dev Initializes the deployer to owner.
      */
     function initialize(
-        Comptroller _comptroller,
-        IERC20Upgradeable _rewardToken,
-        uint256 _loopsLimit
+        Comptroller comptroller_,
+        IERC20Upgradeable rewardToken_,
+        uint256 loopsLimit_,
+        address accessControlManager_
     ) external initializer {
-        comptroller = _comptroller;
-        rewardToken = _rewardToken;
+        comptroller = comptroller_;
+        rewardToken = rewardToken_;
         __Ownable2Step_init();
+        __AccessControlled_init_unchained(accessControlManager_);
 
-        _setMaxLoopsLimit(_loopsLimit);
+        _setMaxLoopsLimit(loopsLimit_);
     }
 
     function initializeMarket(address vToken) external onlyComptroller {

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -134,7 +134,8 @@ contract RiskFund is
      * @dev Min amount to convert setter
      * @param minAmountToConvert_ Min amount to convert.
      */
-    function setMinAmountToConvert(uint256 minAmountToConvert_) external onlyOwner {
+    function setMinAmountToConvert(uint256 minAmountToConvert_) external {
+        _checkAccessAllowed("setMinAmountToConvert(uint256)");
         require(minAmountToConvert_ > 0, "Risk Fund: Invalid min amount to convert");
         uint256 oldMinAmountToConvert = minAmountToConvert;
         minAmountToConvert = minAmountToConvert_;

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -10,19 +10,25 @@ import "../IPancakeswapV2Router.sol";
 import "./ReserveHelpers.sol";
 import "./IRiskFund.sol";
 import "../Shortfall/IShortfall.sol";
-
+import "../Governance/AccessControlled.sol";
 import "../MaxLoopsLimitHelper.sol";
 
 /**
  * @dev This contract does not support BNB.
  */
-contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers, MaxLoopsLimitHelper, IRiskFund {
+contract RiskFund is
+    Ownable2StepUpgradeable,
+    AccessControlled,
+    ExponentialNoError,
+    ReserveHelpers,
+    MaxLoopsLimitHelper,
+    IRiskFund
+{
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     address private pancakeSwapRouter;
     uint256 private minAmountToConvert;
     address private convertibleBaseAsset;
-    address private accessControl;
     address private shortfall;
 
     // Store base asset's reserve for specific pool
@@ -58,32 +64,32 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
 
     /**
      * @dev Initializes the deployer to owner.
-     * @param _pancakeSwapRouter Address of the PancakeSwap router
-     * @param _minAmountToConvert Minimum amount assets must be worth to convert into base asset
-     * @param _convertibleBaseAsset Address of the base asset
-     * @param _accessControl Address of the access control contract.
+     * @param pancakeSwapRouter_ Address of the PancakeSwap router
+     * @param minAmountToConvert_ Minimum amount assets must be worth to convert into base asset
+     * @param convertibleBaseAsset_ Address of the base asset
+     * @param accessControlManager_ Address of the access control contract
+     * @param loopsLimit_ Limit for the loops in the contract to avoid DOS
      */
     function initialize(
-        address _pancakeSwapRouter,
-        uint256 _minAmountToConvert,
-        address _convertibleBaseAsset,
-        address _accessControl,
-        uint256 _loopsLimit
+        address pancakeSwapRouter_,
+        uint256 minAmountToConvert_,
+        address convertibleBaseAsset_,
+        address accessControlManager_,
+        uint256 loopsLimit_
     ) external initializer {
-        require(_pancakeSwapRouter != address(0), "Risk Fund: Pancake swap address invalid");
-        require(_convertibleBaseAsset != address(0), "Risk Fund: Base asset address invalid");
-        require(_minAmountToConvert > 0, "Risk Fund: Invalid min amount to convert");
-        require(_accessControl != address(0), "Risk Fund: Access control address invalid");
-        require(_loopsLimit > 0, "Risk Fund: Loops limit can not be zero");
+        require(pancakeSwapRouter_ != address(0), "Risk Fund: Pancake swap address invalid");
+        require(convertibleBaseAsset_ != address(0), "Risk Fund: Base asset address invalid");
+        require(minAmountToConvert_ > 0, "Risk Fund: Invalid min amount to convert");
+        require(loopsLimit_ > 0, "Risk Fund: Loops limit can not be zero");
 
         __Ownable2Step_init();
+        __AccessControlled_init_unchained(accessControlManager_);
 
-        pancakeSwapRouter = _pancakeSwapRouter;
-        minAmountToConvert = _minAmountToConvert;
-        convertibleBaseAsset = _convertibleBaseAsset;
-        accessControl = _accessControl;
+        pancakeSwapRouter = pancakeSwapRouter_;
+        minAmountToConvert = minAmountToConvert_;
+        convertibleBaseAsset = convertibleBaseAsset_;
 
-        _setMaxLoopsLimit(_loopsLimit);
+        _setMaxLoopsLimit(loopsLimit_);
     }
 
     /**
@@ -99,40 +105,40 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
 
     /**
      * @dev Shortfall contract address setter
-     * @param _shortfallContractAddress Address of the auction contract.
+     * @param shortfallContractAddress_ Address of the auction contract.
      */
-    function setShortfallContractAddress(address _shortfallContractAddress) external onlyOwner {
-        require(_shortfallContractAddress != address(0), "Risk Fund: Shortfall contract address invalid");
+    function setShortfallContractAddress(address shortfallContractAddress_) external onlyOwner {
+        require(shortfallContractAddress_ != address(0), "Risk Fund: Shortfall contract address invalid");
         require(
-            IShortfall(_shortfallContractAddress).convertibleBaseAsset() == convertibleBaseAsset,
+            IShortfall(shortfallContractAddress_).convertibleBaseAsset() == convertibleBaseAsset,
             "Risk Fund: Base asset doesn't match"
         );
 
         address oldShortfallContractAddress = shortfall;
-        shortfall = _shortfallContractAddress;
-        emit ShortfallContractUpdated(oldShortfallContractAddress, _shortfallContractAddress);
+        shortfall = shortfallContractAddress_;
+        emit ShortfallContractUpdated(oldShortfallContractAddress, shortfallContractAddress_);
     }
 
     /**
      * @dev PancakeSwap router address setter
-     * @param _pancakeSwapRouter Address of the PancakeSwap router.
+     * @param pancakeSwapRouter_ Address of the PancakeSwap router.
      */
-    function setPancakeSwapRouter(address _pancakeSwapRouter) external onlyOwner {
-        require(_pancakeSwapRouter != address(0), "Risk Fund: PancakeSwap address invalid");
+    function setPancakeSwapRouter(address pancakeSwapRouter_) external onlyOwner {
+        require(pancakeSwapRouter_ != address(0), "Risk Fund: PancakeSwap address invalid");
         address oldPancakeSwapRouter = pancakeSwapRouter;
-        pancakeSwapRouter = _pancakeSwapRouter;
-        emit PancakeSwapRouterUpdated(oldPancakeSwapRouter, _pancakeSwapRouter);
+        pancakeSwapRouter = pancakeSwapRouter_;
+        emit PancakeSwapRouterUpdated(oldPancakeSwapRouter, pancakeSwapRouter_);
     }
 
     /**
      * @dev Min amount to convert setter
-     * @param _minAmountToConvert Min amount to convert.
+     * @param minAmountToConvert_ Min amount to convert.
      */
-    function setMinAmountToConvert(uint256 _minAmountToConvert) external onlyOwner {
-        require(_minAmountToConvert > 0, "Risk Fund: Invalid min amount to convert");
+    function setMinAmountToConvert(uint256 minAmountToConvert_) external onlyOwner {
+        require(minAmountToConvert_ > 0, "Risk Fund: Invalid min amount to convert");
         uint256 oldMinAmountToConvert = minAmountToConvert;
-        minAmountToConvert = _minAmountToConvert;
-        emit MinAmountToConvertUpdated(oldMinAmountToConvert, _minAmountToConvert);
+        minAmountToConvert = minAmountToConvert_;
+        emit MinAmountToConvertUpdated(oldMinAmountToConvert, minAmountToConvert_);
     }
 
     /**
@@ -146,11 +152,7 @@ contract RiskFund is Ownable2StepUpgradeable, ExponentialNoError, ReserveHelpers
         override
         returns (uint256)
     {
-        bool canSwapPoolsAsset = AccessControlManager(accessControl).isAllowedToCall(
-            msg.sender,
-            "swapPoolsAssets(address[],uint256[])"
-        );
-        require(canSwapPoolsAsset, "Risk fund: Not authorized to swap pool assets.");
+        _checkAccessAllowed("swapPoolsAssets(address[],uint256[])");
         require(poolRegistry != address(0), "Risk fund: Invalid pool registry.");
         require(markets.length == amountsOutMin.length, "Risk fund: markets and amountsOutMin are unequal lengths");
 

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -244,11 +244,27 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
     }
 
     /**
+     * @notice Start a auction when there is not currently one active
+     * @param comptroller Comptroller address of the pool
+     * @custom:event Emits AuctionStarted event on success
+     * @custom:error Unauthorized error is thrown if ACM denies the access
+     * @custom:access Controlled by AccessControlManager
+     */
+    function startAuction(address comptroller) external {
+        _checkAccessAllowed("startAuction(address)");
+        _startAuction(comptroller);
+    }
+
+    /**
      * @notice Restart an auction
      * @param comptroller Address of the pool
      * @custom:event Emits AuctionRestarted event on successful restart
+     * @custom:error Unauthorized error is thrown if ACM denies the access
+     * @custom:access Controlled by AccessControlManager
      */
     function restartAuction(address comptroller) external {
+        _checkAccessAllowed("restartAuction(address)");
+
         Auction storage auction = auctions[comptroller];
 
         require(auction.startBlock != 0 && auction.status == AuctionStatus.STARTED, "no on-going auction");
@@ -260,7 +276,7 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
         auction.status = AuctionStatus.ENDED;
 
         emit AuctionRestarted(comptroller);
-        startAuction(comptroller);
+        _startAuction(comptroller);
     }
 
     /**
@@ -292,10 +308,8 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
     /**
      * @notice Start a auction when there is not currently one active
      * @param comptroller Comptroller address of the pool
-     * @custom:event Emits AuctionStarted event on success
-     * @custom:access Restricted to owner
      */
-    function startAuction(address comptroller) public onlyOwner {
+    function _startAuction(address comptroller) internal {
         PoolRegistryInterface.VenusPool memory pool = PoolRegistry(poolRegistry).getPoolByComptroller(comptroller);
         require(pool.comptroller == comptroller, "comptroller doesn't exist pool registry");
 

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -12,8 +12,9 @@ import "../RiskFund/IRiskFund.sol";
 import "./IShortfall.sol";
 import "../Pool/PoolRegistry.sol";
 import "../Pool/PoolRegistryInterface.sol";
+import "../Governance/AccessControlled.sol";
 
-contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, IShortfall {
+contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuardUpgradeable, IShortfall {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     /// @notice Type of auction
@@ -112,22 +113,27 @@ contract Shortfall is Ownable2StepUpgradeable, ReentrancyGuardUpgradeable, IShor
 
     /**
      * @notice Initalize the shortfall contract
-     * @param _minimumPoolBadDebt Minimum bad debt in BUSD for a pool to start auction
+     * @param convertibleBaseAsset_ Asset to swap the funds to
+     * @param riskFund_ RiskFund contract address
+     * @param minimumPoolBadDebt_ Minimum bad debt in base asset for a pool to start auction
+     * @param accessControlManager_ AccessControlManager contract address
      */
     function initialize(
-        address _convertibleBaseAsset,
-        IRiskFund _riskFund,
-        uint256 _minimumPoolBadDebt
+        address convertibleBaseAsset_,
+        IRiskFund riskFund_,
+        uint256 minimumPoolBadDebt_,
+        address accessControlManager_
     ) external initializer {
-        require(_convertibleBaseAsset != address(0), "invalid base asset address");
-        require(address(_riskFund) != address(0), "invalid risk fund address");
-        require(_minimumPoolBadDebt != 0, "invalid minimum pool bad debt");
+        require(convertibleBaseAsset_ != address(0), "invalid base asset address");
+        require(address(riskFund_) != address(0), "invalid risk fund address");
+        require(minimumPoolBadDebt_ != 0, "invalid minimum pool bad debt");
 
         __Ownable2Step_init();
+        __AccessControlled_init_unchained(accessControlManager_);
         __ReentrancyGuard_init();
-        minimumPoolBadDebt = _minimumPoolBadDebt;
-        convertibleBaseAsset = _convertibleBaseAsset;
-        riskFund = _riskFund;
+        minimumPoolBadDebt = minimumPoolBadDebt_;
+        convertibleBaseAsset = convertibleBaseAsset_;
+        riskFund = riskFund_;
     }
 
     /**

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -9,14 +9,14 @@ import "./VTokenInterfaces.sol";
 import "./ErrorReporter.sol";
 import "./InterestRateModel.sol";
 import "./ExponentialNoError.sol";
-import "./Governance/AccessControlManager.sol";
+import "./Governance/AccessControlled.sol";
 import "./RiskFund/IProtocolShareReserve.sol";
 
 /**
  * @title Venus VToken Contract
  * @author Venus Dev Team
  */
-contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError, TokenErrorReporter {
+contract VToken is Ownable2StepUpgradeable, AccessControlled, VTokenInterface, ExponentialNoError, TokenErrorReporter {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     /*** Reentrancy Guard ***/
@@ -59,11 +59,10 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         string memory symbol_,
         uint8 decimals_,
         address admin_,
-        AccessControlManager accessControlManager_,
+        address accessControlManager_,
         RiskManagementInit memory riskManagement
     ) external initializer {
         require(admin_ != address(0), "invalid admin address");
-        require(address(accessControlManager_) != address(0), "invalid access control manager address");
         require(riskManagement.shortfall != address(0), "invalid shortfall address");
         require(riskManagement.riskFund != address(0), "invalid riskfund address");
         require(riskManagement.protocolShareReserve != address(0), "invalid protocol share reserve address");
@@ -299,20 +298,12 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @dev must be less than liquidation incentive - 1
      * @param newProtocolSeizeShareMantissa_ new protocol share mantissa
      * @custom:event Emits NewProtocolSeizeShare event on success
-     * @custom:error SetProtocolSeizeShareUnauthorized is thrown when the call is not authorized by AccessControlManager
+     * @custom:error Unauthorized error is thrown when the call is not authorized by AccessControlManager
      * @custom:error ProtocolSeizeShareTooBig is thrown when the new seize share is too high
      * @custom:access Controlled by AccessControlManager
      */
     function setProtocolSeizeShare(uint256 newProtocolSeizeShareMantissa_) external {
-        bool canCallFunction = AccessControlManager(accessControlManager).isAllowedToCall(
-            msg.sender,
-            "setProtocolSeizeShare(uint256)"
-        );
-        // Check caller is allowed to call this function
-        if (!canCallFunction) {
-            revert SetProtocolSeizeShareUnauthorized();
-        }
-
+        _checkAccessAllowed("setProtocolSeizeShare(uint256)");
         uint256 liquidationIncentive = ComptrollerViewInterface(address(comptroller)).liquidationIncentiveMantissa();
         if (newProtocolSeizeShareMantissa_ + 1e18 > liquidationIncentive) {
             revert ProtocolSeizeShareTooBig();
@@ -327,36 +318,15 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @notice accrues interest and sets a new reserve factor for the protocol using _setReserveFactorFresh
      * @dev Admin function to accrue interest and set a new reserve factor
      * @custom:event Emits NewReserveFactor event; may emit AccrueInterest
-     * @custom:error SetReserveFactorAdminCheck is thrown when the call is not authorized by AccessControlManager
+     * @custom:error Unauthorized error is thrown when the call is not authorized by AccessControlManager
      * @custom:error SetReserveFactorBoundsCheck is thrown when the new reserve factor is too high
      * @custom:access Controlled by AccessControlManager
      */
     function setReserveFactor(uint256 newReserveFactorMantissa) external override nonReentrant {
-        bool canCallFunction = AccessControlManager(accessControlManager).isAllowedToCall(
-            msg.sender,
-            "setReserveFactor(uint256)"
-        );
-        // Check caller is allowed to call this function
-        if (!canCallFunction) {
-            revert SetReserveFactorAdminCheck();
-        }
+        _checkAccessAllowed("setReserveFactor(uint256)");
 
         accrueInterest();
         _setReserveFactorFresh(newReserveFactorMantissa);
-    }
-
-    /**
-     * @notice Sets the address of AccessControlManager
-     * @dev Admin function to set address of AccessControlManager
-     * @param newAccessControlManager The new address of the AccessControlManager
-     * @custom:event Emits NewAccessControlManager event
-     * @custom:access Only Governance
-     */
-    function setAccessControlAddress(AccessControlManager newAccessControlManager) external {
-        require(msg.sender == owner(), "only admin can set ACL address");
-        require(address(newAccessControlManager) != address(0), "invalid acess control manager address");
-
-        _setAccessControlAddress(newAccessControlManager);
     }
 
     /**
@@ -388,19 +358,11 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
      * @dev Admin function to accrue interest and update the interest rate model
      * @param newInterestRateModel the new interest rate model to use
      * @custom:event Emits NewMarketInterestRateModel event; may emit AccrueInterest
-     * @custom:error SetInterestRateModelOwnerCheck is thrown when the call is not authorized by AccessControlManager
+     * @custom:error Unauthorized error is thrown when the call is not authorized by AccessControlManager
      * @custom:access Controlled by AccessControlManager
      */
     function setInterestRateModel(InterestRateModel newInterestRateModel) external override {
-        bool canCallFunction = AccessControlManager(accessControlManager).isAllowedToCall(
-            msg.sender,
-            "setInterestRateModel(address)"
-        );
-
-        // Check if caller has call permissions
-        if (!canCallFunction) {
-            revert SetInterestRateModelOwnerCheck();
-        }
+        _checkAccessAllowed("setInterestRateModel(address)");
 
         accrueInterest();
         _setInterestRateModelFresh(newInterestRateModel);
@@ -1275,17 +1237,6 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         emit NewMarketInterestRateModel(oldInterestRateModel, newInterestRateModel);
     }
 
-    /**
-     * @notice Sets the address of AccessControlManager
-     * @dev Internal function to set address of AccessControlManager
-     * @param newAccessControlManager The new address of the AccessControlManager
-     */
-    function _setAccessControlAddress(AccessControlManager newAccessControlManager) internal {
-        AccessControlManager oldAccessControlManager = accessControlManager;
-        accessControlManager = newAccessControlManager;
-        emit NewAccessControlManager(oldAccessControlManager, accessControlManager);
-    }
-
     /*** Safe Token ***/
 
     /**
@@ -1379,13 +1330,12 @@ contract VToken is Ownable2StepUpgradeable, VTokenInterface, ExponentialNoError,
         string memory symbol_,
         uint8 decimals_,
         address admin_,
-        AccessControlManager accessControlManager_,
+        address accessControlManager_,
         RiskManagementInit memory riskManagement
     ) internal onlyInitializing {
         __Ownable2Step_init();
+        __AccessControlled_init_unchained(accessControlManager_);
         require(accrualBlockNumber == 0 && borrowIndex == 0, "market may only be initialized once");
-
-        _setAccessControlAddress(accessControlManager_);
 
         // Set initial exchange rate
         initialExchangeRateMantissa = initialExchangeRateMantissa_;

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -6,7 +6,6 @@ import "@venusprotocol/oracle/contracts/PriceOracle.sol";
 import "./ComptrollerInterface.sol";
 import "./InterestRateModel.sol";
 import "./ErrorReporter.sol";
-import "./Governance/AccessControlManager.sol";
 
 contract VTokenStorage {
     /**
@@ -123,11 +122,6 @@ contract VTokenStorage {
     uint256 public protocolSeizeShareMantissa;
 
     /**
-     * @notice Storage of AccessControlManager
-     */
-    AccessControlManager public accessControlManager;
-
-    /**
      * @notice Storage of Shortfall contract address
      */
     address public shortfall;
@@ -218,14 +212,6 @@ abstract contract VTokenInterface is VTokenStorage {
      * @notice Event emitted when comptroller is changed
      */
     event NewComptroller(ComptrollerInterface indexed oldComptroller, ComptrollerInterface indexed newComptroller);
-
-    /**
-     * @notice Event emitted when comptroller is changed
-     */
-    event NewAccessControlManager(
-        AccessControlManager indexed oldAccessControlManager,
-        AccessControlManager indexed newAccessControlManager
-    );
 
     /**
      * @notice Event emitted when interestRateModel is changed

--- a/contracts/test/ComptrollerHarness.sol
+++ b/contracts/test/ComptrollerHarness.sol
@@ -7,7 +7,7 @@ import "../../contracts/Comptroller.sol";
 contract ComptrollerHarness is Comptroller {
     uint256 public blockNumber;
 
-    constructor(address _poolRegistry, address _accessControl) Comptroller(_poolRegistry, _accessControl) {}
+    constructor(address _poolRegistry) Comptroller(_poolRegistry) {}
 
     function harnessFastForward(uint256 blocks) public returns (uint256) {
         blockNumber += blocks;

--- a/contracts/test/ComptrollerScenario.sol
+++ b/contracts/test/ComptrollerScenario.sol
@@ -6,7 +6,7 @@ import "../../contracts/Comptroller.sol";
 contract ComptrollerScenario is Comptroller {
     uint256 public blockNumber;
 
-    constructor(address _poolRegistry, address _accessControl) Comptroller(_poolRegistry, _accessControl) {}
+    constructor(address _poolRegistry) Comptroller(_poolRegistry) {}
 
     function fastForward(uint256 blocks) public returns (uint256) {
         blockNumber += blocks;

--- a/contracts/test/UpgradedVToken.sol
+++ b/contracts/test/UpgradedVToken.sol
@@ -39,7 +39,7 @@ contract UpgradedVToken is VToken {
         string memory symbol_,
         uint8 decimals_,
         address payable admin_,
-        AccessControlManager accessControlManager_,
+        address accessControlManager_,
         RiskManagementInit memory riskManagement
     ) public reinitializer(2) {
         super._initialize(

--- a/deploy/006-riskfund-protocolshare.ts
+++ b/deploy/006-riskfund-protocolshare.ts
@@ -53,7 +53,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       proxyContract: "OpenZeppelinTransparentProxy",
       execute: {
         methodName: "initialize",
-        args: [BUSD.address, riskFund.address, MIN_POOL_BAD_DEBT],
+        args: [BUSD.address, riskFund.address, MIN_POOL_BAD_DEBT, accessControl.address],
       },
       upgradeIndex: 0,
     },

--- a/deploy/007-deploy-factories.ts
+++ b/deploy/007-deploy-factories.ts
@@ -8,6 +8,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deploy } = deployments;
 
   const { deployer } = await getNamedAccounts();
+  const accessControlManager = await ethers.getContract("AccessControlManager");
 
   const vBep20Factory: DeployResult = await deploy("VTokenProxyFactory", {
     from: deployer,
@@ -49,6 +50,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           shortFall.address,
           riskFund.address,
           protocolShareReserve.address,
+          accessControlManager.address,
         ],
       },
       upgradeIndex: 0,

--- a/deploy/008-access-control-configure.ts
+++ b/deploy/008-access-control-configure.ts
@@ -88,6 +88,21 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   );
   await tx.wait();
   console.log("DEFAULT_ADMIN | Deployer           | swapPoolsAssets(address[],uint256[])");
+
+  tx = await accessControlManager.giveCallPermission(
+    poolRegistry.address,
+    "createRegistryPool(string,address,uint256,uint256,uint256,address,uint256,address)",
+    deployer,
+  );
+  await tx.wait();
+  console.log(
+    "PoolRegistry  | Deployer           | createRegistryPool(string,address,uint256,uint256,uint256,address,uint256,address)",
+  );
+
+  tx = await accessControlManager.giveCallPermission(poolRegistry.address, "addMarket(AddMarketInput)", deployer);
+  await tx.wait();
+  console.log("PoolRegistry  | Deployer           | addMarket(AddMarketInput)");
+
   console.log("--------------------------------------------------");
   console.log("Access Control setup ended successfully");
 };

--- a/deploy/008-access-control-configure.ts
+++ b/deploy/008-access-control-configure.ts
@@ -103,6 +103,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await tx.wait();
   console.log("PoolRegistry  | Deployer           | addMarket(AddMarketInput)");
 
+  tx = await accessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
+    "setRewardTokenSpeeds(address[],uint256[],uint256[])",
+    deployer,
+  );
+  await tx.wait();
+  console.log("DEFAULT_ADMIN | Deployer           | setRewardTokenSpeeds(address[],uint256[],uint256[])");
+
   console.log("--------------------------------------------------");
   console.log("Access Control setup ended successfully");
 };

--- a/deploy/008-access-control-configure.ts
+++ b/deploy/008-access-control-configure.ts
@@ -60,6 +60,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   tx = await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
+    "setCloseFactor(uint256)",
+    poolRegistry.address,
+  );
+  await tx.wait();
+  console.log("DEFAULT_ADMIN | PoolRegistry       | setCloseFactor(uint256)");
+
+  tx = await accessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
     "setMinLiquidatableCollateral(uint256)",
     poolRegistry.address,
   );

--- a/deploy/010-deploy-pools.ts
+++ b/deploy/010-deploy-pools.ts
@@ -22,7 +22,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const comptrollerImpl: DeployResult = await deploy("ComptrollerImpl", {
     contract: "Comptroller",
     from: deployer,
-    args: [poolRegistry.address, accessControlManager.address],
+    args: [poolRegistry.address],
     log: true,
     autoMine: true,
   });
@@ -69,6 +69,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         pool.minLiquidatableCollateral,
         priceOracle.address,
         maxLoopsLimit,
+        accessControlManager.address,
       );
       await tx.wait();
       pools = await poolRegistry.callStatic.getAllPools();
@@ -109,7 +110,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         // Make sure that deployer has at least `initialSupply` balance of the token
       }
 
-      console.log("Approving Poolregistry for: " + initialSupply);
+      console.log("Approving PoolRegistry for: " + initialSupply);
       tx = await tokenContract.approve(poolRegistry.address, initialSupply);
       await tx.wait(1);
 

--- a/deploy/011-rewards.ts
+++ b/deploy/011-rewards.ts
@@ -10,6 +10,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await getNamedAccounts();
   const maxLoopsLimit = 150;
   const poolRegistry = await ethers.getContract("PoolRegistry");
+  const accessControl = await ethers.getContract("AccessControlManager");
 
   const { tokensConfig, poolConfig } = await getConfig(hre.network.name);
   const pools = await poolRegistry.callStatic.getAllPools();
@@ -31,7 +32,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           proxyContract: "OpenZeppelinTransparentProxy",
           execute: {
             methodName: "initialize",
-            args: [comptrollerAddress, rewardTokenAddress, maxLoopsLimit],
+            args: [comptrollerAddress, rewardTokenAddress, maxLoopsLimit, accessControl.address],
           },
           upgradeIndex: 0,
         },

--- a/tests/hardhat/AccessControl.ts
+++ b/tests/hardhat/AccessControl.ts
@@ -28,13 +28,13 @@ describe("Access Control", () => {
     accessControlManager = await accessControlFactory.deploy();
 
     comptrollerFactory = await smock.mock<Comptroller__factory>("Comptroller");
-    comptroller = await upgrades.deployProxy(comptrollerFactory, [maxLoopsLimit], {
-      constructorArgs: [await signers[0].getAddress(), accessControlManager.address],
-      initializer: "initialize(uint256)",
+    comptroller = await upgrades.deployProxy(comptrollerFactory, [maxLoopsLimit, accessControlManager.address], {
+      constructorArgs: [await signers[0].getAddress()],
+      initializer: "initialize(uint256,address)",
     });
-    comptroller2 = await upgrades.deployProxy(comptrollerFactory, [maxLoopsLimit], {
-      constructorArgs: [await signers[0].getAddress(), accessControlManager.address],
-      initializer: "initialize(uint256)",
+    comptroller2 = await upgrades.deployProxy(comptrollerFactory, [maxLoopsLimit, accessControlManager.address], {
+      constructorArgs: [await signers[0].getAddress()],
+      initializer: "initialize(uint256,address)",
     });
     await accessControlManager.deployed();
   });

--- a/tests/hardhat/Comptroller/accountLiquidityTest.ts
+++ b/tests/hardhat/Comptroller/accountLiquidityTest.ts
@@ -30,9 +30,9 @@ async function makeComptroller(): Promise<AccountLiquidityTestFixture> {
   const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
   const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
   const maxLoopsLimit = 150;
-  const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit], {
-    constructorArgs: [poolRegistry.address, accessControl.address],
-    initializer: "initialize(uint256)",
+  const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit, accessControl.address], {
+    constructorArgs: [poolRegistry.address],
+    initializer: "initialize(uint256,address)",
   });
   const oracle = await smock.fake<PriceOracle>("PriceOracle");
 

--- a/tests/hardhat/Comptroller/assetsListTest.ts
+++ b/tests/hardhat/Comptroller/assetsListTest.ts
@@ -46,9 +46,9 @@ describe("assetListTest", () => {
     poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
     const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
     const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-    const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit], {
-      constructorArgs: [poolRegistry.address, accessControl.address],
-      initializer: "initialize(uint256)",
+    const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit, accessControl.address], {
+      constructorArgs: [poolRegistry.address],
+      initializer: "initialize(uint256,address)",
     });
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 

--- a/tests/hardhat/Comptroller/healAccountTest.ts
+++ b/tests/hardhat/Comptroller/healAccountTest.ts
@@ -43,9 +43,9 @@ describe("healAccount", () => {
     const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
     const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
     const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-    const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit], {
-      constructorArgs: [poolRegistry.address, accessControl.address],
-      initializer: "initialize(uint256)",
+    const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit, accessControl.address], {
+      constructorArgs: [poolRegistry.address],
+      initializer: "initialize(uint256,address)",
     });
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 

--- a/tests/hardhat/Comptroller/hooks.ts
+++ b/tests/hardhat/Comptroller/hooks.ts
@@ -32,9 +32,9 @@ async function deploySimpleComptroller(): Promise<SimpleComptrollerFixture> {
   const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
   accessControl.isAllowedToCall.returns(true);
   const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-  const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit], {
-    constructorArgs: [poolRegistry.address, accessControl.address],
-    initializer: "initialize(uint256)",
+  const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit, accessControl.address], {
+    constructorArgs: [poolRegistry.address],
+    initializer: "initialize(uint256,address)",
   });
   await comptroller.setPriceOracle(oracle.address);
   await comptroller.setLiquidationIncentive(parseUnits("1", 18));

--- a/tests/hardhat/Comptroller/liquidateAccountTest.ts
+++ b/tests/hardhat/Comptroller/liquidateAccountTest.ts
@@ -70,9 +70,9 @@ describe("liquidateAccount", () => {
     const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
     const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
     const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-    const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit], {
-      constructorArgs: [poolRegistry.address, accessControl.address],
-      initializer: "initialize(uint256)",
+    const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit, accessControl.address], {
+      constructorArgs: [poolRegistry.address],
+      initializer: "initialize(uint256,address)",
     });
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 

--- a/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
+++ b/tests/hardhat/Comptroller/liquidateCalculateAmountSeizeTest.ts
@@ -59,9 +59,9 @@ describe("Comptroller", () => {
     const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
     const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
     const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-    const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit], {
-      constructorArgs: [poolRegistry.address, accessControl.address],
-      initializer: "initialize(uint256)",
+    const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit, accessControl.address], {
+      constructorArgs: [poolRegistry.address],
+      initializer: "initialize(uint256,address)",
     });
     const oracle = await smock.fake<PriceOracle>("PriceOracle");
 

--- a/tests/hardhat/Comptroller/pauseTest.ts
+++ b/tests/hardhat/Comptroller/pauseTest.ts
@@ -36,9 +36,9 @@ async function pauseFixture(): Promise<PauseFixture> {
   const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
   const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
   const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-  const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit], {
-    constructorArgs: [poolRegistry.address, accessControl.address],
-    initializer: "initialize(uint256)",
+  const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit, accessControl.address], {
+    constructorArgs: [poolRegistry.address],
+    initializer: "initialize(uint256,address)",
   });
   const oracle = await smock.fake<PriceOracle>("PriceOracle");
 

--- a/tests/hardhat/Comptroller/setters.ts
+++ b/tests/hardhat/Comptroller/setters.ts
@@ -32,9 +32,9 @@ const comptrollerFixture = async (): Promise<ComptrollerFixture> => {
   const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
   const accessControl = await smock.fake<AccessControlManager>("AccessControlManager");
   const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-  const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit], {
-    constructorArgs: [poolRegistry.address, accessControl.address],
-    initializer: "initialize(uint256)",
+  const comptroller = await upgrades.deployProxy(Comptroller, [maxLoopsLimit, accessControl.address], {
+    constructorArgs: [poolRegistry.address],
+    initializer: "initialize(uint256,address)",
   });
   const oracle = await smock.fake<PriceOracle>("PriceOracle");
 

--- a/tests/hardhat/Comptroller/setters.ts
+++ b/tests/hardhat/Comptroller/setters.ts
@@ -81,16 +81,12 @@ describe("setters", async () => {
   });
 
   describe("setCloseFactor", async () => {
-    let newPriceOracle: FakeContract<PriceOracle>;
-
-    before(async () => {
-      newPriceOracle = await smock.fake<PriceOracle>("PriceOracle");
-    });
-
-    it("reverts if called by a non-owner", async () => {
-      await expect(comptroller.connect(user).setPriceOracle(newPriceOracle.address)).to.be.revertedWith(
-        "Ownable: caller is not the owner",
-      );
+    const newCloseFactor = convertToUnit("0.8", 18);
+    it("reverts if access control manager does not allow the call", async () => {
+      accessControl.isAllowedToCall.whenCalledWith(owner.address, "setCloseFactor(uint256)").returns(false);
+      await expect(comptroller.setCloseFactor(newCloseFactor))
+        .to.be.revertedWithCustomError(comptroller, "Unauthorized")
+        .withArgs(owner.address, comptroller.address, "setCloseFactor(uint256)");
     });
   });
 

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -208,6 +208,14 @@ const riskFundFixture = async (): Promise<void> => {
   );
 
   await accessControlManager.giveCallPermission(
+    poolRegistry.address,
+    "createRegistryPool(string,address,uint256,uint256,uint256,address,uint256,address)",
+    admin.address,
+  );
+
+  await accessControlManager.giveCallPermission(poolRegistry.address, "addMarket(AddMarketInput)", admin.address);
+
+  await accessControlManager.giveCallPermission(
     riskFund.address,
     "swapPoolsAssets(address[],uint256[])",
     admin.address,
@@ -311,7 +319,7 @@ const riskFundFixture = async (): Promise<void> => {
   await USDC.faucet(initialSupply);
   await USDC.approve(poolRegistry.address, initialSupply);
 
-  // Deploy CTokens
+  // Deploy VTokens
   await poolRegistry.addMarket({
     comptroller: comptroller1Proxy.address,
     asset: USDT.address,

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -215,7 +215,7 @@ const riskFundFixture = async (): Promise<void> => {
   await shortfall.connect(shortfall.wallet).setPoolRegistry(poolRegistry.address);
 
   const Comptroller = await ethers.getContractFactory("Comptroller");
-  const comptroller = await Comptroller.deploy(poolRegistry.address, accessControlManager.address);
+  const comptroller = await Comptroller.deploy(poolRegistry.address);
   await comptroller.deployed();
 
   const VTokenContract = await ethers.getContractFactory("VToken");
@@ -255,6 +255,7 @@ const riskFundFixture = async (): Promise<void> => {
     _minLiquidatableCollateral,
     priceOracle.address,
     maxLoopsLimit,
+    accessControlManager.address,
   );
 
   // Registering the second pool
@@ -266,6 +267,7 @@ const riskFundFixture = async (): Promise<void> => {
     _minLiquidatableCollateral,
     priceOracle.address,
     maxLoopsLimit,
+    accessControlManager.address,
   );
 
   // Registering the third pool
@@ -277,6 +279,7 @@ const riskFundFixture = async (): Promise<void> => {
     _minLiquidatableCollateral,
     priceOracle.address,
     maxLoopsLimit,
+    accessControlManager.address,
   );
 
   // Setup Proxies

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -208,6 +208,12 @@ const riskFundFixture = async (): Promise<void> => {
   );
 
   await accessControlManager.giveCallPermission(
+    ethers.constants.AddressZero,
+    "setCloseFactor(uint256)",
+    poolRegistry.address,
+  );
+
+  await accessControlManager.giveCallPermission(
     poolRegistry.address,
     "createRegistryPool(string,address,uint256,uint256,uint256,address,uint256,address)",
     admin.address,

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -497,13 +497,13 @@ describe("Risk Fund: Tests", function () {
   describe("Test all setters", async function () {
     describe("setPoolRegistry", async function () {
       it("reverts on invalid PoolRegistry address", async function () {
-        await expect(riskFund.setPoolRegistry(constants.AddressZero)).to.be.rejectedWith(
+        await expect(riskFund.setPoolRegistry(constants.AddressZero)).to.be.revertedWith(
           "Risk Fund: Pool registry address invalid",
         );
       });
 
       it("fails if called by a non-owner", async function () {
-        await expect(riskFund.connect(usdcUser).setPoolRegistry(poolRegistry.address)).to.be.rejectedWith(
+        await expect(riskFund.connect(usdcUser).setPoolRegistry(poolRegistry.address)).to.be.revertedWith(
           "Ownable: caller is not the owner",
         );
       });
@@ -519,13 +519,13 @@ describe("Risk Fund: Tests", function () {
 
     describe("setShortfallContractAddress", async function () {
       it("Reverts on invalid Auction contract address", async function () {
-        await expect(riskFund.setShortfallContractAddress(constants.AddressZero)).to.be.rejectedWith(
+        await expect(riskFund.setShortfallContractAddress(constants.AddressZero)).to.be.revertedWith(
           "Risk Fund: Shortfall contract address invalid",
         );
       });
 
       it("fails if called by a non-owner", async function () {
-        await expect(riskFund.connect(usdcUser).setShortfallContractAddress(someNonzeroAddress)).to.be.rejectedWith(
+        await expect(riskFund.connect(usdcUser).setShortfallContractAddress(someNonzeroAddress)).to.be.revertedWith(
           "Ownable: caller is not the owner",
         );
       });
@@ -542,13 +542,13 @@ describe("Risk Fund: Tests", function () {
 
     describe("setPancakeSwapRouter", async function () {
       it("Reverts on invalid PancakeSwap router contract address", async function () {
-        await expect(riskFund.setPancakeSwapRouter(constants.AddressZero)).to.be.rejectedWith(
+        await expect(riskFund.setPancakeSwapRouter(constants.AddressZero)).to.be.revertedWith(
           "Risk Fund: PancakeSwap address invalid",
         );
       });
 
       it("fails if called by a non-owner", async function () {
-        await expect(riskFund.connect(usdcUser).setPancakeSwapRouter(someNonzeroAddress)).to.be.rejectedWith(
+        await expect(riskFund.connect(usdcUser).setPancakeSwapRouter(someNonzeroAddress)).to.be.revertedWith(
           "Ownable: caller is not the owner",
         );
       });
@@ -565,17 +565,17 @@ describe("Risk Fund: Tests", function () {
       it("fails if called with incorrect arguments", async function () {
         await expect(
           riskFund.swapPoolsAssets([cUSDT.address, cUSDC.address], [convertToUnit(10, 18)]),
-        ).to.be.rejectedWith("Risk fund: markets and amountsOutMin are unequal lengths");
+        ).to.be.revertedWith("Risk fund: markets and amountsOutMin are unequal lengths");
       });
     });
 
     describe("setMinAmountToConvert", async function () {
       it("reverts on invalid min amount to convert", async function () {
-        await expect(riskFund.setMinAmountToConvert(0)).to.be.rejectedWith("Risk Fund: Invalid min amount to convert");
+        await expect(riskFund.setMinAmountToConvert(0)).to.be.revertedWith("Risk Fund: Invalid min amount to convert");
       });
 
       it("fails if called by a non-owner", async function () {
-        await expect(riskFund.connect(usdcUser).setMinAmountToConvert(1)).to.be.rejectedWith(
+        await expect(riskFund.connect(usdcUser).setMinAmountToConvert(1)).to.be.revertedWith(
           "Ownable: caller is not the owner",
         );
       });
@@ -597,9 +597,7 @@ describe("Risk Fund: Tests", function () {
         admin.address,
       );
       // Fails
-      await expect(riskFund.swapPoolsAssets([], [])).to.be.rejectedWith(
-        "Risk fund: Not authorized to swap pool assets.",
-      );
+      await expect(riskFund.swapPoolsAssets([], [])).to.be.revertedWithCustomError(riskFund, "Unauthorized");
 
       // Reset
       await accessControlManager.giveCallPermission(
@@ -731,14 +729,14 @@ describe("Risk Fund: Tests", function () {
     it("Revert while transfering funds to Auction contract", async function () {
       await expect(
         riskFund.connect(busdUser).transferReserveForAuction(comptroller1Proxy.address, convertToUnit(30, 18)),
-      ).to.be.rejectedWith("Risk fund: Only callable by Shortfall contract");
+      ).to.be.revertedWith("Risk fund: Only callable by Shortfall contract");
 
       const auctionContract = shortfall.address;
       await riskFund.setShortfallContractAddress(auctionContract);
 
       await expect(
         riskFund.connect(shortfall.wallet).transferReserveForAuction(comptroller1Proxy.address, convertToUnit(100, 18)),
-      ).to.be.rejectedWith("Risk Fund: Insufficient pool reserve.");
+      ).to.be.revertedWith("Risk Fund: Insufficient pool reserve.");
     });
 
     it("Transfer funds to auction contact", async function () {
@@ -822,7 +820,7 @@ describe("Risk Fund: Tests", function () {
 
       await expect(
         riskFund.transferReserveForAuction(comptroller1Proxy.address, convertToUnit(20, 18)),
-      ).to.be.rejectedWith("Risk fund: Only callable by Shortfall contract");
+      ).to.be.revertedWith("Risk fund: Only callable by Shortfall contract");
 
       // reset
       await accessControlManager.giveCallPermission(

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -166,6 +166,7 @@ const riskFundFixture = async (): Promise<void> => {
     shortfall.address,
     riskFund.address,
     protocolShareReserve.address,
+    accessControlManager.address,
   ]);
 
   await protocolShareReserve.setPoolRegistry(poolRegistry.address);

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -156,7 +156,7 @@ const riskFundFixture = async (): Promise<void> => {
   await shortfall.setPoolRegistry(poolRegistry.address);
 
   const Comptroller = await ethers.getContractFactory("Comptroller");
-  const comptroller = await Comptroller.deploy(poolRegistry.address, fakeAccessControlManager.address);
+  const comptroller = await Comptroller.deploy(poolRegistry.address);
   await comptroller.deployed();
 
   const VTokenContract = await ethers.getContractFactory("VToken");
@@ -194,6 +194,7 @@ const riskFundFixture = async (): Promise<void> => {
     _minLiquidatableCollateral,
     priceOracle.address,
     maxLoopsLimit,
+    fakeAccessControlManager.address,
   );
 
   // Setup Proxies

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -154,6 +154,7 @@ const riskFundFixture = async (): Promise<void> => {
     shortfall.address,
     riskFund.address,
     protocolShareReserve.address,
+    fakeAccessControlManager.address,
   ]);
 
   await protocolShareReserve.setPoolRegistry(poolRegistry.address);

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -121,7 +121,12 @@ const riskFundFixture = async (): Promise<void> => {
   fakeAccessControlManager.isAllowedToCall.returns(true);
 
   const Shortfall = await ethers.getContractFactory("Shortfall");
-  const shortfall = await upgrades.deployProxy(Shortfall, [BUSD.address, AddressOne, parseUnits("10000", 18)]);
+  const shortfall = await upgrades.deployProxy(Shortfall, [
+    BUSD.address,
+    AddressOne,
+    parseUnits("10000", 18),
+    fakeAccessControlManager.address,
+  ]);
 
   const RiskFund = await ethers.getContractFactory("RiskFund");
   riskFund = await upgrades.deployProxy(RiskFund, [

--- a/tests/hardhat/Lens/PoolLens.ts
+++ b/tests/hardhat/Lens/PoolLens.ts
@@ -110,7 +110,7 @@ describe("PoolLens", async function () {
     poolRegistryAddress = poolRegistry.address;
 
     const Comptroller = await ethers.getContractFactory("Comptroller");
-    const comptroller = await Comptroller.deploy(poolRegistry.address, fakeAccessControlManager.address);
+    const comptroller = await Comptroller.deploy(poolRegistry.address);
     await comptroller.deployed();
 
     const VTokenContract = await ethers.getContractFactory("VToken");
@@ -140,6 +140,7 @@ describe("PoolLens", async function () {
       minLiquidatableCollateral,
       priceOracle.address,
       maxLoopsLimit,
+      fakeAccessControlManager.address,
     );
 
     closeFactor2 = convertToUnit(0.05, 18);
@@ -154,6 +155,7 @@ describe("PoolLens", async function () {
       minLiquidatableCollateral,
       priceOracle.address,
       maxLoopsLimit,
+      fakeAccessControlManager.address,
     );
 
     const MockDAI = await ethers.getContractFactory("MockToken");

--- a/tests/hardhat/Lens/PoolLens.ts
+++ b/tests/hardhat/Lens/PoolLens.ts
@@ -65,7 +65,12 @@ describe("PoolLens", async function () {
   let borrowerWbtc: Signer;
   let borrowerDai: Signer;
 
-  const poolRegistryFixture = async (): Promise<PoolRegistry> => {
+  interface PoolRegistryFixture {
+    poolRegistry: PoolRegistry;
+    fakeAccessControlManager: FakeContract<AccessControlManager>;
+  }
+
+  const poolRegistryFixture = async (): Promise<PoolRegistryFixture> => {
     const VTokenProxyFactory = await ethers.getContractFactory("VTokenProxyFactory");
     const vTokenFactory = await VTokenProxyFactory.deploy();
     await vTokenFactory.deployed();
@@ -82,6 +87,9 @@ describe("PoolLens", async function () {
     const riskFund = await smock.fake<RiskFund>("Shortfall");
     const protocolShareReserve = await smock.fake<ProtocolShareReserve>("Shortfall");
 
+    fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
+    fakeAccessControlManager.isAllowedToCall.returns(true);
+
     const PoolRegistry = await ethers.getContractFactory("PoolRegistry");
     poolRegistry = await upgrades.deployProxy(PoolRegistry, [
       vTokenFactory.address,
@@ -90,9 +98,10 @@ describe("PoolLens", async function () {
       shortfall.address,
       riskFund.address,
       protocolShareReserve.address,
+      fakeAccessControlManager.address,
     ]);
 
-    return poolRegistry;
+    return { poolRegistry, fakeAccessControlManager };
   };
 
   /**
@@ -103,9 +112,7 @@ describe("PoolLens", async function () {
     [borrowerWbtc, borrowerDai] = rest;
     ownerAddress = await owner.getAddress();
 
-    poolRegistry = await loadFixture(poolRegistryFixture);
-    fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
-    fakeAccessControlManager.isAllowedToCall.returns(true);
+    ({ poolRegistry, fakeAccessControlManager } = await loadFixture(poolRegistryFixture));
 
     poolRegistryAddress = poolRegistry.address;
 

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -122,6 +122,9 @@ describe("PoolRegistry: Tests", function () {
     const riskFund = await smock.fake<RiskFund>("RiskFund");
     const protocolShareReserve = await smock.fake<ProtocolShareReserve>("ProtocolShareReserve");
 
+    fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
+    fakeAccessControlManager.isAllowedToCall.returns(true);
+
     const PoolRegistry = await ethers.getContractFactory("PoolRegistry");
     poolRegistry = await upgrades.deployProxy(PoolRegistry, [
       vTokenFactory.address,
@@ -130,10 +133,8 @@ describe("PoolRegistry: Tests", function () {
       shortfall.address,
       riskFund.address,
       protocolShareReserve.address,
+      fakeAccessControlManager.address,
     ]);
-
-    fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
-    fakeAccessControlManager.isAllowedToCall.returns(true);
 
     const Comptroller = await ethers.getContractFactory("Comptroller");
     const comptroller = await Comptroller.deploy(poolRegistry.address);

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -136,7 +136,7 @@ describe("PoolRegistry: Tests", function () {
     fakeAccessControlManager.isAllowedToCall.returns(true);
 
     const Comptroller = await ethers.getContractFactory("Comptroller");
-    const comptroller = await Comptroller.deploy(poolRegistry.address, fakeAccessControlManager.address);
+    const comptroller = await Comptroller.deploy(poolRegistry.address);
     await comptroller.deployed();
 
     const VTokenContract = await ethers.getContractFactory("VToken");
@@ -183,6 +183,7 @@ describe("PoolRegistry: Tests", function () {
       _minLiquidatableCollateral,
       priceOracle.address,
       maxLoopsLimit,
+      fakeAccessControlManager.address,
     );
 
     // Registering the second pool
@@ -194,6 +195,7 @@ describe("PoolRegistry: Tests", function () {
       _minLiquidatableCollateral,
       priceOracle.address,
       maxLoopsLimit,
+      fakeAccessControlManager.address,
     );
 
     // Setup Proxies

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -3,6 +3,7 @@ import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { BigNumberish, constants } from "ethers";
+import { parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../helpers/utils";
@@ -272,14 +273,20 @@ describe("PoolRegistry: Tests", function () {
 
   beforeEach(async () => {
     await loadFixture(poolRegistryFixture);
+    fakeAccessControlManager.isAllowedToCall.reset();
+    fakeAccessControlManager.isAllowedToCall.returns(true);
   });
 
   describe("setPoolName", async () => {
     const newName = "My fancy pool";
 
-    it("reverts if not called by owner", async () => {
-      await expect(poolRegistry.connect(user).setPoolName(comptroller1Proxy.address, newName)).to.be.revertedWith(
-        "Ownable: caller is not the owner",
+    it("reverts if ACM denies the access", async () => {
+      fakeAccessControlManager.isAllowedToCall
+        .whenCalledWith(owner.address, "setPoolName(address,string)")
+        .returns(false);
+      await expect(poolRegistry.setPoolName(comptroller1Proxy.address, newName)).to.be.revertedWithCustomError(
+        poolRegistry,
+        "Unauthorized",
       );
     });
 
@@ -297,9 +304,13 @@ describe("PoolRegistry: Tests", function () {
   });
 
   describe("addMarket", async () => {
-    it("reverts if called by a non-owner", async () => {
-      await expect(poolRegistry.connect(user).addMarket(await withDefaultMarketParameters({}))).to.be.rejectedWith(
-        "Ownable: caller is not the owner",
+    it("reverts if ACM denies the access", async () => {
+      fakeAccessControlManager.isAllowedToCall
+        .whenCalledWith(owner.address, "addMarket(AddMarketInput)")
+        .returns(false);
+      await expect(poolRegistry.addMarket(await withDefaultMarketParameters({}))).to.be.revertedWithCustomError(
+        poolRegistry,
+        "Unauthorized",
       );
     });
 
@@ -417,11 +428,13 @@ describe("PoolRegistry: Tests", function () {
       description,
     };
 
-    it("reverts if called by a non-owner", async () => {
-      const [, user] = await ethers.getSigners();
+    it("reverts if ACM denies the access", async () => {
+      fakeAccessControlManager.isAllowedToCall
+        .whenCalledWith(owner.address, "updatePoolMetadata(address,VenusPoolMetaData)")
+        .returns(false);
       await expect(
-        poolRegistry.connect(user).updatePoolMetadata(comptroller1Proxy.address, newMetadata),
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+        poolRegistry.updatePoolMetadata(comptroller1Proxy.address, newMetadata),
+      ).to.be.revertedWithCustomError(poolRegistry, "Unauthorized");
     });
 
     it("sets new pool metadata", async () => {
@@ -439,6 +452,25 @@ describe("PoolRegistry: Tests", function () {
       await expect(tx)
         .to.emit(poolRegistry, "PoolMetadataUpdated")
         .withArgs(comptroller1Proxy.address, oldMetadata, [riskRating, category, logoURL, description]);
+    });
+  });
+
+  describe("createRegistryPool", async () => {
+    it("reverts if ACM denies the access", async () => {
+      const createRegistryPool = "createRegistryPool(string,address,uint256,uint256,uint256,address,uint256,address)";
+      fakeAccessControlManager.isAllowedToCall.whenCalledWith(owner.address, createRegistryPool).returns(false);
+      await expect(
+        poolRegistry.createRegistryPool(
+          "Pool 3",
+          comptrollerBeacon.address,
+          parseUnits("0.5", 18),
+          parseUnits("1.1", 18),
+          parseUnits("100", 18),
+          priceOracle.address,
+          maxLoopsLimit,
+          fakeAccessControlManager.address,
+        ),
+      ).to.be.revertedWithCustomError(poolRegistry, "Unauthorized");
     });
   });
 });

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -72,7 +72,7 @@ async function rewardsFixture() {
   fakeAccessControlManager.isAllowedToCall.returns(true);
 
   const Comptroller = await ethers.getContractFactory("Comptroller");
-  const comptroller = await Comptroller.deploy(poolRegistry.address, fakeAccessControlManager.address);
+  const comptroller = await Comptroller.deploy(poolRegistry.address);
   await comptroller.deployed();
 
   const VTokenContract = await ethers.getContractFactory("VToken");
@@ -128,6 +128,7 @@ async function rewardsFixture() {
     _minLiquidatableCollateral,
     fakePriceOracle.address,
     maxLoopsLimit,
+    fakeAccessControlManager.address,
   );
 
   // Get all pools list.

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -211,16 +211,18 @@ async function rewardsFixture() {
 
   // Configure rewards for pool
   const RewardsDistributor = await ethers.getContractFactory("RewardsDistributor");
-  rewardsDistributor = rewardsDistributor = await upgrades.deployProxy(RewardsDistributor, [
+  rewardsDistributor = await upgrades.deployProxy(RewardsDistributor, [
     comptrollerProxy.address,
     xvs.address,
     maxLoopsLimit,
+    fakeAccessControlManager.address,
   ]);
 
   const rewardsDistributor2 = await upgrades.deployProxy(RewardsDistributor, [
     comptrollerProxy.address,
     mockDAI.address,
     maxLoopsLimit,
+    fakeAccessControlManager.address,
   ]);
 
   const initialXvs = convertToUnit(1000000, 18);
@@ -293,6 +295,7 @@ describe("Rewards: Tests", async function () {
       comptrollerProxy.address,
       xvs.address,
       maxLoopsLimit,
+      fakeAccessControlManager.address,
     ]);
 
     await expect(comptrollerProxy.addRewardsDistributor(rewardsDistributor.address)).to.be.revertedWith(
@@ -306,6 +309,7 @@ describe("Rewards: Tests", async function () {
       comptrollerProxy.address,
       mockWBTC.address,
       maxLoopsLimit,
+      fakeAccessControlManager.address,
     ]);
 
     await expect(comptrollerProxy.addRewardsDistributor(rewardsDistributor.address))

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -58,6 +58,9 @@ async function rewardsFixture() {
   const protocolShareReserve = await smock.fake<ProtocolShareReserve>("ProtocolShareReserve");
   const shortfall = await smock.fake<Shortfall>("Shortfall");
 
+  fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
+  fakeAccessControlManager.isAllowedToCall.returns(true);
+
   const PoolRegistry = await smock.mock<PoolRegistry__factory>("PoolRegistry");
   poolRegistry = await upgrades.deployProxy(PoolRegistry, [
     vTokenFactory.address,
@@ -66,10 +69,8 @@ async function rewardsFixture() {
     shortfall.address,
     riskFund.address,
     protocolShareReserve.address,
+    fakeAccessControlManager.address,
   ]);
-
-  fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
-  fakeAccessControlManager.isAllowedToCall.returns(true);
 
   const Comptroller = await ethers.getContractFactory("Comptroller");
   const comptroller = await Comptroller.deploy(poolRegistry.address);

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -9,6 +9,7 @@ import { ethers, upgrades } from "hardhat";
 
 import { AddressOne, convertToUnit } from "../../helpers/utils";
 import {
+  AccessControlManager,
   Comptroller,
   Comptroller__factory,
   IRiskFund,
@@ -30,6 +31,7 @@ let someone: SignerWithAddress;
 let bidder1: SignerWithAddress;
 let bidder2: SignerWithAddress;
 let shortfall: MockContract<Shortfall>;
+let fakeAccessControlManager: FakeContract<AccessControlManager>;
 let fakeRiskFund: FakeContract<IRiskFund>;
 let mockBUSD: MockToken;
 let mockDAI: MockToken;
@@ -51,6 +53,8 @@ async function shortfallFixture() {
   mockBUSD = await MockBUSD.deploy("BUSD", "BUSD", 18);
   await mockBUSD.faucet(convertToUnit(100000, 18));
 
+  fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
+  fakeAccessControlManager.isAllowedToCall.returns(true);
   fakeRiskFund = await smock.fake<IRiskFund>("IRiskFund");
 
   const Shortfall = await smock.mock<Shortfall__factory>("Shortfall");
@@ -58,6 +62,7 @@ async function shortfallFixture() {
     mockBUSD.address,
     fakeRiskFund.address,
     parseUnits(minimumPoolBadDebt, "18"),
+    fakeAccessControlManager.address,
   ]);
 
   [owner, someone, bidder1, bidder2] = await ethers.getSigners();

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -9,7 +9,6 @@ import { ethers, upgrades } from "hardhat";
 
 import { AddressOne, convertToUnit } from "../../helpers/utils";
 import {
-  AccessControlManager,
   Comptroller,
   Comptroller__factory,
   IRiskFund,
@@ -38,7 +37,6 @@ let mockWBTC: MockToken;
 let vDAI: MockContract<VToken>;
 let vWBTC: MockContract<VToken>;
 let comptroller: FakeContract<Comptroller>;
-let fakeAccessControlManager: FakeContract<AccessControlManager>;
 let fakePriceOracle: FakeContract<PriceOracle>;
 
 let riskFundBalance = "10000";
@@ -77,11 +75,8 @@ async function shortfallFixture() {
   mockWBTC = await MockWBTC.deploy("Bitcoin", "BTC", 8);
   await mockWBTC.faucet(convertToUnit(1000000000, 8));
 
-  fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
-  fakeAccessControlManager.isAllowedToCall.returns(true);
-
   const Comptroller = await smock.mock<Comptroller__factory>("Comptroller");
-  comptroller = await Comptroller.deploy(poolRegistry.address, fakeAccessControlManager.address);
+  comptroller = await Comptroller.deploy(poolRegistry.address);
   poolAddress = comptroller.address;
 
   poolRegistry.getPoolByComptroller.returns({

--- a/tests/hardhat/Tokens/setters.ts
+++ b/tests/hardhat/Tokens/setters.ts
@@ -46,7 +46,7 @@ describe("VToken", function () {
         .returns(false);
       await expect(vToken.setProtocolSeizeShare(parseUnits("0.03", 18))).to.be.revertedWithCustomError(
         vToken,
-        "SetProtocolSeizeShareUnauthorized",
+        "Unauthorized",
       );
       expect(await vToken.protocolSeizeShareMantissa()).to.equal(parseUnits("0.05", 18));
     });
@@ -71,13 +71,13 @@ describe("VToken", function () {
 
   describe("set access control manager", () => {
     it("reverts if not an owner set access control manager", async () => {
-      await expect(vToken.connect(user).setAccessControlAddress(accessControlManager.address)).revertedWith(
-        "only admin can set ACL address",
+      await expect(vToken.connect(user).setAccessControlManager(accessControlManager.address)).revertedWith(
+        "Ownable: caller is not the owner",
       );
     });
 
     it("success by admin", async () => {
-      await vToken.connect(root).setAccessControlAddress(accessControlManager.address);
+      await vToken.connect(root).setAccessControlManager(accessControlManager.address);
     });
   });
 
@@ -86,7 +86,7 @@ describe("VToken", function () {
       accessControlManager.isAllowedToCall.returns(false);
       await expect(vToken.connect(user).setInterestRateModel(interestRateModel.address)).to.be.revertedWithCustomError(
         vToken,
-        "SetInterestRateModelOwnerCheck",
+        "Unauthorized",
       );
     });
 
@@ -100,7 +100,7 @@ describe("VToken", function () {
       accessControlManager.isAllowedToCall.returns(false);
       await expect(vToken.connect(user).setReserveFactor(convertToUnit(1, 17))).to.be.revertedWithCustomError(
         vToken,
-        "SetReserveFactorAdminCheck",
+        "Unauthorized",
       );
     });
 

--- a/tests/hardhat/UpgradedVToken.ts
+++ b/tests/hardhat/UpgradedVToken.ts
@@ -45,6 +45,9 @@ describe("UpgradedVToken: Tests", function () {
     const riskFund = await smock.fake<RiskFund>("RiskFund");
     const protocolShareReserve = await smock.fake<ProtocolShareReserve>("ProtocolShareReserve");
 
+    fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
+    fakeAccessControlManager.isAllowedToCall.returns(true);
+
     const PoolRegistry = await ethers.getContractFactory("PoolRegistry");
     poolRegistry = await upgrades.deployProxy(PoolRegistry, [
       vTokenFactory.address,
@@ -53,10 +56,8 @@ describe("UpgradedVToken: Tests", function () {
       shortfall.address,
       riskFund.address,
       protocolShareReserve.address,
+      fakeAccessControlManager.address,
     ]);
-
-    fakeAccessControlManager = await smock.fake<AccessControlManager>("AccessControlManager");
-    fakeAccessControlManager.isAllowedToCall.returns(true);
 
     const Comptroller = await ethers.getContractFactory("Comptroller");
     const comptroller = await Comptroller.deploy(poolRegistry.address);

--- a/tests/hardhat/UpgradedVToken.ts
+++ b/tests/hardhat/UpgradedVToken.ts
@@ -59,7 +59,7 @@ describe("UpgradedVToken: Tests", function () {
     fakeAccessControlManager.isAllowedToCall.returns(true);
 
     const Comptroller = await ethers.getContractFactory("Comptroller");
-    const comptroller = await Comptroller.deploy(poolRegistry.address, fakeAccessControlManager.address);
+    const comptroller = await Comptroller.deploy(poolRegistry.address);
     await comptroller.deployed();
 
     const VTokenContract = await ethers.getContractFactory("VToken");
@@ -100,6 +100,7 @@ describe("UpgradedVToken: Tests", function () {
       _minLiquidatableCollateral,
       priceOracle.address,
       maxLoopsLimit,
+      fakeAccessControlManager.address,
     );
 
     // Setup Proxies

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -183,6 +183,7 @@ describe("Positive Cases", () => {
           ethers.constants.AddressZero,
           ethers.constants.AddressZero,
           ethers.constants.AddressZero,
+          ethers.constants.AddressZero,
         ),
       ).to.be.revertedWith("Initializable: contract is already initialized");
     });


### PR DESCRIPTION
This PR refactors the access control mechanism to use `AccessControlled` mixin and adds access controls to the following methods:

Shortfall:
  * startAuction
  * restartAuction

BaseJumpRateModelV2:
  * updateJumpRateModel

PoolRegistry:
  * addMarket
  * createRegistryPool
  * updatePoolMetadata
  * setPoolName

RewardsDistributor:
  * setRewardTokenSpeeds

RiskFund:
  * setMinAmountToConvert

Comptroller:
  * setCloseFactor