### PR TITLE
fix: generate typings before building typescript

### DIFF
--- a/deploy/013-vip-based-config.ts
+++ b/deploy/013-vip-based-config.ts
@@ -98,7 +98,7 @@ const configureRewards = async (
       const poolCommands = await Promise.all(
         rewards.map(async (rewardConfig: RewardConfig) => {
           const contractName = `RewardsDistributor_${rewardConfig.asset}_${pool.id}`;
-          const rewardsDistributor = await ethers.getContract(contractName);
+          const rewardsDistributor = await ethers.getContract<RewardsDistributor>(contractName);
           return [
             ...(await acceptOwnership(contractName, hre)),
             await addRewardsDistributor(rewardsDistributor, pool, rewardConfig),
@@ -273,7 +273,7 @@ const addMarkets = async (
   deploymentConfig: DeploymentConfig,
   hre: HardhatRuntimeEnvironment,
 ) => {
-  const poolRegistry = await ethers.getContract("PoolRegistry");
+  const poolRegistry = await ethers.getContract<PoolRegistry>("PoolRegistry");
   const poolCommands = await Promise.all(
     unregisteredVTokens.map(async (pool: PoolConfig) => {
       const vTokenCommands = await Promise.all(

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:ts:fix": "eslint --fix --ext .js,.ts .",
     "prettier": "prettier --write \"**/*.{js,json,md,sol,ts,yaml,yml}\"",
     "prettier:check": "prettier --check \"**/*.{js,json,md,sol,ts,yaml,yml}\"",
-    "build": "rm -rf dist && tsc --declaration && hardhat compile",
+    "build": "rm -rf dist && hardhat compile && tsc --declaration",
     "docgen": "hardhat docgen",
     "prepare": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "files": [
     "artifacts",
+    "typechain",
     "dist",
     "contracts",
     "deployments"


### PR DESCRIPTION
This PR modifies the build script to first generate typings for the contracts and then build TypeScript. The second commit adds the missing typings to fix ts compilation.

Note: there's a `fix` commit to trigger a release.