### PR TITLE
[VEN-1703]: support deadline in swapPoolsAssets

### DIFF
--- a/contracts/RiskFund/IRiskFund.sol
+++ b/contracts/RiskFund/IRiskFund.sol
@@ -10,7 +10,8 @@ interface IRiskFund {
     function swapPoolsAssets(
         address[] calldata markets,
         uint256[] calldata amountsOutMin,
-        address[][] calldata paths
+        address[][] calldata paths,
+        uint256 deadline
     ) external returns (uint256);
 
     function transferReserveForAuction(address comptroller, uint256 amount) external returns (uint256);

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -145,15 +145,18 @@ contract RiskFund is AccessControlledV8, ExponentialNoError, ReserveHelpers, Max
      * @param markets Array of vTokens whose assets to swap for base asset
      * @param amountsOutMin Minimum amount to receive for swap
      * @param paths A path consisting of PCS token pairs for each swap
+     * @param deadline Deadline for the swap
      * @return Number of swapped tokens
      * @custom:error ZeroAddressNotAllowed is thrown if PoolRegistry contract address is not configured
      */
     function swapPoolsAssets(
         address[] calldata markets,
         uint256[] calldata amountsOutMin,
-        address[][] calldata paths
+        address[][] calldata paths,
+        uint256 deadline
     ) external override returns (uint256) {
         _checkAccessAllowed("swapPoolsAssets(address[],uint256[],address[][])");
+        require(deadline >= block.timestamp, "Risk fund: deadline passed");
         address poolRegistry_ = poolRegistry;
         ensureNonzeroAddress(poolRegistry_);
         require(markets.length == amountsOutMin.length, "Risk fund: markets and amountsOutMin are unequal lengths");
@@ -165,14 +168,13 @@ contract RiskFund is AccessControlledV8, ExponentialNoError, ReserveHelpers, Max
         _ensureMaxLoops(marketsCount);
 
         for (uint256 i; i < marketsCount; ++i) {
-            VToken vToken = VToken(markets[i]);
-            address comptroller = address(vToken.comptroller());
+            address comptroller = address(VToken(markets[i]).comptroller());
 
             PoolRegistry.VenusPool memory pool = PoolRegistry(poolRegistry_).getPoolByComptroller(comptroller);
             require(pool.comptroller == comptroller, "comptroller doesn't exist pool registry");
-            require(Comptroller(comptroller).isMarketListed(vToken), "market is not listed");
+            require(Comptroller(comptroller).isMarketListed(VToken(markets[i])), "market is not listed");
 
-            uint256 swappedTokens = _swapAsset(vToken, comptroller, amountsOutMin[i], paths[i]);
+            uint256 swappedTokens = _swapAsset(VToken(markets[i]), comptroller, amountsOutMin[i], paths[i]);
             poolsAssetsReserves[comptroller][convertibleBaseAsset] += swappedTokens;
             assetsReserves[convertibleBaseAsset] += swappedTokens;
             totalAmount = totalAmount + swappedTokens;

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -223,6 +223,7 @@ describe("Risk Fund: Swap Tests", () => {
   beforeEach(async () => {
     await loadFixture(riskFundFixture);
   });
+
   it("Swap All Pool Assets", async () => {
     await USDT.connect(usdtUser).approve(vUSDT.address, ADD_RESERVE_AMOUNT);
     await vUSDT.connect(usdtUser).addReserves(ADD_RESERVE_AMOUNT);
@@ -230,7 +231,8 @@ describe("Risk Fund: Swap Tests", () => {
 
     await protocolShareReserve.releaseFunds(comptroller1Proxy.address, USDT.address, REDUCE_RESERVE_AMOUNT);
 
-    await riskFund.swapPoolsAssets([vUSDT.address], [parseUnits("10", 18)], [[USDT.address, BUSD.address]]);
+    const deadline = (await ethers.provider.getBlock("latest")).timestamp + 100;
+    await riskFund.swapPoolsAssets([vUSDT.address], [parseUnits("10", 18)], [[USDT.address, BUSD.address]], deadline);
     expect(await riskFund.getPoolsBaseAssetReserves(comptroller1Proxy.address)).to.be.equal("14960261570862459704");
 
     const balance = await BUSD.balanceOf(riskFund.address);


### PR DESCRIPTION
Problem: When we swap pools' assets we must protect ourselves against transaction delays – miners may want to delay the execution of our transaction to potentially gain profits from a changing exchange rate.

Solution: Add `deadline` parameter that would invalidate the transaction if it's executed after the deadline is passed.

Note: I had to remove the local vToken variable to avoid stack too deep error. Although the code is less readable now, other solutions I could come up with (e.g. the standard one – introduce a struct SwapLocalVars {...} containing the local variables for the function) harm readability even more.

Resolves VEN-1703

## Checklist

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
