### PR TITLE
Refactor/make setters external

### DIFF
--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -308,13 +308,13 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
     }
 
     /**
-     * @notice Sets the pool registry this shortfall supports
+     * @notice Update the pool registry this shortfall supports
      * @dev After Pool Registry is deployed we need to set the pool registry address
      * @param _poolRegistry Address of pool registry contract
      * @custom:event Emits PoolRegistryUpdated on success
      * @custom:access Restricted to owner
      */
-    function setPoolRegistry(address _poolRegistry) external onlyOwner {
+    function updatePoolRegistry(address _poolRegistry) external onlyOwner {
         require(_poolRegistry != address(0), "invalid address");
         address oldPoolRegistry = poolRegistry;
         poolRegistry = _poolRegistry;

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -289,7 +289,7 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
      * @custom:event Emits MinimumPoolBadDebtUpdated on success
      * @custom:access Restricted to owner
      */
-    function updateMinimumPoolBadDebt(uint256 _minimumPoolBadDebt) public onlyOwner {
+    function updateMinimumPoolBadDebt(uint256 _minimumPoolBadDebt) external onlyOwner {
         uint256 oldMinimumPoolBadDebt = minimumPoolBadDebt;
         minimumPoolBadDebt = _minimumPoolBadDebt;
         emit MinimumPoolBadDebtUpdated(oldMinimumPoolBadDebt, _minimumPoolBadDebt);
@@ -301,7 +301,7 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
      * @custom:event Emits WaitForFirstBidderUpdated on success
      * @custom:access Restricted to owner
      */
-    function updateWaitForFirstBidder(uint256 _waitForFirstBidder) public onlyOwner {
+    function updateWaitForFirstBidder(uint256 _waitForFirstBidder) external onlyOwner {
         uint256 oldWaitForFirstBidder = waitForFirstBidder;
         waitForFirstBidder = _waitForFirstBidder;
         emit WaitForFirstBidderUpdated(oldWaitForFirstBidder, _waitForFirstBidder);
@@ -314,7 +314,7 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
      * @custom:event Emits PoolRegistryUpdated on success
      * @custom:access Restricted to owner
      */
-    function setPoolRegistry(address _poolRegistry) public onlyOwner {
+    function setPoolRegistry(address _poolRegistry) external onlyOwner {
         require(_poolRegistry != address(0), "invalid address");
         address oldPoolRegistry = poolRegistry;
         poolRegistry = _poolRegistry;

--- a/deploy/007-deploy-factories.ts
+++ b/deploy/007-deploy-factories.ts
@@ -62,7 +62,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const poolRegistry = await ethers.getContract("PoolRegistry");
   const deployerSigner = ethers.provider.getSigner(deployer);
 
-  const tx = await shortFall.connect(deployerSigner).setPoolRegistry(poolRegistry.address);
+  const tx = await shortFall.connect(deployerSigner).updatePoolRegistry(poolRegistry.address);
   await tx.wait();
 };
 

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -229,7 +229,7 @@ const riskFundFixture = async (): Promise<void> => {
     admin.address,
   );
 
-  await shortfall.connect(shortfall.wallet).setPoolRegistry(poolRegistry.address);
+  await shortfall.connect(shortfall.wallet).updatePoolRegistry(poolRegistry.address);
 
   const Comptroller = await ethers.getContractFactory("Comptroller");
   const comptroller = await Comptroller.deploy(poolRegistry.address);

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -159,7 +159,7 @@ const riskFundFixture = async (): Promise<void> => {
 
   await protocolShareReserve.setPoolRegistry(poolRegistry.address);
 
-  await shortfall.setPoolRegistry(poolRegistry.address);
+  await shortfall.updatePoolRegistry(poolRegistry.address);
 
   const Comptroller = await ethers.getContractFactory("Comptroller");
   const comptroller = await Comptroller.deploy(poolRegistry.address);

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -69,7 +69,7 @@ async function shortfallFixture() {
 
   poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
 
-  await shortfall.setPoolRegistry(poolRegistry.address);
+  await shortfall.updatePoolRegistry(poolRegistry.address);
 
   // Deploy Mock Tokens
   const MockDAI = await ethers.getContractFactory("MockToken");
@@ -153,19 +153,19 @@ describe("Shortfall: Tests", async function () {
   describe("setters", async function () {
     beforeEach(setup);
 
-    describe("setPoolRegistry", async function () {
+    describe("updatePoolRegistry", async function () {
       it("reverts on invalid PoolRegistry address", async function () {
-        await expect(shortfall.setPoolRegistry(constants.AddressZero)).to.be.revertedWith("invalid address");
+        await expect(shortfall.updatePoolRegistry(constants.AddressZero)).to.be.revertedWith("invalid address");
       });
 
       it("fails if called by a non-owner", async function () {
-        await expect(shortfall.connect(someone).setPoolRegistry(poolRegistry.address)).to.be.rejectedWith(
+        await expect(shortfall.connect(someone).updatePoolRegistry(poolRegistry.address)).to.be.rejectedWith(
           "Ownable: caller is not the owner",
         );
       });
 
       it("emits PoolRegistryUpdated event", async function () {
-        const tx = shortfall.setPoolRegistry(someone.address);
+        const tx = shortfall.updatePoolRegistry(someone.address);
         await expect(tx).to.emit(shortfall, "PoolRegistryUpdated").withArgs(poolRegistry.address, someone.address);
       });
     });


### PR DESCRIPTION
## Description

Makes public setters that aren't used internally external.
Change setPoolRegistry method name to match event