### PR TITLE
refactor: add lib/ folder with constants and pure utility functions

### DIFF
--- a/contracts/BaseJumpRateModelV2.sol
+++ b/contracts/BaseJumpRateModelV2.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 
+import { BLOCKS_PER_YEAR, BASE } from "./lib/constants.sol";
 import "@venusprotocol/governance-contracts/contracts/Governance/IAccessControlManagerV8.sol";
 import "./InterestRateModel.sol";
 
@@ -10,17 +11,10 @@ import "./InterestRateModel.sol";
  * @notice Version 2 modifies Version 1 by enabling updateable parameters.
  */
 abstract contract BaseJumpRateModelV2 is InterestRateModel {
-    uint256 private constant BASE = 1e18;
-
     /**
      * @notice The address of the AccessControlManager contract
      */
     IAccessControlManagerV8 public accessControlManager;
-
-    /**
-     * @notice The approximate number of blocks per year that is assumed by the interest rate model
-     */
-    uint256 public constant blocksPerYear = 10512000;
 
     /**
      * @notice The multiplier of utilization rate that gives the slope of the interest rate
@@ -154,9 +148,9 @@ abstract contract BaseJumpRateModelV2 is InterestRateModel {
         uint256 jumpMultiplierPerYear,
         uint256 kink_
     ) internal {
-        baseRatePerBlock = baseRatePerYear / blocksPerYear;
-        multiplierPerBlock = (multiplierPerYear * BASE) / (blocksPerYear * kink_);
-        jumpMultiplierPerBlock = jumpMultiplierPerYear / blocksPerYear;
+        baseRatePerBlock = baseRatePerYear / BLOCKS_PER_YEAR;
+        multiplierPerBlock = (multiplierPerYear * BASE) / (BLOCKS_PER_YEAR * kink_);
+        jumpMultiplierPerBlock = jumpMultiplierPerYear / BLOCKS_PER_YEAR;
         kink = kink_;
 
         emit NewInterestParams(baseRatePerBlock, multiplierPerBlock, jumpMultiplierPerBlock, kink);

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.13;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
+import { ensureNonzeroAddress } from "./lib/validators.sol";
 import "./VToken.sol";
 import "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";
 import "./ComptrollerInterface.sol";
@@ -124,8 +125,9 @@ contract Comptroller is
     error BorrowCapExceeded(address market, uint256 cap);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
+    /// @custom:error ZeroAddressNotAllowed is thrown when pool registry address is zero
     constructor(address poolRegistry_) {
-        require(poolRegistry_ != address(0), "invalid pool registry address");
+        ensureNonzeroAddress(poolRegistry_);
 
         poolRegistry = poolRegistry_;
         _disableInitializers();
@@ -957,9 +959,10 @@ contract Comptroller is
      * @dev Only callable by the admin
      * @param newOracle Address of the new ResilientOracleInterface to set
      * @custom:event Emits NewPriceOracle on success
+     * @custom:error ZeroAddressNotAllowed is thrown when the new oracle address is zero
      */
     function setPriceOracle(ResilientOracleInterface newOracle) external onlyOwner {
-        require(address(newOracle) != address(0), "invalid price oracle address");
+        ensureNonzeroAddress(address(newOracle));
 
         ResilientOracleInterface oldOracle = oracle;
         oracle = newOracle;

--- a/contracts/ErrorReporter.sol
+++ b/contracts/ErrorReporter.sol
@@ -54,6 +54,4 @@ contract TokenErrorReporter {
     error ReduceReservesCashValidation();
 
     error SetInterestRateModelFreshCheck();
-
-    error ZeroAddressNotAllowed();
 }

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -6,6 +6,7 @@ import "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
+import { ensureNonzeroAddress } from "../lib/validators.sol";
 import "../Comptroller.sol";
 import "../Factories/VTokenProxyFactory.sol";
 import "../Factories/JumpRateModelFactory.sol";
@@ -141,11 +142,6 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlledV8, PoolRegist
      */
     event NewProtocolShareReserve(address indexed oldProtocolShareReserve, address indexed newProtocolShareReserve);
 
-    /**
-     * @notice Thrown if trying to set a zero address where it's not allowed
-     */
-    error ZeroAddressNotAllowed();
-
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         // Note that the contract is upgradeable. Use initialize() or reinitializers
@@ -160,6 +156,8 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlledV8, PoolRegist
      * @param whitePaperFactory_ white paper factory address.
      * @param protocolShareReserve_ protocol's shares reserve address.
      * @param accessControlManager_ AccessControlManager contract address.
+     * @custom:error ZeroAddressNotAllowed is thrown when shortfall contract address is zero
+     * @custom:error ZeroAddressNotAllowed is thrown when protocol share reserve address is zero
      */
     function initialize(
         VTokenProxyFactory vTokenFactory_,
@@ -209,6 +207,8 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlledV8, PoolRegist
      * @param maxLoopsLimit The maximum limit for the loops can iterate.
      * @return index The index of the registered Venus pool
      * @return proxyAddress The the Comptroller proxy address
+     * @custom:error ZeroAddressNotAllowed is thrown when Comptroller beacon address is zero
+     * @custom:error ZeroAddressNotAllowed is thrown when price oracle address is zero
      */
     function createRegistryPool(
         string calldata name,
@@ -222,8 +222,8 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlledV8, PoolRegist
     ) external virtual returns (uint256 index, address proxyAddress) {
         _checkAccessAllowed("createRegistryPool(string,address,uint256,uint256,uint256,address,uint256,address)");
         // Input validation
-        require(beaconAddress != address(0), "PoolRegistry: Invalid Comptroller beacon address.");
-        require(priceOracle != address(0), "PoolRegistry: Invalid ResilientOracleInterface address.");
+        ensureNonzeroAddress(beaconAddress);
+        ensureNonzeroAddress(priceOracle);
 
         BeaconProxy proxy = new BeaconProxy(
             beaconAddress,
@@ -251,13 +251,17 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlledV8, PoolRegist
     /**
      * @notice Add a market to an existing pool and then mint to provide initial supply.
      * @param input The structure describing the parameters for adding a market to a pool.
+     * @custom:error ZeroAddressNotAllowed is thrown when Comptroller address is zero
+     * @custom:error ZeroAddressNotAllowed is thrown when asset address is zero
+     * @custom:error ZeroAddressNotAllowed is thrown when VToken beacon address is zero
+     * @custom:error ZeroAddressNotAllowed is thrown when vTokenReceiver address is zero
      */
     function addMarket(AddMarketInput memory input) external {
         _checkAccessAllowed("addMarket(AddMarketInput)");
-        require(input.comptroller != address(0), "PoolRegistry: Invalid comptroller address");
-        require(input.asset != address(0), "PoolRegistry: Invalid asset address");
-        require(input.beaconAddress != address(0), "PoolRegistry: Invalid beacon address");
-        require(input.vTokenReceiver != address(0), "PoolRegistry: Invalid vTokenReceiver address");
+        ensureNonzeroAddress(input.comptroller);
+        ensureNonzeroAddress(input.asset);
+        ensureNonzeroAddress(input.beaconAddress);
+        ensureNonzeroAddress(input.vTokenReceiver);
 
         // solhint-disable-next-line reason-string
         require(
@@ -419,18 +423,14 @@ contract PoolRegistry is Ownable2StepUpgradeable, AccessControlledV8, PoolRegist
     }
 
     function _setShortfallContract(Shortfall shortfall_) internal {
-        if (address(shortfall_) == address(0)) {
-            revert ZeroAddressNotAllowed();
-        }
+        ensureNonzeroAddress(address(shortfall_));
         address oldShortfall = address(shortfall);
         shortfall = shortfall_;
         emit NewShortfallContract(oldShortfall, address(shortfall_));
     }
 
     function _setProtocolShareReserve(address payable protocolShareReserve_) internal {
-        if (protocolShareReserve_ == address(0)) {
-            revert ZeroAddressNotAllowed();
-        }
+        ensureNonzeroAddress(protocolShareReserve_);
         address oldProtocolShareReserve = protocolShareReserve;
         protocolShareReserve = protocolShareReserve_;
         emit NewProtocolShareReserve(oldProtocolShareReserve, protocolShareReserve_);

--- a/contracts/RiskFund/ProtocolShareReserve.sol
+++ b/contracts/RiskFund/ProtocolShareReserve.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.13;
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
+import { ensureNonzeroAddress } from "../lib/validators.sol";
 import "../ExponentialNoError.sol";
 import "./IRiskFund.sol";
 import "./ReserveHelpers.sol";
@@ -33,28 +34,31 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
 
     /**
      * @dev Initializes the deployer to owner.
-     * @param _protocolIncome The address protocol income will be sent to
-     * @param _riskFund Risk fund address
+     * @param protocolIncome_ The address protocol income will be sent to
+     * @param riskFund_ Risk fund address
+     * @custom:error ZeroAddressNotAllowed is thrown when protocol income address is zero
+     * @custom:error ZeroAddressNotAllowed is thrown when risk fund address is zero
      */
-    function initialize(address _protocolIncome, address _riskFund) external initializer {
-        require(_protocolIncome != address(0), "ProtocolShareReserve: Protocol Income address invalid");
-        require(_riskFund != address(0), "ProtocolShareReserve: Risk Fund address invalid");
+    function initialize(address protocolIncome_, address riskFund_) external initializer {
+        ensureNonzeroAddress(protocolIncome_);
+        ensureNonzeroAddress(riskFund_);
 
         __Ownable2Step_init();
 
-        protocolIncome = _protocolIncome;
-        riskFund = _riskFund;
+        protocolIncome = protocolIncome_;
+        riskFund = riskFund_;
     }
 
     /**
      * @dev Pool registry setter.
-     * @param _poolRegistry Address of the pool registry
+     * @param poolRegistry_ Address of the pool registry
+     * @custom:error ZeroAddressNotAllowed is thrown when pool registry address is zero
      */
-    function setPoolRegistry(address _poolRegistry) external onlyOwner {
-        require(_poolRegistry != address(0), "ProtocolShareReserve: Pool registry address invalid");
+    function setPoolRegistry(address poolRegistry_) external onlyOwner {
+        ensureNonzeroAddress(poolRegistry_);
         address oldPoolRegistry = poolRegistry;
-        poolRegistry = _poolRegistry;
-        emit PoolRegistryUpdated(oldPoolRegistry, _poolRegistry);
+        poolRegistry = poolRegistry_;
+        emit PoolRegistryUpdated(oldPoolRegistry, poolRegistry_);
     }
 
     /**
@@ -62,13 +66,14 @@ contract ProtocolShareReserve is Ownable2StepUpgradeable, ExponentialNoError, Re
      * @param asset  Asset to be released
      * @param amount Amount to release
      * @return Number of total released tokens
+     * @custom:error ZeroAddressNotAllowed is thrown when asset address is zero
      */
     function releaseFunds(
         address comptroller,
         address asset,
         uint256 amount
     ) external returns (uint256) {
-        require(asset != address(0), "ProtocolShareReserve: Asset address invalid");
+        ensureNonzeroAddress(asset);
         require(amount <= poolsAssetsReserves[comptroller][asset], "ProtocolShareReserve: Insufficient pool balance");
 
         assetsReserves[asset] -= amount;

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.13;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
+import { ensureNonzeroAddress } from "../lib/validators.sol";
 import "../ComptrollerInterface.sol";
 import "../Pool/PoolRegistryInterface.sol";
 
@@ -34,10 +35,11 @@ contract ReserveHelpers {
      * @param comptroller  Comptroller address(pool).
      * @param asset Asset address.
      * @return Asset's reserve in risk fund.
+     * @custom:error ZeroAddressNotAllowed is thrown when asset address is zero
      */
     function getPoolAssetReserve(address comptroller, address asset) external view returns (uint256) {
+        ensureNonzeroAddress(asset);
         require(ComptrollerInterface(comptroller).isComptroller(), "ReserveHelpers: Comptroller address invalid");
-        require(asset != address(0), "ReserveHelpers: Asset address invalid");
         return poolsAssetsReserves[comptroller][asset];
     }
 
@@ -46,10 +48,11 @@ contract ReserveHelpers {
      * and transferring funds to the protocol share reserve
      * @param comptroller  Comptroller address(pool).
      * @param asset Asset address.
+     * @custom:error ZeroAddressNotAllowed is thrown when asset address is zero
      */
     function updateAssetsState(address comptroller, address asset) public virtual {
+        ensureNonzeroAddress(asset);
         require(ComptrollerInterface(comptroller).isComptroller(), "ReserveHelpers: Comptroller address invalid");
-        require(asset != address(0), "ReserveHelpers: Asset address invalid");
         require(poolRegistry != address(0), "ReserveHelpers: Pool Registry address is not set");
         require(
             PoolRegistryInterface(poolRegistry).getVTokenForAsset(comptroller, asset) != address(0),

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";
 
+import { ensureNonzeroAddress } from "../lib/validators.sol";
 import "../VToken.sol";
 import "../ComptrollerInterface.sol";
 import "../RiskFund/IRiskFund.sol";
@@ -127,6 +128,8 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlledV8, ReentrancyGua
      * @param riskFund_ RiskFund contract address
      * @param minimumPoolBadDebt_ Minimum bad debt in base asset for a pool to start auction
      * @param accessControlManager_ AccessControlManager contract address
+     * @custom:error ZeroAddressNotAllowed is thrown when convertible base asset address is zero
+     * @custom:error ZeroAddressNotAllowed is thrown when risk fund address is zero
      */
     function initialize(
         address convertibleBaseAsset_,
@@ -134,8 +137,8 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlledV8, ReentrancyGua
         uint256 minimumPoolBadDebt_,
         address accessControlManager_
     ) external initializer {
-        require(convertibleBaseAsset_ != address(0), "invalid base asset address");
-        require(address(riskFund_) != address(0), "invalid risk fund address");
+        ensureNonzeroAddress(convertibleBaseAsset_);
+        ensureNonzeroAddress(address(riskFund_));
         require(minimumPoolBadDebt_ != 0, "invalid minimum pool bad debt");
 
         __Ownable2Step_init();
@@ -341,15 +344,16 @@ contract Shortfall is Ownable2StepUpgradeable, AccessControlledV8, ReentrancyGua
     /**
      * @notice Update the pool registry this shortfall supports
      * @dev After Pool Registry is deployed we need to set the pool registry address
-     * @param _poolRegistry Address of pool registry contract
+     * @param poolRegistry_ Address of pool registry contract
      * @custom:event Emits PoolRegistryUpdated on success
      * @custom:access Restricted to owner
+     * @custom:error ZeroAddressNotAllowed is thrown when pool registry address is zero
      */
-    function updatePoolRegistry(address _poolRegistry) external onlyOwner {
-        require(_poolRegistry != address(0), "invalid address");
+    function updatePoolRegistry(address poolRegistry_) external onlyOwner {
+        ensureNonzeroAddress(poolRegistry_);
         address oldPoolRegistry = poolRegistry;
-        poolRegistry = _poolRegistry;
-        emit PoolRegistryUpdated(oldPoolRegistry, _poolRegistry);
+        poolRegistry = poolRegistry_;
+        emit PoolRegistryUpdated(oldPoolRegistry, poolRegistry_);
     }
 
     /**

--- a/contracts/WhitePaperInterestRateModel.sol
+++ b/contracts/WhitePaperInterestRateModel.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity 0.8.13;
 
+import { BLOCKS_PER_YEAR, BASE } from "./lib/constants.sol";
 import "./InterestRateModel.sol";
 
 /**
@@ -9,13 +10,6 @@ import "./InterestRateModel.sol";
  * @notice The parameterized model described in section 2.4 of the original Compound Protocol whitepaper
  */
 contract WhitePaperInterestRateModel is InterestRateModel {
-    uint256 private constant BASE = 1e18;
-
-    /**
-     * @notice The approximate number of blocks per year that is assumed by the interest rate model
-     */
-    uint256 public constant blocksPerYear = 2102400;
-
     /**
      * @notice The multiplier of utilization rate that gives the slope of the interest rate
      */
@@ -34,8 +28,8 @@ contract WhitePaperInterestRateModel is InterestRateModel {
      * @param multiplierPerYear The rate of increase in interest rate wrt utilization (scaled by BASE)
      */
     constructor(uint256 baseRatePerYear, uint256 multiplierPerYear) {
-        baseRatePerBlock = baseRatePerYear / blocksPerYear;
-        multiplierPerBlock = multiplierPerYear / blocksPerYear;
+        baseRatePerBlock = baseRatePerYear / BLOCKS_PER_YEAR;
+        multiplierPerBlock = multiplierPerYear / BLOCKS_PER_YEAR;
 
         emit NewInterestParams(baseRatePerBlock, multiplierPerBlock);
     }

--- a/contracts/lib/constants.sol
+++ b/contracts/lib/constants.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.8.13;
+
+/// @dev The approximate number of blocks per year that is assumed by the interest rate model
+uint256 constant BLOCKS_PER_YEAR = 10_512_000;
+
+/// @dev Base unit for computations
+uint256 constant BASE = 1e18;

--- a/contracts/lib/validators.sol
+++ b/contracts/lib/validators.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.13;
+
+/// @notice Thrown if the supplied address is a zero address where it is not allowed
+error ZeroAddressNotAllowed();
+
+/// @notice Checks if the provided address is nonzero, reverts otherwise
+/// @param address_ Address to check
+/// @custom:error ZeroAddressNotAllowed is thrown if the provided address is a zero address
+function ensureNonzeroAddress(address address_) pure {
+    if (address_ == address(0)) {
+        revert ZeroAddressNotAllowed();
+    }
+}

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -518,8 +518,9 @@ describe("Risk Fund: Tests", function () {
   describe("Test all setters", async function () {
     describe("setPoolRegistry", async function () {
       it("reverts on invalid PoolRegistry address", async function () {
-        await expect(riskFund.setPoolRegistry(constants.AddressZero)).to.be.revertedWith(
-          "Risk Fund: Pool registry address invalid",
+        await expect(riskFund.setPoolRegistry(constants.AddressZero)).to.be.revertedWithCustomError(
+          riskFund,
+          "ZeroAddressNotAllowed",
         );
       });
 
@@ -540,8 +541,9 @@ describe("Risk Fund: Tests", function () {
 
     describe("setShortfallContractAddress", async function () {
       it("Reverts on invalid Auction contract address", async function () {
-        await expect(riskFund.setShortfallContractAddress(constants.AddressZero)).to.be.revertedWith(
-          "Risk Fund: Shortfall contract address invalid",
+        await expect(riskFund.setShortfallContractAddress(constants.AddressZero)).to.be.revertedWithCustomError(
+          riskFund,
+          "ZeroAddressNotAllowed",
         );
       });
 
@@ -563,8 +565,9 @@ describe("Risk Fund: Tests", function () {
 
     describe("setPancakeSwapRouter", async function () {
       it("Reverts on invalid PancakeSwap router contract address", async function () {
-        await expect(riskFund.setPancakeSwapRouter(constants.AddressZero)).to.be.revertedWith(
-          "Risk Fund: PancakeSwap address invalid",
+        await expect(riskFund.setPancakeSwapRouter(constants.AddressZero)).to.be.revertedWithCustomError(
+          riskFund,
+          "ZeroAddressNotAllowed",
         );
       });
 

--- a/tests/hardhat/PoolRegistry.ts
+++ b/tests/hardhat/PoolRegistry.ts
@@ -329,25 +329,25 @@ describe("PoolRegistry: Tests", function () {
     it("reverts if Comptroller address is zero", async () => {
       await expect(
         poolRegistry.addMarket(withDefaultMarketParameters({ comptroller: constants.AddressZero })),
-      ).to.be.revertedWith("PoolRegistry: Invalid comptroller address");
+      ).to.be.revertedWithCustomError(poolRegistry, "ZeroAddressNotAllowed");
     });
 
     it("reverts if the asset address is zero", async () => {
       await expect(
         poolRegistry.addMarket(withDefaultMarketParameters({ asset: constants.AddressZero })),
-      ).to.be.revertedWith("PoolRegistry: Invalid asset address");
+      ).to.be.revertedWithCustomError(poolRegistry, "ZeroAddressNotAllowed");
     });
 
     it("reverts if the beacon address is zero", async () => {
       await expect(
         poolRegistry.addMarket(withDefaultMarketParameters({ beaconAddress: constants.AddressZero })),
-      ).to.be.revertedWith("PoolRegistry: Invalid beacon address");
+      ).to.be.revertedWithCustomError(poolRegistry, "ZeroAddressNotAllowed");
     });
 
     it("reverts if vTokenReceiver address is zero", async () => {
       await expect(
         poolRegistry.addMarket(withDefaultMarketParameters({ vTokenReceiver: constants.AddressZero })),
-      ).to.be.revertedWith("PoolRegistry: Invalid vTokenReceiver address");
+      ).to.be.revertedWithCustomError(poolRegistry, "ZeroAddressNotAllowed");
     });
 
     it("adds a new vToken to the pool", async () => {
@@ -600,7 +600,7 @@ describe("PoolRegistry: Tests", function () {
           maxLoopsLimit,
           fakeAccessControlManager.address,
         ),
-      ).to.be.revertedWith("PoolRegistry: Invalid Comptroller beacon address.");
+      ).to.be.revertedWithCustomError(poolRegistry, "ZeroAddressNotAllowed");
     });
 
     it("reverts if price oracle address is zero", async () => {
@@ -615,7 +615,7 @@ describe("PoolRegistry: Tests", function () {
           maxLoopsLimit,
           fakeAccessControlManager.address,
         ),
-      ).to.be.revertedWith("PoolRegistry: Invalid ResilientOracleInterface address.");
+      ).to.be.revertedWithCustomError(poolRegistry, "ZeroAddressNotAllowed");
     });
   });
 

--- a/tests/hardhat/ProtocolShareReserve.ts
+++ b/tests/hardhat/ProtocolShareReserve.ts
@@ -1,6 +1,7 @@
 import { FakeContract, smock } from "@defi-wonderland/smock";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
+import { constants } from "ethers";
 import { ethers, upgrades } from "hardhat";
 
 import { convertToUnit } from "../../helpers/utils";
@@ -49,8 +50,8 @@ describe("ProtocolShareReserve: Tests", function () {
 
   it("Revert on invalid asset address.", async function () {
     await expect(
-      protocolShareReserve.releaseFunds(fakeComptroller.address, "0x0000000000000000000000000000000000000000", 10),
-    ).to.be.rejectedWith("ProtocolShareReserve: Asset address invalid");
+      protocolShareReserve.releaseFunds(fakeComptroller.address, constants.AddressZero, 10),
+    ).to.be.revertedWithCustomError(protocolShareReserve, "ZeroAddressNotAllowed");
   });
 
   it("Revert on Insufficient balance.", async function () {
@@ -60,7 +61,7 @@ describe("ProtocolShareReserve: Tests", function () {
         mockDAI.address,
         10,
       ),
-    ).to.be.rejectedWith("ProtocolShareReserve: Insufficient pool balance");
+    ).to.be.revertedWith("ProtocolShareReserve: Insufficient pool balance");
   });
 
   it("Release liquidated share reserve", async function () {

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -167,7 +167,10 @@ describe("Shortfall: Tests", async function () {
 
     describe("updatePoolRegistry", async function () {
       it("reverts on invalid PoolRegistry address", async function () {
-        await expect(shortfall.updatePoolRegistry(constants.AddressZero)).to.be.revertedWith("invalid address");
+        await expect(shortfall.updatePoolRegistry(constants.AddressZero)).to.be.revertedWithCustomError(
+          shortfall,
+          "ZeroAddressNotAllowed",
+        );
       });
 
       it("fails if called by a non-owner", async function () {


### PR DESCRIPTION
This PR moves address validation and constants out of the contracts to separate files. This would provide better reusability and reduce code duplication.

Let me know what you think of this approach.