### PR TITLE
[VEN-1477]: avoid locking on failed transfers to previous bidders

### DIFF
--- a/contracts/lib/TokenDebtTracker.sol
+++ b/contracts/lib/TokenDebtTracker.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+/**
+ * @title TokenDebtTracker
+ * @author Venus
+ * @notice TokenDebtTracker is an abstract contract that handles transfers _out_ of the inheriting contract.
+ * If there is an error transferring out (due to any reason, e.g. the token contract restricted the user from
+ * receiving incoming transfers), the amount is recorded as a debt that can be claimed later.
+ * @dev Note that the inheriting contract keeps some amount of users' tokens on its balance, so be careful when
+ * using balanceOf(address(this))!
+ */
+abstract contract TokenDebtTracker is Initializable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    /**
+     * @notice Mapping (IERC20Upgradeable token => (address user => uint256 amount)).
+     * Tracks failed transfers: when a token transfer fails, we record the
+     * amount of the transfer, so that the user can redeem this debt later.
+     */
+    mapping(IERC20Upgradeable => mapping(address => uint256)) public tokenDebt;
+
+    /**
+     * @notice Mapping (IERC20Upgradeable token => uint256 amount) shows how many
+     * tokens the contract owes to all users. This is useful for accounting to
+     * understand how much of balanceOf(address(this)) is already owed to users.
+     */
+    mapping(IERC20Upgradeable => uint256) public totalTokenDebt;
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[48] private __gap;
+
+    /**
+     * @notice Emitted when the contract's debt to the user is increased due to a failed transfer
+     * @param token Token address
+     * @param user User address
+     * @param amount The amount of debt added
+     */
+    event TokenDebtAdded(address indexed token, address indexed user, uint256 amount);
+
+    /**
+     * @notice Emitted when a user claims tokens that the contract owes them
+     * @param token Token address
+     * @param user User address
+     * @param amount The amount transferred
+     */
+    event TokenDebtClaimed(address indexed token, address indexed user, uint256 amount);
+
+    /**
+     * @notice Thrown if the user tries to claim more tokens than they are owed
+     * @param token The token the user is trying to claim
+     * @param owedAmount The amount of tokens the contract owes to the user
+     * @param amount The amount of tokens the user is trying to claim
+     */
+    error InsufficientDebt(address token, address user, uint256 owedAmount, uint256 amount);
+
+    /**
+     * @notice Transfers the tokens we owe to msg.sender, if any
+     * @param token The token to claim
+     * @param amount_ The amount of tokens to claim (or max uint256 to claim all)
+     */
+    function claimTokenDebt(IERC20Upgradeable token, uint256 amount_) external {
+        uint256 owedAmount = tokenDebt[token][msg.sender];
+        uint256 amount = (amount_ == type(uint256).max ? owedAmount : amount_);
+        if (amount > owedAmount) {
+            revert InsufficientDebt(address(token), msg.sender, owedAmount, amount);
+        }
+        unchecked {
+            // Safe because we revert if amount > owedAmount above
+            tokenDebt[token][msg.sender] = owedAmount - amount;
+        }
+        totalTokenDebt[token] -= amount;
+        emit TokenDebtClaimed(address(token), msg.sender, amount);
+        token.safeTransfer(msg.sender, amount);
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function __TokenDebtTracker_init() internal onlyInitializing {
+        __TokenDebtTracker_init_unchained();
+    }
+
+    // solhint-disable-next-line func-name-mixedcase, no-empty-blocks
+    function __TokenDebtTracker_init_unchained() internal onlyInitializing {}
+
+    /**
+     * @dev Transfers tokens to the recipient, or records the debt if the transfer fails.
+     * @param token The token to transfer
+     * @param to The recipient of the transfer
+     * @param amount The amount to transfer
+     */
+    function _transferOutOrTrackDebt(
+        IERC20Upgradeable token,
+        address to,
+        uint256 amount
+    ) internal {
+        // We can't use safeTransfer here because we can't try-catch internal calls
+        bool success = _tryTransferOut(token, to, amount);
+        if (!success) {
+            tokenDebt[token][to] += amount;
+            totalTokenDebt[token] += amount;
+            emit TokenDebtAdded(address(token), to, amount);
+        }
+    }
+
+    /**
+     * @dev Either transfers tokens to the recepient or returns false. Supports tokens
+     *      thet revert or return false to indicate failure, and the non-compliant ones
+     *      that do not return any value.
+     * @param token The token to transfer
+     * @param to The recipient of the transfer
+     * @param amount The amount to transfer
+     * @return true if the transfer succeeded, false otherwise
+     */
+    function _tryTransferOut(
+        IERC20Upgradeable token,
+        address to,
+        uint256 amount
+    ) private returns (bool) {
+        bytes memory callData = abi.encodeCall(token.transfer, (to, amount));
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = address(token).call(callData);
+        return success && (returndata.length == 0 || abi.decode(returndata, (bool))) && address(token).code.length > 0;
+    }
+}

