### PR TITLE
[VEN-1246] refactor: make poolReserves public on RiskFund

### DIFF
--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -32,7 +32,7 @@ contract RiskFund is
     address private shortfall;
 
     // Store base asset's reserve for specific pool
-    mapping(address => uint256) private poolReserves;
+    mapping(address => uint256) public poolReserves;
 
     /// @notice Emitted when pool registry address is updated
     event PoolRegistryUpdated(address indexed oldPoolRegistry, address indexed newPoolRegistry);

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -698,6 +698,9 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
         ],
       );
+
+      expect(await riskFund.poolReserves(comptroller1Proxy.address)).to.be.equal("29916047622748892393");
+
       const balanceAfter = await USDC.balanceOf(riskFund.address);
       expect(balanceAfter).equal("0");
 
@@ -741,6 +744,9 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
         ],
       );
+
+      expect(await riskFund.poolReserves(comptroller1Proxy.address)).to.be.equal("59832095245497784786");
+
       const balanceBUSD = await BUSD.balanceOf(riskFund.address);
       expect(Number(balanceBUSD)).to.be.closeTo(Number(convertToUnit(60, 18)), Number(convertToUnit(3, 17)));
 
@@ -836,6 +842,8 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
         ],
       );
+
+      expect(await riskFund.poolReserves(comptroller1Proxy.address)).to.be.equal(0);
 
       // revoke
       await accessControlManager.revokeCallPermission(
@@ -958,6 +966,8 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
         ],
       );
+
+      expect(await riskFund.poolReserves(comptroller1Proxy.address)).to.be.equal("56841295980235012443");
 
       riskUSDTFor1 = await riskFund.getPoolAssetReserve(comptroller1Proxy.address, USDT.address);
       riskUSDCFor1 = await riskFund.getPoolAssetReserve(comptroller1Proxy.address, USDC.address);

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -283,6 +283,7 @@ describe("Risk Fund: Swap Tests", () => {
     await protocolShareReserve.releaseFunds(comptroller1Proxy.address, USDT.address, REDUCE_RESERVE_AMOUNT);
 
     await riskFund.swapPoolsAssets([vUSDT.address], [parseUnits("10", 18)]);
+    expect(await riskFund.poolReserves(comptroller1Proxy.address)).to.be.equal("14960261570862459704");
     const balance = await BUSD.balanceOf(riskFund.address);
     expect(Number(balance)).to.be.closeTo(Number(parseUnits("15", 18)), Number(parseUnits("1", 17)));
   });


### PR DESCRIPTION
## Description

Makes poolReserves public for transparency

Resolves [VEN-1246]

