### PR TITLE
[VEN-1495] [VEN-1496] [VEN-1497]: Fix/code4rena medium issues

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -344,7 +344,7 @@ contract Comptroller is
         if (!markets[vToken].accountMembership[borrower]) {
             // only vTokens may call borrowAllowed if borrower not in market
             _checkSenderIs(vToken);
-
+            _ensureMaxLoops(accountAssets[msg.sender].length + 1);
             // attempt to add borrower to the market or revert
             _addToMarket(VToken(msg.sender), borrower);
         }

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -907,7 +907,7 @@ contract Comptroller is
         uint256 marketsCount = marketsList.length;
         uint256 actionsCount = actionsList.length;
 
-        _ensureMaxLoops(marketsCount);
+        _ensureMaxLoops(marketsCount * actionsCount);
 
         for (uint256 marketIdx; marketIdx < marketsCount; ++marketIdx) {
             for (uint256 actionIdx; actionIdx < actionsCount; ++actionIdx) {

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -619,7 +619,7 @@ contract Comptroller is
         );
 
         Exp memory percentage = div_(collateral, scaledBorrows);
-        if (lessThanExp(Exp({ mantissa: MANTISSA_ONE }), percentage)) {
+        if (lessThanOrEqualExp(Exp({ mantissa: MANTISSA_ONE }), percentage)) {
             revert CollateralExceedsThreshold(scaledBorrows.mantissa, collateral.mantissa);
         }
 

--- a/contracts/ExponentialNoError.sol
+++ b/contracts/ExponentialNoError.sol
@@ -62,6 +62,13 @@ contract ExponentialNoError {
         return left.mantissa < right.mantissa;
     }
 
+    /**
+     * @dev Checks if first Exp is less than or equal second Exp.
+     */
+    function lessThanOrEqualExp(Exp memory left, Exp memory right) internal pure returns (bool) {
+        return left.mantissa <= right.mantissa;
+    }
+
     function safe224(uint256 n, string memory errorMessage) internal pure returns (uint224) {
         require(n <= type(uint224).max, errorMessage);
         return uint224(n);

--- a/tests/hardhat/Comptroller/healAccountTest.ts
+++ b/tests/hardhat/Comptroller/healAccountTest.ts
@@ -10,7 +10,7 @@ import {
   Comptroller,
   Comptroller__factory,
   PoolRegistry,
-  PriceOracle,
+  ResilientOracleInterface,
   VToken,
 } from "../../../typechain";
 
@@ -30,7 +30,7 @@ describe("healAccount", () => {
   type HealAccountFixture = {
     accessControl: FakeContract<AccessControlManager>;
     comptroller: MockContract<Comptroller>;
-    oracle: FakeContract<PriceOracle>;
+    oracle: FakeContract<ResilientOracleInterface>;
     OMG: FakeContract<VToken>;
     ZRX: FakeContract<VToken>;
     BAT: FakeContract<VToken>;
@@ -47,7 +47,7 @@ describe("healAccount", () => {
       constructorArgs: [poolRegistry.address],
       initializer: "initialize(uint256,address)",
     });
-    const oracle = await smock.fake<PriceOracle>("PriceOracle");
+    const oracle = await smock.fake<ResilientOracleInterface>("ResilientOracleInterface");
 
     accessControl.isAllowedToCall.returns(true);
     await comptroller.setPriceOracle(oracle.address);

--- a/tests/hardhat/Comptroller/healAccountTest.ts
+++ b/tests/hardhat/Comptroller/healAccountTest.ts
@@ -10,7 +10,7 @@ import {
   Comptroller,
   Comptroller__factory,
   PoolRegistry,
-  ResilientOracleInterface,
+  PriceOracle,
   VToken,
 } from "../../../typechain";
 
@@ -30,7 +30,7 @@ describe("healAccount", () => {
   type HealAccountFixture = {
     accessControl: FakeContract<AccessControlManager>;
     comptroller: MockContract<Comptroller>;
-    oracle: FakeContract<ResilientOracleInterface>;
+    oracle: FakeContract<PriceOracle>;
     OMG: FakeContract<VToken>;
     ZRX: FakeContract<VToken>;
     BAT: FakeContract<VToken>;
@@ -47,7 +47,7 @@ describe("healAccount", () => {
       constructorArgs: [poolRegistry.address],
       initializer: "initialize(uint256,address)",
     });
-    const oracle = await smock.fake<ResilientOracleInterface>("ResilientOracleInterface");
+    const oracle = await smock.fake<PriceOracle>("PriceOracle");
 
     accessControl.isAllowedToCall.returns(true);
     await comptroller.setPriceOracle(oracle.address);
@@ -89,16 +89,16 @@ describe("healAccount", () => {
     beforeEach(async () => {
       await comptroller.connect(user).enterMarkets([OMG.address, ZRX.address, BAT.address]);
 
-      // Supply 1.05 OMG, borrow 0 OMG
-      OMG.getAccountSnapshot.whenCalledWith(user.address).returns([0, parseUnits("1.05", 18), 0, parseUnits("1", 18)]);
+      // Supply 1.06 OMG, borrow 0 OMG
+      OMG.getAccountSnapshot.whenCalledWith(user.address).returns([0, parseUnits("1.06", 18), 0, parseUnits("1", 18)]);
 
       // Supply 1.15 ZRX, borrow 1 ZRX
       ZRX.getAccountSnapshot
         .whenCalledWith(user.address)
         .returns([0, parseUnits("1.15", 18), parseUnits("1", 18), parseUnits("1", 18)]);
 
-      // Supply 0 BAT, borrow 1 BAT
-      BAT.getAccountSnapshot.whenCalledWith(user.address).returns([0, 0, parseUnits("1", 18), parseUnits("1", 18)]);
+      // Supply 0 BAT, borrow 1.1 BAT
+      BAT.getAccountSnapshot.whenCalledWith(user.address).returns([0, 0, parseUnits("1.1", 18), parseUnits("1", 18)]);
     });
 
     it("fails if the vToken account snapshot returns an error", async () => {
@@ -113,11 +113,11 @@ describe("healAccount", () => {
       await comptroller.setMinLiquidatableCollateral("2199999999999999999");
       await expect(comptroller.connect(liquidator).healAccount(user.address))
         .to.be.revertedWithCustomError(comptroller, "CollateralExceedsThreshold")
-        .withArgs("2199999999999999999", "2200000000000000000");
+        .withArgs("2199999999999999999", "2210000000000000000");
     });
 
     it("seizes the entire collateral", async () => {
-      const omgToSeize = parseUnits("1.05", 18);
+      const omgToSeize = parseUnits("1.06", 18);
       const zrxToSeize = parseUnits("1.15", 18);
       await comptroller.connect(liquidator).healAccount(user.address);
       expect(OMG.seize).to.have.been.calledWith(liquidator.address, user.address, omgToSeize);
@@ -126,8 +126,8 @@ describe("healAccount", () => {
     });
 
     it("does not accrue bad debt", async () => {
-      const zrxToRepay = parseUnits("1", 18);
-      const batToRepay = parseUnits("1", 18);
+      const zrxToRepay = parseUnits(".956709956709956709", 18);
+      const batToRepay = parseUnits("1.052380952380952379", 18);
       await comptroller.connect(liquidator).healAccount(user.address);
       expect(OMG.healBorrow).to.have.not.been.called;
       expect(ZRX.healBorrow).to.have.been.calledWith(liquidator.address, user.address, zrxToRepay);
@@ -208,6 +208,25 @@ describe("healAccount", () => {
         comptroller,
         "InsufficientShortfall",
       );
+    });
+
+    it("fails if liquidation incentive * debt <= collateral", async () => {
+      await comptroller.connect(user).enterMarkets([OMG.address, ZRX.address, BAT.address]);
+
+      // Supply 1.05 OMG, borrow 0 OMG
+      OMG.getAccountSnapshot.whenCalledWith(user.address).returns([0, parseUnits("1.05", 18), 0, parseUnits("1", 18)]);
+
+      // Supply 1.15 ZRX, borrow 1 ZRX
+      ZRX.getAccountSnapshot
+        .whenCalledWith(user.address)
+        .returns([0, parseUnits("1.15", 18), parseUnits("1", 18), parseUnits("1", 18)]);
+
+      // Supply 0 BAT, borrow 1 BAT
+      BAT.getAccountSnapshot.whenCalledWith(user.address).returns([0, 0, parseUnits("1", 18), parseUnits("1", 18)]);
+
+      await expect(comptroller.connect(liquidator).healAccount(user.address))
+        .to.be.revertedWithCustomError(comptroller, "CollateralExceedsThreshold")
+        .withArgs("2200000000000000000", "2200000000000000000");
     });
   });
 });

--- a/tests/hardhat/Comptroller/pauseTest.ts
+++ b/tests/hardhat/Comptroller/pauseTest.ts
@@ -30,7 +30,7 @@ type PauseFixture = {
   names: string[];
 };
 
-const maxLoopsLimit = 150;
+const maxLoopsLimit = 15;
 
 async function pauseFixture(): Promise<PauseFixture> {
   const poolRegistry = await smock.fake<PoolRegistry>("PoolRegistry");
@@ -161,6 +161,12 @@ describe("Comptroller", () => {
       await expect(comptroller.exitMarket(SKT.address))
         .to.be.revertedWithCustomError(comptroller, "MarketNotListed")
         .withArgs(SKT.address);
+    });
+
+    it("reverts if maxloops limit is crossed", async () => {
+      await expect(comptroller.setActionsPaused([OMG.address, BAT.address, ZRX.address], [1, 2, 3, 4, 5, 6], true))
+        .to.be.revertedWithCustomError(comptroller, "MaxLoopsLimitExceeded")
+        .withArgs(maxLoopsLimit, 18);
     });
   });
 });


### PR DESCRIPTION
## Description

VEN-1495: MaxLoopLimitHelper._ensureMaxLoop() is validating the wrong input in Comptroller.setActionsPaused()
VEN-1496: Comptroller.sol#preBorrowHook can be exploited to bypass maxLoopsLimit
VEN-1497: Reject healAccount when ratio collateral/scaledBorrows is 1

Resolves VEN-1495, VEN-1496, VEN-1497

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