--- a/contracts/test/lib/TokenDebtTrackerHarness.sol
+++ b/contracts/test/lib/TokenDebtTrackerHarness.sol
@@ -26,4 +26,12 @@ contract TokenDebtTrackerHarness is TokenDebtTracker {
     ) external {
         _transferOutOrTrackDebt(token, user, amount);
     }
+
+    function transferOutOrTrackDebtSkippingBalanceCheck(
+        IERC20Upgradeable token,
+        address user,
+        uint256 amount
+    ) external {
+        _transferOutOrTrackDebtSkippingBalanceCheck(token, user, amount);
+    }
 }

--- a/contracts/test/lib/TokenDebtTrackerHarness.sol
+++ b/contracts/test/lib/TokenDebtTrackerHarness.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.13;
+
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { TokenDebtTracker } from "../../lib/TokenDebtTracker.sol";
+
+contract TokenDebtTrackerHarness is TokenDebtTracker {
+    function initialize() external initializer {
+        __TokenDebtTracker_init();
+    }
+
+    function addTokenDebt(
+        IERC20Upgradeable token,
+        address user,
+        uint256 amount
+    ) external {
+        tokenDebt[token][user] += amount;
+        totalTokenDebt[token] += amount;
+    }
+
+    function transferOutOrTrackDebt(
+        IERC20Upgradeable token,
+        address user,
+        uint256 amount
+    ) external {
+        _transferOutOrTrackDebt(token, user, amount);
+    }
+}

