### PR TITLE
[VEN-1248] Refactor: add path to swapPoolAssets

### DIFF
--- a/contracts/RiskFund/IRiskFund.sol
+++ b/contracts/RiskFund/IRiskFund.sol
@@ -2,7 +2,11 @@
 pragma solidity 0.8.13;
 
 interface IRiskFund {
-    function swapPoolsAssets(address[] calldata markets, uint256[] calldata amountsOutMin) external returns (uint256);
+    function swapPoolsAssets(
+        address[] calldata markets,
+        uint256[] calldata amountsOutMin,
+        address[][] calldata paths
+    ) external returns (uint256);
 
     function transferReserveForAuction(address comptroller, uint256 amount) external returns (uint256);
 

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -148,14 +148,15 @@ contract RiskFund is
      * @param amountsOutMin Minimum amount to recieve for swap
      * @return Number of swapped tokens.
      */
-    function swapPoolsAssets(address[] calldata markets, uint256[] calldata amountsOutMin)
-        external
-        override
-        returns (uint256)
-    {
-        _checkAccessAllowed("swapPoolsAssets(address[],uint256[])");
+    function swapPoolsAssets(
+        address[] calldata markets,
+        uint256[] calldata amountsOutMin,
+        address[][] calldata paths
+    ) external override returns (uint256) {
+        _checkAccessAllowed("swapPoolsAssets(address[],uint256[],address[][])");
         require(poolRegistry != address(0), "Risk fund: Invalid pool registry.");
         require(markets.length == amountsOutMin.length, "Risk fund: markets and amountsOutMin are unequal lengths");
+        require(markets.length == paths.length, "Risk fund: markets and paths are unequal lengths");
 
         uint256 totalAmount;
         uint256 marketsCount = markets.length;
@@ -170,7 +171,7 @@ contract RiskFund is
             require(pool.comptroller == comptroller, "comptroller doesn't exist pool registry");
             require(Comptroller(comptroller).isMarketListed(vToken), "market is not listed");
 
-            uint256 swappedTokens = _swapAsset(vToken, comptroller, amountsOutMin[i]);
+            uint256 swappedTokens = _swapAsset(vToken, comptroller, amountsOutMin[i], paths[i]);
             poolReserves[comptroller] = poolReserves[comptroller] + swappedTokens;
             totalAmount = totalAmount + swappedTokens;
         }
@@ -233,7 +234,8 @@ contract RiskFund is
     function _swapAsset(
         VToken vToken,
         address comptroller,
-        uint256 amountOutMin
+        uint256 amountOutMin,
+        address[] calldata path
     ) internal returns (uint256) {
         require(amountOutMin != 0, "RiskFund: amountOutMin must be greater than 0 to swap vToken");
         require(amountOutMin >= minAmountToConvert, "RiskFund: amountOutMin should be greater than minAmountToConvert");
@@ -257,9 +259,11 @@ contract RiskFund is
                 poolsAssetsReserves[comptroller][underlyingAsset] -= balanceOfUnderlyingAsset;
 
                 if (underlyingAsset != convertibleBaseAsset) {
-                    address[] memory path = new address[](2);
-                    path[0] = underlyingAsset;
-                    path[1] = convertibleBaseAsset;
+                    require(path[0] == underlyingAsset, "RiskFund: swap path must start with the underlying asset");
+                    require(
+                        path[path.length - 1] == convertibleBaseAsset,
+                        "RiskFund: finally path must be convertible base asset"
+                    );
                     IERC20Upgradeable(underlyingAsset).safeApprove(pancakeSwapRouter, 0);
                     IERC20Upgradeable(underlyingAsset).safeApprove(pancakeSwapRouter, balanceOfUnderlyingAsset);
                     uint256[] memory amounts = IPancakeswapV2Router(pancakeSwapRouter).swapExactTokensForTokens(

--- a/deploy/008-access-control-configure.ts
+++ b/deploy/008-access-control-configure.ts
@@ -91,7 +91,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log("DEFAULT_ADMIN | VTokenProxyFactory | setInterestRateModel(address)");
   tx = await accessControlManager.giveCallPermission(
     riskFund.address,
-    "swapPoolsAssets(address[],uint256[])",
+    "swapPoolsAssets(address[],uint256[],address[][])",
     deployer,
   );
   await tx.wait();

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -225,7 +225,7 @@ const riskFundFixture = async (): Promise<void> => {
 
   await accessControlManager.giveCallPermission(
     riskFund.address,
-    "swapPoolsAssets(address[],uint256[])",
+    "swapPoolsAssets(address[],uint256[],address[][])",
     admin.address,
   );
 
@@ -586,8 +586,37 @@ describe("Risk Fund: Tests", function () {
     describe("swapPoolsAssets", async function () {
       it("fails if called with incorrect arguments", async function () {
         await expect(
-          riskFund.swapPoolsAssets([cUSDT.address, cUSDC.address], [convertToUnit(10, 18)]),
+          riskFund.swapPoolsAssets([cUSDT.address, cUSDC.address], [convertToUnit(10, 18)], []),
         ).to.be.revertedWith("Risk fund: markets and amountsOutMin are unequal lengths");
+      });
+
+      it("fails if called with incorrect path length", async function () {
+        await expect(
+          riskFund.swapPoolsAssets([cUSDT.address, cUSDC.address], [convertToUnit(10, 18), convertToUnit(10, 18)], []),
+        ).to.be.revertedWith("Risk fund: markets and paths are unequal lengths");
+      });
+
+      it("fails if start path is not market", async function () {
+        await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
+
+        await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
+        await cUSDC.reduceReserves(convertToUnit(100, 18));
+        await protocolShareReserve.releaseFunds(comptroller1Proxy.address, USDC.address, convertToUnit(100, 18));
+
+        await expect(
+          riskFund.swapPoolsAssets([cUSDC.address], [convertToUnit(10, 18)], [[USDT.address, BUSD.address]]),
+        ).to.be.revertedWith("RiskFund: swap path must start with the underlying asset");
+      });
+
+      it("fails if final path is not base convertible asset", async function () {
+        await USDC.connect(usdcUser).approve(cUSDC.address, convertToUnit(1000, 18));
+
+        await cUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
+        await cUSDC.reduceReserves(convertToUnit(100, 18));
+        await protocolShareReserve.releaseFunds(comptroller1Proxy.address, USDC.address, convertToUnit(100, 18));
+        await expect(
+          riskFund.swapPoolsAssets([cUSDC.address], [convertToUnit(10, 18)], [[USDC.address, USDT.address]]),
+        ).to.be.revertedWith("RiskFund: finally path must be convertible base asset");
       });
     });
 
@@ -619,20 +648,20 @@ describe("Risk Fund: Tests", function () {
       // Revoke
       await accessControlManager.revokeCallPermission(
         riskFund.address,
-        "swapPoolsAssets(address[],uint256[])",
+        "swapPoolsAssets(address[],uint256[],address[][])",
         admin.address,
       );
       // Fails
-      await expect(riskFund.swapPoolsAssets([], [])).to.be.revertedWithCustomError(riskFund, "Unauthorized");
+      await expect(riskFund.swapPoolsAssets([], [], [])).to.be.revertedWithCustomError(riskFund, "Unauthorized");
 
       // Reset
       await accessControlManager.giveCallPermission(
         riskFund.address,
-        "swapPoolsAssets(address[],uint256[])",
+        "swapPoolsAssets(address[],uint256[],address[][])",
         admin.address,
       );
       // Succeeds
-      await riskFund.swapPoolsAssets([], []);
+      await riskFund.swapPoolsAssets([], [], []);
     });
 
     it("Convert to BUSD without funds", async function () {
@@ -644,6 +673,13 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
           convertToUnit(10, 18),
           convertToUnit(10, 18),
+        ],
+        [
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
         ],
       );
       expect(amount).equal("0");
@@ -671,6 +707,13 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
           convertToUnit(10, 18),
         ],
+        [
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+        ],
       );
       expect(amount).equal("0");
     });
@@ -696,6 +739,13 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
           convertToUnit(10, 18),
           convertToUnit(10, 18),
+        ],
+        [
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
         ],
       );
 
@@ -742,6 +792,13 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
           convertToUnit(10, 18),
           convertToUnit(10, 18),
+        ],
+        [
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
         ],
       );
 
