### PR TITLE
feat: use core pool behavior for jump rate multiplier

### DIFF
--- a/contracts/BaseJumpRateModelV2.sol
+++ b/contracts/BaseJumpRateModelV2.sol
@@ -163,7 +163,7 @@ abstract contract BaseJumpRateModelV2 is InterestRateModel {
         uint256 kink_
     ) internal {
         baseRatePerBlock = baseRatePerYear / BLOCKS_PER_YEAR;
-        multiplierPerBlock = (multiplierPerYear * EXP_SCALE) / (BLOCKS_PER_YEAR * kink_);
+        multiplierPerBlock = multiplierPerYear / BLOCKS_PER_YEAR;
         jumpMultiplierPerBlock = jumpMultiplierPerYear / BLOCKS_PER_YEAR;
         kink = kink_;
 

--- a/tests/hardhat/JumpRateModelV2.ts
+++ b/tests/hardhat/JumpRateModelV2.ts
@@ -46,9 +46,7 @@ describe("Jump rate model tests", () => {
 
   it("Update jump rate model", async () => {
     let baseRatePerBlock = new BigNumber(baseRatePerYear).dividedBy(blocksPerYear).toFixed(0);
-    let multiplierPerBlock = new BigNumber(multiplierPerYear)
-      .dividedBy(new BigNumber(blocksPerYear))
-      .toFixed(0);
+    let multiplierPerBlock = new BigNumber(multiplierPerYear).dividedBy(new BigNumber(blocksPerYear)).toFixed(0);
     let jumpMultiplierPerBlock = new BigNumber(jumpMultiplierPerYear).dividedBy(blocksPerYear).toFixed(0);
 
     expect(await jumpRateModel.baseRatePerBlock()).equal(baseRatePerBlock);
@@ -59,9 +57,7 @@ describe("Jump rate model tests", () => {
     await jumpRateModel.updateJumpRateModel(convertToUnit(3, 12), convertToUnit(5, 14), convertToUnit(2.2, 18), kink);
 
     baseRatePerBlock = new BigNumber(convertToUnit(3, 12)).dividedBy(blocksPerYear).toFixed(0);
-    multiplierPerBlock = new BigNumber(convertToUnit(5, 14))
-      .dividedBy(new BigNumber(blocksPerYear))
-      .toFixed(0);
+    multiplierPerBlock = new BigNumber(convertToUnit(5, 14)).dividedBy(new BigNumber(blocksPerYear)).toFixed(0);
     jumpMultiplierPerBlock = new BigNumber(convertToUnit(2.2, 18)).dividedBy(blocksPerYear).toFixed(0);
 
     expect(await jumpRateModel.baseRatePerBlock()).equal(baseRatePerBlock);

--- a/tests/hardhat/JumpRateModelV2.ts
+++ b/tests/hardhat/JumpRateModelV2.ts
@@ -47,8 +47,7 @@ describe("Jump rate model tests", () => {
   it("Update jump rate model", async () => {
     let baseRatePerBlock = new BigNumber(baseRatePerYear).dividedBy(blocksPerYear).toFixed(0);
     let multiplierPerBlock = new BigNumber(multiplierPerYear)
-      .multipliedBy(expScale)
-      .dividedBy(new BigNumber(blocksPerYear).multipliedBy(kink))
+      .dividedBy(new BigNumber(blocksPerYear))
       .toFixed(0);
     let jumpMultiplierPerBlock = new BigNumber(jumpMultiplierPerYear).dividedBy(blocksPerYear).toFixed(0);
 
@@ -61,8 +60,7 @@ describe("Jump rate model tests", () => {
 
     baseRatePerBlock = new BigNumber(convertToUnit(3, 12)).dividedBy(blocksPerYear).toFixed(0);
     multiplierPerBlock = new BigNumber(convertToUnit(5, 14))
-      .multipliedBy(expScale)
-      .dividedBy(new BigNumber(blocksPerYear).multipliedBy(kink))
+      .dividedBy(new BigNumber(blocksPerYear))
       .toFixed(0);
     jumpMultiplierPerBlock = new BigNumber(convertToUnit(2.2, 18)).dividedBy(blocksPerYear).toFixed(0);
 

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -420,7 +420,7 @@ describe("Straight Cases For Single User Liquidation and healing", function () {
       );
     });
 
-    it.only("Should success on liquidation when repay amount is equal to borrowing", async function () {
+    it("Should success on liquidation when repay amount is equal to borrowing", async function () {
       await BNX.connect(acc2Signer).faucet(1e10);
       await BNX.connect(acc2Signer).approve(vBNX.address, 1e10);
       await vBNX.connect(acc2Signer).mint(1e10);

--- a/tests/integration/index.ts
+++ b/tests/integration/index.ts
@@ -420,7 +420,7 @@ describe("Straight Cases For Single User Liquidation and healing", function () {
       );
     });
 
-    it("Should success on liquidation when repay amount is equal to borrowing", async function () {
+    it.only("Should success on liquidation when repay amount is equal to borrowing", async function () {
       await BNX.connect(acc2Signer).faucet(1e10);
       await BNX.connect(acc2Signer).approve(vBNX.address, 1e10);
       await vBNX.connect(acc2Signer).mint(1e10);
@@ -437,7 +437,7 @@ describe("Straight Cases For Single User Liquidation and healing", function () {
       );
 
       await Comptroller.setPriceOracle(dummyPriceOracle.address);
-      const repayAmount = convertToUnit("1000000000011889", 0);
+      const repayAmount = convertToUnit("1000000000007133", 0);
       const param = {
         vTokenCollateral: vBNX.address,
         vTokenBorrowed: vBTCB.address,


### PR DESCRIPTION
Problem: The new IL JumpRateModel is based on Compound's updated version. The problem with that is that the multiplier is divided by kink in this updated version. This is counterintuitive and inconsistend with the core pool behavior.

Solution: Use the classic computation, i.e. not divide the slope by kink.