--- a/tests/hardhat/lib/TokenDebtTracker.ts
+++ b/tests/hardhat/lib/TokenDebtTracker.ts
@@ -1,0 +1,184 @@
+import { smock } from "@defi-wonderland/smock";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import chai from "chai";
+import { parseUnits } from "ethers/lib/utils";
+import { ethers, upgrades } from "hardhat";
+import { SignerWithAddress } from "hardhat-deploy-ethers/signers";
+
+import {
+  ERC20Harness,
+  ERC20Harness__factory,
+  FaucetNonStandardToken__factory,
+  TokenDebtTrackerHarness,
+  TokenDebtTrackerHarness__factory,
+} from "../../../typechain";
+
+const { expect } = chai;
+
+const INITIAL_SUPPLY = parseUnits("1000000", 18);
+
+interface Fixture {
+  tokenDebtTracker: TokenDebtTrackerHarness;
+  token: ERC20Harness;
+}
+
+const fixture = async (): Promise<Fixture> => {
+  const factory: TokenDebtTrackerHarness__factory = await ethers.getContractFactory("TokenDebtTrackerHarness");
+  const tokenDebtTracker: TokenDebtTrackerHarness = await upgrades.deployProxy(factory, [], {
+    initializer: "initialize()",
+  });
+  const tokenFactory: ERC20Harness__factory = await ethers.getContractFactory("ERC20Harness");
+  const token = await tokenFactory.deploy(INITIAL_SUPPLY, "Test", 18, "TST");
+  return { tokenDebtTracker, token };
+};
+
+describe("Token debt tracker", () => {
+  let user: SignerWithAddress;
+  let user2: SignerWithAddress;
+  let tokenDebtTracker: TokenDebtTrackerHarness;
+  let token: ERC20Harness;
+
+  beforeEach(async () => {
+    ({ tokenDebtTracker, token } = await loadFixture(fixture));
+    [, user, user2] = await ethers.getSigners();
+    await token.transfer(tokenDebtTracker.address, parseUnits("100", 18));
+  });
+
+  describe("_transferOutOrTrackDebt", () => {
+    describe("ERC20 tokens", () => {
+      it("transfers out the specified amount", async () => {
+        await tokenDebtTracker.transferOutOrTrackDebt(token.address, user.address, parseUnits("44", 18));
+        expect(await token.balanceOf(tokenDebtTracker.address)).to.equal(parseUnits("56", 18));
+        expect(await token.balanceOf(user.address)).to.equal(parseUnits("44", 18));
+      });
+
+      it("does not emit TokenDebtAdded event upon successful transfer", async () => {
+        const tx = await tokenDebtTracker.transferOutOrTrackDebt(token.address, user.address, parseUnits("44", 18));
+        await expect(tx).to.not.emit(tokenDebtTracker, "TokenDebtAdded");
+      });
+
+      it("records the debt if requested amount can't be transferred", async () => {
+        await tokenDebtTracker.transferOutOrTrackDebt(token.address, user.address, parseUnits("101", 18));
+        expect(await token.balanceOf(tokenDebtTracker.address)).to.equal(parseUnits("100", 18));
+        expect(await token.balanceOf(user.address)).to.equal(parseUnits("0", 18));
+        expect(await tokenDebtTracker.tokenDebt(token.address, user.address)).to.equal(parseUnits("101", 18));
+        expect(await tokenDebtTracker.totalTokenDebt(token.address)).to.equal(parseUnits("101", 18));
+      });
+
+      it("tracks total debt amount", async () => {
+        await tokenDebtTracker.transferOutOrTrackDebt(token.address, user.address, parseUnits("111", 18));
+        await tokenDebtTracker.transferOutOrTrackDebt(token.address, user2.address, parseUnits("444", 18));
+        expect(await tokenDebtTracker.totalTokenDebt(token.address)).to.equal(parseUnits("555", 18));
+      });
+
+      it("tracks individual debt amounts", async () => {
+        await tokenDebtTracker.transferOutOrTrackDebt(token.address, user.address, parseUnits("111", 18));
+        await tokenDebtTracker.transferOutOrTrackDebt(token.address, user2.address, parseUnits("444", 18));
+        expect(await tokenDebtTracker.tokenDebt(token.address, user.address)).to.equal(parseUnits("111", 18));
+        expect(await tokenDebtTracker.tokenDebt(token.address, user2.address)).to.equal(parseUnits("444", 18));
+      });
+
+      it("emits TokenDebtAdded event upon failed transfer", async () => {
+        const tx = await tokenDebtTracker.transferOutOrTrackDebt(token.address, user.address, parseUnits("101", 18));
+        await expect(tx)
+          .to.emit(tokenDebtTracker, "TokenDebtAdded")
+          .withArgs(token.address, user.address, parseUnits("101", 18));
+      });
+
+      it("tracks debt if the token contract returns false on transfer()", async () => {
+        const tokenReturningFalse = await smock.fake<ERC20Harness>("ERC20Harness");
+        tokenReturningFalse.transfer.returns(false);
+        await tokenDebtTracker.transferOutOrTrackDebt(tokenReturningFalse.address, user.address, parseUnits("1", 18));
+        expect(await tokenDebtTracker.tokenDebt(tokenReturningFalse.address, user.address)).to.equal(
+          parseUnits("1", 18),
+        );
+        expect(await tokenDebtTracker.totalTokenDebt(tokenReturningFalse.address)).to.equal(parseUnits("1", 18));
+      });
+
+      it("tracks debt if the token contract reverts on transfer()", async () => {
+        const revertingTokenContract = await smock.fake<ERC20Harness>("ERC20Harness");
+        revertingTokenContract.transfer.reverts();
+        await tokenDebtTracker.transferOutOrTrackDebt(
+          revertingTokenContract.address,
+          user.address,
+          parseUnits("100", 18),
+        );
+        expect(await tokenDebtTracker.tokenDebt(revertingTokenContract.address, user.address)).to.equal(
+          parseUnits("100", 18),
+        );
+        expect(await tokenDebtTracker.totalTokenDebt(revertingTokenContract.address)).to.equal(parseUnits("100", 18));
+      });
+    });
+
+    describe("Non-conforming tokens", async () => {
+      // We must handle non-ERC20 tokens gracefully. The only non-conforming scenario we can handle is
+      // transfer(...) not returning any value. In other scenarios (e.g. token contract is an EOA, so the
+      // internal tx doesn't fail but no tokens get transferred) we can't reliably check what's going on,
+      // so the only sensible thing to do is to track debt.
+
+      it("transfers tokens even if the token contract does not return a value on transfer()", async () => {
+        const NonCompliantToken: FaucetNonStandardToken__factory = await ethers.getContractFactory(
+          "FaucetNonStandardToken",
+        );
+        const nonCompliantToken = await NonCompliantToken.deploy(INITIAL_SUPPLY, "Test", 18, "TST");
+        await nonCompliantToken.transfer(tokenDebtTracker.address, parseUnits("100", 18));
+        await tokenDebtTracker.transferOutOrTrackDebt(nonCompliantToken.address, user.address, parseUnits("100", 18));
+        expect(await nonCompliantToken.balanceOf(tokenDebtTracker.address)).to.equal(0);
+        expect(await nonCompliantToken.balanceOf(user.address)).to.equal(parseUnits("100", 18));
+      });
+
+      it("tracks debt if the token contract is an EOA", async () => {
+        await tokenDebtTracker.transferOutOrTrackDebt(user.address, user.address, parseUnits("100", 18));
+        expect(await tokenDebtTracker.tokenDebt(user.address, user.address)).to.equal(parseUnits("100", 18));
+        expect(await tokenDebtTracker.totalTokenDebt(user.address)).to.equal(parseUnits("100", 18));
+      });
+    });
+  });
+
+  describe("claimTokenDebt", () => {
+    const DEBT = parseUnits("100", 18);
+
+    beforeEach(async () => {
+      await tokenDebtTracker.addTokenDebt(token.address, user.address, DEBT);
+    });
+
+    it("transfers out the specified amount if amount < debt", async () => {
+      await tokenDebtTracker.connect(user).claimTokenDebt(token.address, DEBT.sub(1));
+      expect(await token.balanceOf(tokenDebtTracker.address)).to.equal(1);
+      expect(await token.balanceOf(user.address)).to.equal(DEBT.sub(1));
+    });
+
+    it("updates the individual debt value", async () => {
+      await tokenDebtTracker.connect(user).claimTokenDebt(token.address, DEBT.sub(1));
+      expect(await tokenDebtTracker.tokenDebt(token.address, user.address)).to.equal(1);
+    });
+
+    it("updates the total debt value", async () => {
+      await tokenDebtTracker.connect(user).claimTokenDebt(token.address, DEBT.sub(1));
+      expect(await tokenDebtTracker.totalTokenDebt(token.address)).to.equal(1);
+    });
+
+    it("emits TokenDebtClaimed event", async () => {
+      const tx = await tokenDebtTracker.connect(user).claimTokenDebt(token.address, DEBT.sub(1));
+      await expect(tx).to.emit(tokenDebtTracker, "TokenDebtClaimed").withArgs(token.address, user.address, DEBT.sub(1));
+    });
+
+    it("reverts if amount > debt and amount != type(uint256).max", async () => {
+      await expect(tokenDebtTracker.connect(user).claimTokenDebt(token.address, DEBT.add(1)))
+        .to.be.revertedWithCustomError(tokenDebtTracker, "InsufficientDebt")
+        .withArgs(token.address, user.address, DEBT, DEBT.add(1));
+    });
+
+    it("transfers the full debt amount if amount == debt", async () => {
+      await tokenDebtTracker.connect(user).claimTokenDebt(token.address, DEBT);
+      expect(await token.balanceOf(tokenDebtTracker.address)).to.equal(0);
+      expect(await token.balanceOf(user.address)).to.equal(DEBT);
+    });
+
+    it("transfers the full debt amount if amount == type(uint256).max", async () => {
+      await tokenDebtTracker.connect(user).claimTokenDebt(token.address, ethers.constants.MaxUint256);
+      expect(await token.balanceOf(tokenDebtTracker.address)).to.equal(0);
+      expect(await token.balanceOf(user.address)).to.equal(DEBT);
+    });
+  });
+});


### PR DESCRIPTION
Problem: Shortfall contract transfers tokens to previous bidders on placeBid. This might lock the auction if the receiver can not receive a transfer due to some reason, e.g. if the receiver is blacklisted in the token contract.

Solution: Track the tokens owed to users due to failed transfer attempts.

Resolves #VEN-1477

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [x] I have updated the documentation to account for the changes in the code.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [x] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