@@ -801,6 +858,13 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
           convertToUnit(10, 18),
         ],
+        [
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+        ],
       );
 
       const beforeTransfer = await BUSD.balanceOf(shortfall.address);
@@ -841,6 +905,13 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
           convertToUnit(10, 18),
         ],
+        [
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+        ],
       );
 
       expect(await riskFund.poolReserves(comptroller1Proxy.address)).to.be.equal(0);
@@ -864,7 +935,7 @@ describe("Risk Fund: Tests", function () {
       );
     });
 
-    it("Transfer single asset from multiple pools to riskFund.", async function () {
+    it("Transfer single asset from multiple pools to riskFund", async function () {
       const auctionContract = await smock.fake<Shortfall>("Shortfall");
       await auctionContract.convertibleBaseAsset.returns(BUSD.address);
 
@@ -964,6 +1035,14 @@ describe("Risk Fund: Tests", function () {
           convertToUnit(10, 18),
           convertToUnit(10, 18),
           convertToUnit(10, 18),
+        ],
+        [
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+          [USDC.address, BUSD.address],
+          [USDT.address, BUSD.address],
+          [USDT.address, BUSD.address],
         ],
       );
 

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -282,8 +282,9 @@ describe("Risk Fund: Swap Tests", () => {
 
     await protocolShareReserve.releaseFunds(comptroller1Proxy.address, USDT.address, REDUCE_RESERVE_AMOUNT);
 
-    await riskFund.swapPoolsAssets([vUSDT.address], [parseUnits("10", 18)]);
+    await riskFund.swapPoolsAssets([vUSDT.address], [parseUnits("10", 18)], [[USDT.address, BUSD.address]]);
     expect(await riskFund.poolReserves(comptroller1Proxy.address)).to.be.equal("14960261570862459704");
+
     const balance = await BUSD.balanceOf(riskFund.address);
     expect(Number(balance)).to.be.closeTo(Number(parseUnits("15", 18)), Number(parseUnits("1", 17)));
   });


### PR DESCRIPTION
## Description

This PR adds an array of swap paths to the `swapPoolsAsset` method. This allows for multiple hops in the swap allowing better optimization for price

Resolves [VEN-1248]