### PR TITLE
[VEN-1527]: new Comptroller.getBorrowingPower view

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -991,6 +991,27 @@ contract Comptroller is
     }
 
     /**
+     * @notice Determine the current account liquidity with respect to liquidation threshold requirements
+     * @dev The interface of this function is intentionally kept compatible with Compound and Venus Core
+     * @param account The account get liquidity for
+     * @return error Always NO_ERROR for compatibility with Venus core tooling
+     * @return liquidity Account liquidity in excess of liquidation threshold requirements,
+     * @return shortfall Account shortfall below liquidation threshold requirements
+     */
+    function getAccountLiquidity(address account)
+        external
+        view
+        returns (
+            uint256 error,
+            uint256 liquidity,
+            uint256 shortfall
+        )
+    {
+        AccountLiquiditySnapshot memory snapshot = _getCurrentLiquiditySnapshot(account, _getLiquidationThreshold);
+        return (NO_ERROR, snapshot.liquidity, snapshot.shortfall);
+    }
+
+    /**
      * @notice Determine the current account liquidity with respect to collateral requirements
      * @dev The interface of this function is intentionally kept compatible with Compound and Venus Core
      * @param account The account get liquidity for
@@ -998,7 +1019,7 @@ contract Comptroller is
      * @return liquidity Account liquidity in excess of collateral requirements,
      * @return shortfall Account shortfall below collateral requirements
      */
-    function getAccountLiquidity(address account)
+    function getBorrowingPower(address account)
         external
         view
         returns (

--- a/tests/hardhat/Comptroller/liquidateAccountTest.ts
+++ b/tests/hardhat/Comptroller/liquidateAccountTest.ts
@@ -90,7 +90,7 @@ describe("liquidateAccount", () => {
         oracle.getUnderlyingPrice.returns(parseUnits("1", 18));
         await comptroller
           .connect(poolRegistry.wallet)
-          .setCollateralFactor(vToken.address, parseUnits("0.9", 18), parseUnits("0.9", 18));
+          .setCollateralFactor(vToken.address, parseUnits("0.8", 18), parseUnits("0.9", 18));
         return vToken;
       }),
     );

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -293,7 +293,7 @@ describe("Positive Cases", () => {
       expect(error).to.equal(Error.NO_ERROR);
       expect(balance).to.equal(vTokenMintAmount);
       expect(borrowBalance).to.equal(0);
-      [error, liquidity, shortfall] = await Comptroller.connect(acc2Signer).getAccountLiquidity(acc2);
+      [error, liquidity, shortfall] = await Comptroller.connect(acc2Signer).getBorrowingPower(acc2);
       expect(error).to.equal(Error.NO_ERROR);
       expect(liquidity).to.equal(new BigNumber(mintAmount).multipliedBy(bnxCollateralFactor).multipliedBy(vBNXPrice));
       expect(shortfall).to.equal(0);
@@ -308,7 +308,7 @@ describe("Positive Cases", () => {
       expect(error).to.equal(Error.NO_ERROR);
       expect(balance).to.equal(vTokenMintAmount);
       expect(borrowBalance).to.equal(0);
-      [error, liquidity, shortfall] = await Comptroller.connect(acc1Signer).getAccountLiquidity(acc1);
+      [error, liquidity, shortfall] = await Comptroller.connect(acc1Signer).getBorrowingPower(acc1);
       expect(error).to.equal(Error.NO_ERROR);
       expect(liquidity).to.equal(new BigNumber(mintAmount).multipliedBy(btcbCollateralFactor).multipliedBy(vBTCBPrice));
       expect(shortfall).to.equal(0);
@@ -338,7 +338,7 @@ describe("Positive Cases", () => {
       const bnxLiquidity = new BigNumber(mintAmount).minus(new BigNumber(tokenRedeemAmount)).multipliedBy(vBNXPrice);
       const BTCBBorrow = new BigNumber(borrowBalance.toString()).multipliedBy(vBTCBPrice);
       let preComputeLiquidity = bnxLiquidity.minus(BTCBBorrow).multipliedBy(bnxCollateralFactor);
-      [error, liquidity, shortfall] = await Comptroller.connect(acc2Signer).getAccountLiquidity(acc2);
+      [error, liquidity, shortfall] = await Comptroller.connect(acc2Signer).getBorrowingPower(acc2);
       expect(error).to.equal(Error.NO_ERROR);
       expect(Number(liquidity)).to.be.closeTo(preComputeLiquidity.toNumber(), Number(convertToUnit(1, 18)));
       expect(shortfall).to.equal(0);
@@ -353,7 +353,7 @@ describe("Positive Cases", () => {
       expect(balance).to.equal(balanceAfterVToken);
       expect(borrowBalance).to.equal(0);
       preComputeLiquidity = balanceAfter.multipliedBy(bnxCollateralFactor).multipliedBy(vBNXPrice);
-      [error, liquidity, shortfall] = await Comptroller.connect(acc2Signer).getAccountLiquidity(acc2);
+      [error, liquidity, shortfall] = await Comptroller.connect(acc2Signer).getBorrowingPower(acc2);
       expect(error).to.equal(Error.NO_ERROR);
       expect(Number(liquidity)).to.be.closeTo(preComputeLiquidity.toNumber(), Number(convertToUnit(1, 14)));
       expect(shortfall).to.equal(0);
@@ -899,17 +899,17 @@ describe("Multiple Users Engagement in a Block", () => {
     await vBTCB.connect(acc3Signer).redeem(redeemAmount);
     await mineBlock();
     await toggleMining(true);
-    [error, liquidity, shortfall] = await Comptroller.connect(acc1Signer).getAccountLiquidity(acc1);
+    [error, liquidity, shortfall] = await Comptroller.connect(acc1Signer).getBorrowingPower(acc1);
     expect(error).to.equal(Error.NO_ERROR);
     expect(liquidity).to.equal((mintAmount1 * btcbCollateralFactor * vBTCBPrice).toString());
     expect(shortfall).to.equal(0);
 
-    [error, liquidity, shortfall] = await Comptroller.connect(acc3Signer).getAccountLiquidity(acc2);
+    [error, liquidity, shortfall] = await Comptroller.connect(acc3Signer).getBorrowingPower(acc2);
     expect(error).to.equal(Error.NO_ERROR);
     expect(liquidity).to.equal((mintAmount2 * bnxCollateralFactor * vBNXPrice).toString());
     expect(shortfall).to.equal(0);
 
-    [error, liquidity, shortfall] = await Comptroller.connect(acc3Signer).getAccountLiquidity(acc3);
+    [error, liquidity, shortfall] = await Comptroller.connect(acc3Signer).getBorrowingPower(acc3);
     expect(error).to.equal(Error.NO_ERROR);
     expect(liquidity).to.equal((mintAmount3 * bnxCollateralFactor * vBNXPrice).toString());
     expect(shortfall).to.equal(0);


### PR DESCRIPTION
## Description

This PR includes:
1. use _getLiquidationThreshold instead of _getCollateralFactor in the current Comptroller.getAccountLiquidity
2.define a new view Comptroller.getBorrowingPower, similar to Comptroller.getAccountLiquidity , but using _getCollateralFactor
liquidation tests pass and liquidity tests are extended to also check getBorrowingPower
Resolves #[VEN-1527]

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
