### PR TITLE
refactor: remove access controls on auctions

### DIFF
--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -251,11 +251,8 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
      * @notice Start a auction when there is not currently one active
      * @param comptroller Comptroller address of the pool
      * @custom:event Emits AuctionStarted event on success
-     * @custom:error Unauthorized error is thrown if ACM denies the access
-     * @custom:access Controlled by AccessControlManager
      */
     function startAuction(address comptroller) external {
-        _checkAccessAllowed("startAuction(address)");
         _startAuction(comptroller);
     }
 
@@ -263,12 +260,8 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlled, ReentrancyGuard
      * @notice Restart an auction
      * @param comptroller Address of the pool
      * @custom:event Emits AuctionRestarted event on successful restart
-     * @custom:error Unauthorized error is thrown if ACM denies the access
-     * @custom:access Controlled by AccessControlManager
      */
     function restartAuction(address comptroller) external {
-        _checkAccessAllowed("restartAuction(address)");
-
         Auction storage auction = auctions[comptroller];
 
         require(auction.startBlock != 0 && auction.status == AuctionStatus.STARTED, "no on-going auction");

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -212,12 +212,6 @@ describe("Shortfall: Tests", async function () {
   describe("LARGE_POOL_DEBT Scenario", async function () {
     before(setup);
 
-    it("startAuction fails if ACM does not allow the call", async function () {
-      fakeAccessControlManager.isAllowedToCall.returns(false);
-      await expect(shortfall.startAuction(poolAddress)).to.be.revertedWithCustomError(shortfall, "Unauthorized");
-      fakeAccessControlManager.isAllowedToCall.returns(true);
-    });
-
     it("Should have debt and reserve", async function () {
       vDAI.badDebt.returns(parseUnits("1000", 18));
       vWBTC.badDebt.returns(parseUnits("1", 8));
@@ -493,11 +487,6 @@ describe("Shortfall: Tests", async function () {
 
   describe("Restart Auction", async function () {
     beforeEach(setup);
-
-    it("fails if ACM does not allow the call", async function () {
-      fakeAccessControlManager.isAllowedToCall.returns(false);
-      await expect(shortfall.restartAuction(poolAddress)).to.be.revertedWithCustomError(shortfall, "Unauthorized");
-    });
 
     it("Can't restart auction early ", async function () {
       vDAI.badDebt.returns(parseUnits("10000", 18));


### PR DESCRIPTION
## Description

Removes access controls for starting and restarting auctions as any one can start an auction as long as the conditions are met