### PR TITLE
Fairyproof audit fixes of VToken Automatic Income Allocation

### DIFF
--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -102,7 +102,7 @@ contract VToken is
         address accessControlManager_,
         RiskManagementInit memory riskManagement,
         uint256 reserveFactorMantissa_
-    ) external reinitializer(2) {
+    ) external initializer {
         ensureNonzeroAddress(admin_);
 
         // Initialize the market

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -422,20 +422,15 @@ contract VToken is
      * @notice Accrues interest and reduces reserves by transferring to the protocol reserve contract
      * @dev Gracefully return if reserves already reduced in accrueInterest
      * @param reduceAmount Amount of reduction to reserves
-     * @param kind kind of reserve
      * @custom:event Emits ReservesReduced event; may emit AccrueInterest
      * @custom:error ReduceReservesCashNotAvailable is thrown when the vToken does not have sufficient cash
      * @custom:error ReduceReservesCashValidation is thrown when trying to withdraw more cash than the reserves have
      * @custom:access Not restricted
      */
-    function reduceReserves(uint256 reduceAmount, IProtocolShareReserve.IncomeType kind)
-        external
-        override
-        nonReentrant
-    {
+    function reduceReserves(uint256 reduceAmount) external override nonReentrant {
         accrueInterest();
         if (reduceReservesBlockNumber == _getBlockNumber()) return;
-        _reduceReservesFresh(reduceAmount, kind);
+        _reduceReservesFresh(reduceAmount, IProtocolShareReserve.IncomeType.SPREAD);
     }
 
     /**

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -152,10 +152,6 @@ contract VTokenStorage {
  * @notice Interface implemented by the `VToken` contract
  */
 abstract contract VTokenInterface is VTokenStorage {
-    enum IncomeType {
-        LIQUIDATION,
-        SPREAD
-    }
     struct RiskManagementInit {
         address shortfall;
         address payable protocolShareReserve;

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -342,7 +342,7 @@ abstract contract VTokenInterface is VTokenStorage {
 
     function setReserveFactor(uint256 newReserveFactorMantissa) external virtual;
 
-    function reduceReserves(uint256 reduceAmount, IProtocolShareReserve.IncomeType kind) external virtual;
+    function reduceReserves(uint256 reduceAmount) external virtual;
 
     function exchangeRateCurrent() external virtual returns (uint256);
 

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -282,8 +282,6 @@ abstract contract VTokenInterface is VTokenStorage {
      */
     event SweepToken(address indexed token);
 
-    event NewReduceReservesThreshold(uint256 oldReduceReservesThreshold, uint256 NewReduceReservesThreshold);
-
     event NewReduceReservesBlockDelta(uint256 oldReduceReservesBlockDelta, uint256 newReduceReservesBlockDelta);
 
     /*** User Interface ***/

--- a/tests/hardhat/Fork/RiskFund.ts
+++ b/tests/hardhat/Fork/RiskFund.ts
@@ -201,24 +201,6 @@ const riskFundFixture = async (): Promise<void> => {
 
   await accessControlManager.giveCallPermission(
     ethers.constants.AddressZero,
-    "setReduceReservesThreshold(uint256)",
-    admin.address,
-  );
-
-  await accessControlManager.giveCallPermission(
-    ethers.constants.AddressZero,
-    "setReduceReservesBlockDelta(uint256)",
-    admin.address,
-  );
-
-  await accessControlManager.giveCallPermission(
-    ethers.constants.AddressZero,
-    "setReduceReservesThreshold(uint256)",
-    admin.address,
-  );
-
-  await accessControlManager.giveCallPermission(
-    ethers.constants.AddressZero,
     "setReduceReservesBlockDelta(uint256)",
     admin.address,
   );
@@ -517,7 +499,7 @@ describe("Risk Fund: Tests", function () {
       it("fails if start path is not market", async function () {
         await USDC.connect(usdcUser).approve(vUSDC.address, convertToUnit(1000, 18));
         await vUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
-        await vUSDC.reduceReserves(convertToUnit(100, 18), 0);
+        await vUSDC.reduceReserves(convertToUnit(100, 18));
         await protocolShareReserve.releaseFunds(comptroller1Proxy.address, USDC.address, convertToUnit(100, 18), 0);
         await expect(
           riskFund.swapPoolsAssets([vUSDC.address], [convertToUnit(10, 18)], [[USDT.address, BUSD.address]]),
@@ -527,7 +509,7 @@ describe("Risk Fund: Tests", function () {
       it("fails if final path is not base convertible asset", async function () {
         await USDC.connect(usdcUser).approve(vUSDC.address, convertToUnit(1000, 18));
         await vUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
-        await vUSDC.reduceReserves(convertToUnit(100, 18), 0);
+        await vUSDC.reduceReserves(convertToUnit(100, 18));
         await protocolShareReserve.releaseFunds(comptroller1Proxy.address, USDC.address, convertToUnit(100, 18), 0);
         await expect(
           riskFund.swapPoolsAssets([vUSDC.address], [convertToUnit(10, 18)], [[USDC.address, USDT.address]]),
@@ -630,7 +612,7 @@ describe("Risk Fund: Tests", function () {
     it("Below min threshold amount", async function () {
       await USDC.connect(usdcUser).approve(vUSDC.address, convertToUnit(1000, 18));
       await vUSDC.connect(usdcUser).addReserves(convertToUnit(100, 18));
-      await vUSDC.reduceReserves(convertToUnit(50, 18), 0);
+      await vUSDC.reduceReserves(convertToUnit(50, 18));
 
       const protocolReserveUSDCBal = await USDC.balanceOf(protocolShareReserve.address);
       expect(protocolReserveUSDCBal).equal(convertToUnit(50, 18));
@@ -661,7 +643,7 @@ describe("Risk Fund: Tests", function () {
     it("Above min threshold amount", async function () {
       await USDC.connect(usdcUser).approve(vUSDC.address, convertToUnit(1000, 18));
       await vUSDC.connect(usdcUser).addReserves(convertToUnit(200, 18));
-      await vUSDC.reduceReserves(convertToUnit(100, 18), 0);
+      await vUSDC.reduceReserves(convertToUnit(100, 18));
       const protocolReserveUSDCBal = await USDC.balanceOf(protocolShareReserve.address);
       expect(protocolReserveUSDCBal).equal(convertToUnit(100, 18));
 
@@ -705,9 +687,9 @@ describe("Risk Fund: Tests", function () {
 
       await vUSDT.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
-      await vUSDT.reduceReserves(convertToUnit(100, 18), 0);
+      await vUSDT.reduceReserves(convertToUnit(100, 18));
 
-      await vUSDC.reduceReserves(convertToUnit(100, 18), 0);
+      await vUSDC.reduceReserves(convertToUnit(100, 18));
 
       const protocolReserveUSDCBal = await USDC.balanceOf(protocolShareReserve.address);
       expect(protocolReserveUSDCBal).equal(convertToUnit(100, 18));
@@ -776,8 +758,8 @@ describe("Risk Fund: Tests", function () {
 
       await vUSDT.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
-      await vUSDT.reduceReserves(convertToUnit(100, 18), 0);
-      await vUSDC.reduceReserves(convertToUnit(100, 18), 0);
+      await vUSDT.reduceReserves(convertToUnit(100, 18));
+      await vUSDC.reduceReserves(convertToUnit(100, 18));
       const protocolReserveUSDCBal = await USDC.balanceOf(protocolShareReserve.address);
       expect(protocolReserveUSDCBal).equal(convertToUnit(100, 18));
 
@@ -831,8 +813,8 @@ describe("Risk Fund: Tests", function () {
 
       await vUSDT.connect(usdtUser).addReserves(convertToUnit(200, 18));
 
-      await vUSDT.reduceReserves(convertToUnit(100, 18), 0);
-      await vUSDC.reduceReserves(convertToUnit(100, 18), 0);
+      await vUSDT.reduceReserves(convertToUnit(100, 18));
+      await vUSDC.reduceReserves(convertToUnit(100, 18));
       await riskFund.swapPoolsAssets(
         [vUSDT.address, vUSDC.address, vUSDT2.address, vUSDC2.address, vUSDT3.address],
         [
@@ -902,12 +884,12 @@ describe("Risk Fund: Tests", function () {
 
       await vBUSD3.connect(busdUser).addReserves(convertToUnit(50, 18));
 
-      await vUSDT.reduceReserves(convertToUnit(110, 18), 0);
-      await vUSDC.reduceReserves(convertToUnit(120, 18), 0);
-      await vUSDT2.reduceReserves(convertToUnit(150, 18), 0);
-      await vUSDC2.reduceReserves(convertToUnit(160, 18), 0);
-      await vUSDT3.reduceReserves(convertToUnit(175, 18), 0);
-      await vBUSD3.reduceReserves(convertToUnit(50, 18), 0);
+      await vUSDT.reduceReserves(convertToUnit(110, 18));
+      await vUSDC.reduceReserves(convertToUnit(120, 18));
+      await vUSDT2.reduceReserves(convertToUnit(150, 18));
+      await vUSDC2.reduceReserves(convertToUnit(160, 18));
+      await vUSDT3.reduceReserves(convertToUnit(175, 18));
+      await vBUSD3.reduceReserves(convertToUnit(50, 18));
 
       let protocolUSDTFor1 = await protocolShareReserve.getPoolAssetReserve(comptroller1Proxy.address, USDT.address);
       let protocolUSDCFor1 = await protocolShareReserve.getPoolAssetReserve(comptroller1Proxy.address, USDC.address);

--- a/tests/hardhat/Fork/RiskFundSwap.ts
+++ b/tests/hardhat/Fork/RiskFundSwap.ts
@@ -226,7 +226,7 @@ describe("Risk Fund: Swap Tests", () => {
   it("Swap All Pool Assets", async () => {
     await USDT.connect(usdtUser).approve(vUSDT.address, ADD_RESERVE_AMOUNT);
     await vUSDT.connect(usdtUser).addReserves(ADD_RESERVE_AMOUNT);
-    await vUSDT.connect(usdtUser).reduceReserves(REDUCE_RESERVE_AMOUNT, 0);
+    await vUSDT.connect(usdtUser).reduceReserves(REDUCE_RESERVE_AMOUNT);
 
     await protocolShareReserve.releaseFunds(comptroller1Proxy.address, USDT.address, REDUCE_RESERVE_AMOUNT, 0);
 


### PR DESCRIPTION
## Description

3.1.1 Changes in VTokenInterface.IncomeType (IL) - Removed unused enum
3.1.2 Rest of suggestions in VTokenInterface.sol (IL) - Removed unused events
3.2.1 VToke.reduceReserves kind param (IL) - Removed kind parameter from reduceReserves() function
3.2.2 VToken reinitializer(2) (IL) - Reverted	
3.2.3 VToken.healBorrow and RepayBorrow event (IL)-	We treat healing as "repayment”
Additionally, the comptroller only call healBorrow while there is borrowBalance in the market, therefore if repayAmount is 0 then also badDebtDelta block will be executed.
3.2.4 VToken._redeemFresh (IL)-It gives flexibility to user to redeem any number of tokens, if the amount resulted be zero it will fail [here](https://github.com/VenusProtocol/isolated-pools/blob/fix/fairyproof-audit-fixes/contracts/VToken.sol#L916)
3.2.5 VToken calculation of protocolSeizeTokens (IL) - Fixed by merging develop in feature
3.2.6 VToken other suggestions (IL)- Fixed by merging develop in feature
3.3 Other contracts (IL)- Fixed by merging develop in feature
Resolves [VEN-1775]

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
