### PR TITLE
POC of adding firstRewardingBlock

### DIFF
--- a/contracts/Lens/PoolLens.sol
+++ b/contracts/Lens/PoolLens.sol
@@ -114,6 +114,8 @@ contract PoolLens is ExponentialNoError {
         // The block number the index was last updated at
         uint32 block;
         // The block number at which to stop rewards
+        uint32 firstRewardingBlock;
+        // The block number at which to stop rewards
         uint32 lastRewardingBlock;
     }
 
@@ -446,10 +448,10 @@ contract PoolLens is ExponentialNoError {
         for (uint256 i; i < markets.length; ++i) {
             // Market borrow and supply state we will modify update in-memory, in order to not modify storage
             RewardTokenState memory borrowState;
-            (borrowState.index, borrowState.block, borrowState.lastRewardingBlock) = rewardsDistributor
+            (borrowState.index, borrowState.block, borrowState.firstRewardingBlock, borrowState.lastRewardingBlock) = rewardsDistributor
             .rewardTokenBorrowState(address(markets[i]));
             RewardTokenState memory supplyState;
-            (supplyState.index, supplyState.block, supplyState.lastRewardingBlock) = rewardsDistributor
+            (supplyState.index, supplyState.block, supplyState.firstRewardingBlock ,supplyState.lastRewardingBlock) = rewardsDistributor
             .rewardTokenSupplyState(address(markets[i]));
             Exp memory marketBorrowIndex = Exp({ mantissa: markets[i].borrowIndex() });
 


### PR DESCRIPTION
## Description

This POC shows availability to accrue rewards only for a given period of time. Lets say we want to accrue rewards for the following blocks [0-100] [200-400].  For this purpose a new variable `firstRewardingBlock ` was introduced to correctly handle the time between the the pause of rewarding (in our case between blocks 100-200).
The only disadvantage to this POC is that we would need initially to set the range [0-100] and after block `100`, we can set the new range.

NOTE: this is a POC and code in `PoolLens` has not been accommodated to calculate the pending rewards correctly. Also some other bugs in the implementation may be persistent.

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
