### PR TITLE
[VEN-2010]: Deployment scripts for cross chain XVS bridge

### DIFF
--- a/deploy/016-xvs-bridge-local.ts
+++ b/deploy/016-xvs-bridge-local.ts
@@ -1,0 +1,155 @@
+import { BigNumberish } from "ethers";
+import { ethers } from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { bridgeConfig, getConfig, xvsBridgeAdminMethods } from "../helpers/deploymentConfig";
+import { toAddress } from "../helpers/deploymentUtils";
+import { getArgTypesFromSignature } from "../helpers/utils";
+import { XVSBridgeAdmin, XVSProxyOFTSrc } from "../typechain";
+
+interface GovernanceCommand {
+  contract: string;
+  signature: string;
+  argTypes: string[];
+  parameters: any[];
+  value: BigNumberish;
+}
+
+const configureAccessControls = async (
+  methods: string[],
+  accessControlManagerAddress: string,
+  caller: string,
+  target: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<GovernanceCommand[]> => {
+  const commands = await Promise.all(
+    methods.map(async method => {
+      const callerAddress = await toAddress(caller, hre);
+      const targetAddress = await toAddress(target, hre);
+      return [
+        {
+          contract: accessControlManagerAddress,
+          signature: "giveCallPermission(address,string,address)",
+          argTypes: ["address", "string", "address"],
+          parameters: [targetAddress, method, callerAddress],
+          value: 0,
+        },
+      ];
+    }),
+  );
+  return commands.flat();
+};
+
+const configureBridgeCommands = async (
+  target: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<GovernanceCommand[]> => {
+  const commands = await Promise.all(
+    bridgeConfig[hre.network.name].methods.map(async (entry: { method: string; args: any[] }) => {
+      const { method, args } = entry;
+      return {
+        contract: target,
+        signature: method,
+        argTypes: getArgTypesFromSignature(method),
+        parameters: args,
+        value: 0,
+      };
+    }),
+  );
+  return commands.flat();
+};
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre;
+  const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+  const deploymentConfig = await getConfig(hre.network.name);
+  const { preconfiguredAddresses } = deploymentConfig;
+
+  const proxyAdmin = await ethers.getContract("DefaultProxyAdmin");
+  const owner = await proxyAdmin.owner();
+
+  const XVSProxyOFTSrc = await deploy("XVSProxyOFTSrc", {
+    from: deployer,
+    contract: "XVSProxyOFTSrc",
+    args: [preconfiguredAddresses.XVS, 8, preconfiguredAddresses.LzEndpoint, preconfiguredAddresses.ResilientOracle],
+    autoMine: true,
+    log: true,
+  });
+
+  const XVSBridgeAdmin = await deploy("XVSBridgeAdmin", {
+    from: deployer,
+    args: [XVSProxyOFTSrc.address],
+    contract: "XVSBridgeAdmin",
+    proxy: {
+      owner: owner,
+      proxyContract: "OpenZeppelinTransparentProxy",
+      execute: {
+        methodName: "initialize",
+        args: [preconfiguredAddresses.AccessControlManager],
+      },
+      upgradeIndex: 0,
+    },
+    log: true,
+    autoMine: true,
+  });
+
+  const bridge = await ethers.getContractAt<XVSProxyOFTSrc>("XVSProxyOFTSrc", XVSProxyOFTSrc.address, deployer);
+  const bridgeAdmin = await ethers.getContractAt<XVSBridgeAdmin>("XVSBridgeAdmin", XVSBridgeAdmin.address, deployer);
+
+  const removeArray = new Array(xvsBridgeAdminMethods.length).fill(false);
+  let tx = await bridgeAdmin.upsertSignature(xvsBridgeAdminMethods, removeArray);
+  await tx.wait();
+
+  tx = await bridge.transferOwnership(XVSBridgeAdmin.address);
+  await tx.wait();
+
+  tx = await bridgeAdmin.transferOwnership(preconfiguredAddresses.NormalTimelock);
+  await tx.wait();
+  console.log(
+    `Bridge Admin owner ${deployer} sucessfully changed to ${preconfiguredAddresses.NormalTimelock}. Please accept the ownership.`,
+  );
+
+  const commands = [
+    ...(await configureAccessControls(
+      xvsBridgeAdminMethods,
+      preconfiguredAddresses.AccessControlManager,
+      preconfiguredAddresses.NormalTimelock,
+      XVSBridgeAdmin.address,
+      hre,
+    )),
+    ...(await configureAccessControls(
+      xvsBridgeAdminMethods,
+      preconfiguredAddresses.AccessControlManager,
+      preconfiguredAddresses.FastTrackTimelock,
+      XVSBridgeAdmin.address,
+      hre,
+    )),
+    ...(await configureAccessControls(
+      xvsBridgeAdminMethods,
+      preconfiguredAddresses.AccessControlManager,
+      preconfiguredAddresses.CriticalTimelock,
+      XVSBridgeAdmin.address,
+      hre,
+    )),
+    ...(await configureBridgeCommands(XVSBridgeAdmin.address, hre)),
+    {
+      contract: XVSBridgeAdmin.address,
+      signature: "acceptOwnership()",
+      parameters: [],
+      value: 0,
+    },
+  ];
+  console.log("Please propose a VIP with the following commands:");
+  console.log(
+    JSON.stringify(
+      commands.map(c => ({ target: c.contract, signature: c.signature, params: c.parameters, value: c.value })),
+    ),
+  );
+};
+func.tags = ["XVSBridgeSrc", "il"];
+
+func.skip = async (hre: HardhatRuntimeEnvironment) =>
+  !(hre.network.name === "bsctestnet" || hre.network.name === "bscmainnet");
+export default func;

--- a/deploy/016-xvs-bridge-local.ts
+++ b/deploy/016-xvs-bridge-local.ts
@@ -3,7 +3,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { bridgeAdminMethods, bridgeConfig, getConfig, xvsBridgeAdminMethods } from "../helpers/deploymentConfig";
+import { bridgeAdminMethods, bridgeConfig, getConfig, xvsBridgeMethods } from "../helpers/deploymentConfig";
 import { toAddress } from "../helpers/deploymentUtils";
 import { getArgTypesFromSignature } from "../helpers/utils";
 import { XVSBridgeAdmin, XVSProxyOFTSrc } from "../typechain";
@@ -98,8 +98,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const bridge = await ethers.getContractAt<XVSProxyOFTSrc>("XVSProxyOFTSrc", XVSProxyOFTSrc.address, deployer);
   const bridgeAdmin = await ethers.getContractAt<XVSBridgeAdmin>("XVSBridgeAdmin", XVSBridgeAdmin.address, deployer);
 
-  const removeArray = new Array(xvsBridgeAdminMethods.length).fill(false);
-  let tx = await bridgeAdmin.upsertSignature(xvsBridgeAdminMethods, removeArray);
+  const removeArray = new Array(xvsBridgeMethods.length).fill(false);
+  let tx = await bridgeAdmin.upsertSignature(xvsBridgeMethods, removeArray);
   await tx.wait();
 
   tx = await bridge.transferOwnership(XVSBridgeAdmin.address);
@@ -113,7 +113,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const commands = [
     ...(await configureAccessControls(
-      xvsBridgeAdminMethods,
+      xvsBridgeMethods,
       preconfiguredAddresses.AccessControlManager,
       preconfiguredAddresses.NormalTimelock,
       XVSBridgeAdmin.address,
@@ -131,6 +131,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       contract: XVSBridgeAdmin.address,
       signature: "acceptOwnership()",
       parameters: [],
+      value: 0,
+    },
+
+    {
+      contract: XVSBridgeAdmin.address,
+      signature: "setTrustedRemoteAddress(uint16,bytes)",
+      parameters: [preconfiguredAddresses.LzVirtualChainIdL, "0xDestAddress"],
       value: 0,
     },
 

--- a/deploy/016-xvs-bridge-local.ts
+++ b/deploy/016-xvs-bridge-local.ts
@@ -3,7 +3,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { bridgeConfig, getConfig, xvsBridgeAdminMethods } from "../helpers/deploymentConfig";
+import { bridgeAdminMethods, bridgeConfig, getConfig, xvsBridgeAdminMethods } from "../helpers/deploymentConfig";
 import { toAddress } from "../helpers/deploymentUtils";
 import { getArgTypesFromSignature } from "../helpers/utils";
 import { XVSBridgeAdmin, XVSProxyOFTSrc } from "../typechain";
@@ -120,16 +120,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       hre,
     )),
     ...(await configureAccessControls(
-      xvsBridgeAdminMethods,
+      bridgeAdminMethods,
       preconfiguredAddresses.AccessControlManager,
-      preconfiguredAddresses.FastTrackTimelock,
-      XVSBridgeAdmin.address,
-      hre,
-    )),
-    ...(await configureAccessControls(
-      xvsBridgeAdminMethods,
-      preconfiguredAddresses.AccessControlManager,
-      preconfiguredAddresses.CriticalTimelock,
+      preconfiguredAddresses.NormalTimelock,
       XVSBridgeAdmin.address,
       hre,
     )),

--- a/deploy/017-xvs-bridge-remote.ts
+++ b/deploy/017-xvs-bridge-remote.ts
@@ -42,7 +42,6 @@ const configureAccessControls = async (
 const configureXVSTokenMintCapCommands = async (
   xvsToken: string,
   minterAddress: string,
-  hre: HardhatRuntimeEnvironment,
 ): Promise<GovernanceCommand[]> => {
   const command = [
     {
@@ -159,12 +158,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     {
       contract: XVSBridgeAdmin.address,
-      signature: "setTrustedRemote(uint16,bytes)",
-      parameters: [preconfiguredAddresses.LzVirtualChainIdL, "0xDestAddressSrcAddress"],
+      signature: "setTrustedRemoteAddress(uint16,bytes)",
+      parameters: [preconfiguredAddresses.LzVirtualChainIdL, "0xDestAddress"],
       value: 0,
     },
 
-    ...(await configureXVSTokenMintCapCommands(preconfiguredAddresses.XVS, XVSProxyOFTDest.address, hre)),
+    ...(await configureXVSTokenMintCapCommands(preconfiguredAddresses.XVS, XVSProxyOFTDest.address)),
   ];
   console.log("Please propose a Multisig tx with the following commands:");
   console.log(

--- a/deploy/017-xvs-bridge-remote.ts
+++ b/deploy/017-xvs-bridge-remote.ts
@@ -3,7 +3,13 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { bridgeConfig, getConfig, xvsBridgeAdminMethods, xvsTokenPermissions } from "../helpers/deploymentConfig";
+import {
+  bridgeAdminMethods,
+  bridgeConfig,
+  getConfig,
+  xvsBridgeAdminMethods,
+  xvsTokenPermissions,
+} from "../helpers/deploymentConfig";
 import { toAddress } from "../helpers/deploymentUtils";
 import { XVSBridgeAdmin, XVSProxyOFTDest } from "../typechain";
 
@@ -146,6 +152,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       preconfiguredAddresses.AccessControlManager,
       preconfiguredAddresses.NormalTimelock,
       preconfiguredAddresses.XVS,
+      hre,
+    )),
+
+    ...(await configureAccessControls(
+      bridgeAdminMethods,
+      preconfiguredAddresses.AccessControlManager,
+      preconfiguredAddresses.NormalTimelock,
+      XVSBridgeAdmin.address,
       hre,
     )),
 

--- a/deploy/017-xvs-bridge-remote.ts
+++ b/deploy/017-xvs-bridge-remote.ts
@@ -7,7 +7,7 @@ import {
   bridgeAdminMethods,
   bridgeConfig,
   getConfig,
-  xvsBridgeAdminMethods,
+  xvsBridgeMethods,
   xvsTokenPermissions,
 } from "../helpers/deploymentConfig";
 import { toAddress } from "../helpers/deploymentUtils";
@@ -117,8 +117,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   await executeBridgeCommands(bridge, hre, deployer);
 
-  const removeArray = new Array(xvsBridgeAdminMethods.length).fill(false);
-  let tx = await bridgeAdmin.upsertSignature(xvsBridgeAdminMethods, removeArray);
+  const removeArray = new Array(xvsBridgeMethods.length).fill(false);
+  let tx = await bridgeAdmin.upsertSignature(xvsBridgeMethods, removeArray);
   await tx.wait();
 
   tx = await bridge.transferOwnership(XVSBridgeAdmin.address);
@@ -132,7 +132,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const commands = [
     ...(await configureAccessControls(
-      xvsBridgeAdminMethods,
+      xvsBridgeMethods,
       preconfiguredAddresses.AccessControlManager,
       preconfiguredAddresses.NormalTimelock,
       XVSBridgeAdmin.address,

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -111,7 +111,7 @@ const preconfiguredAddresses = {
     XVS: "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
     ResilientOracle: "0x3cD69251D04A28d887Ac14cbe2E14c52F3D57823",
     LzEndpoint: "0x6Fcb97553D41516Cb228ac03FdC8B9a0a9df04A1",
-    LzVirtualChainIdL: "10102",
+    LzVirtualChainId: "10102",
   },
   bscmainnet: {
     VTreasury: "0xF322942f644A996A617BD29c16bd7d231d9F35E9",
@@ -127,7 +127,7 @@ const preconfiguredAddresses = {
     XVS: "0xcF6BB5389c92Bdda8a3747Ddb454cB7a64626C63",
     ResilientOracle: "0x6592b5DE802159F3E74B2486b091D11a8256ab8A",
     LzEndpoint: "0x6592b5DE802159F3E74B2486b091D11a8256ab8A",
-    LzVirtualChainIdL: "102",
+    LzVirtualChainId: "102",
   },
   sepolia: {
     VTreasury: "0xFc43c055B9be2Ec3BEe6f8C291Af862d764016a0",
@@ -139,7 +139,7 @@ const preconfiguredAddresses = {
     XVS: "0xD657eB80daA42c334B1c70Cb274E83E4163A3dDc",
     ResilientOracle: "0x1B85FAbE5c0846662F5FB0E3598fC48eF587e9f0",
     LzEndpoint: "0xae92d5aD7583AD66E49A0c67BAd18F6ba52dDDc1",
-    LzVirtualChainIdL: "10161",
+    LzVirtualChainId: "10161",
   },
   ethereum: {
     // TODO
@@ -159,7 +159,6 @@ export const xvsBridgeAdminMethods = [
   "unpause()",
   "setTrustedRemote(uint16,bytes)",
   "setTrustedRemoteAddress(uint16,bytes)",
-  "getTrustedRemoteAddress(uint16)",
   "setPrecrime(address)",
   "setMinDstGas(uint16,uint16,uint256)",
   "setPayloadSizeLimit(uint16,uint256)",
@@ -183,7 +182,7 @@ export const bridgeConfig: BridgeConfig = {
   bscmainnet: {
     methods: [
       { method: "setTrustedRemote(uint16,bytes)", args: [101, ANY_CONTRACT] },
-      { method: "setMinDstGas(uint16,uint16,uint256)", args: [10161, 0, "200000"] },
+      { method: "setMinDstGas(uint16,uint16,uint256)", args: [101, 0, "200000"] },
       { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [101, "500000000000000000000"] },
       { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -7,6 +7,7 @@ export type NetworkConfig = {
   hardhat: DeploymentConfig;
   bsctestnet: DeploymentConfig;
   bscmainnet: DeploymentConfig;
+  sepolia: RemoteDeploymentConfig;
 };
 
 export type PreconfiguredAddresses = { [contract: string]: string };
@@ -15,6 +16,10 @@ export type DeploymentConfig = {
   tokensConfig: TokenConfig[];
   poolConfig: PoolConfig[];
   accessControlConfig: AccessControlEntry[];
+  preconfiguredAddresses: PreconfiguredAddresses;
+};
+
+export type RemoteDeploymentConfig = {
   preconfiguredAddresses: PreconfiguredAddresses;
 };
 
@@ -77,6 +82,12 @@ export type AccessControlEntry = {
 export enum InterestRateModels {
   WhitePaper,
   JumpRate,
+}
+
+interface BridgeConfig {
+  [networkName: string]: {
+    methods: { method: string; args: any[] }[];
+  };
 }
 
 const ANY_CONTRACT = ethers.constants.AddressZero;
@@ -157,20 +168,7 @@ export const xvsBridgeAdminMethods = [
   "setConfig(uint16,uint16,uint256,bytes)",
 ];
 
-export const xvsTokenPermissions = (bridge: string, xvs: string): AccessControlEntry[] => {
-  const methods = ["setMintCap(address,uint256)", "mint(address,uint256)", "burn(address,uint256)"];
-  return methods.map(method => ({
-    caller: bridge,
-    target: xvs,
-    method,
-  }));
-};
-
-interface BridgeConfig {
-  [networkName: string]: {
-    methods: { method: string; args: any[] }[];
-  };
-}
+export const xvsTokenPermissions = ["mint(address,uint256)", "burn(address,uint256)"];
 
 export const bridgeConfig: BridgeConfig = {
   bsctestnet: {
@@ -196,7 +194,7 @@ export const bridgeConfig: BridgeConfig = {
   sepolia: {
     methods: [
       { method: "setTrustedRemote(uint16,bytes)", args: [10102, ANY_CONTRACT] },
-      { method: "setMinDstGas(uint16,uint16,uint256)", args: [10161, 0, "200000"] },
+      { method: "setMinDstGas(uint16,uint16,uint256)", args: [10102, 0, "200000"] },
       { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [10102, "500000000000000000000"] },
       { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
@@ -2034,6 +2032,9 @@ export const globalConfig: NetworkConfig = {
     ],
     preconfiguredAddresses: preconfiguredAddresses.bscmainnet,
   },
+  sepolia: {
+    preconfiguredAddresses: preconfiguredAddresses.sepolia,
+  },
 };
 
 export async function getConfig(networkName: string): Promise<DeploymentConfig> {
@@ -2044,6 +2045,8 @@ export async function getConfig(networkName: string): Promise<DeploymentConfig> 
       return globalConfig.bsctestnet;
     case "bscmainnet":
       return globalConfig.bscmainnet;
+    case "sepolia":
+      return globalConfig.sepolia;
     case "development":
       return globalConfig.bsctestnet;
     default:

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -157,7 +157,6 @@ export const xvsBridgeAdminMethods = [
   "setMaxDailyReceiveLimit(uint16,uint256)",
   "pause()",
   "unpause()",
-  "setUseCustomAdapterParams(bool)",
   "setTrustedRemote(uint16,bytes)",
   "setTrustedRemoteAddress(uint16,bytes)",
   "getTrustedRemoteAddress(uint16)",

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -80,6 +80,7 @@ export enum InterestRateModels {
 }
 
 const ANY_CONTRACT = ethers.constants.AddressZero;
+const SEPOLIA_MULTISIG = "0x94fa6078b6b8a26f0b6edffbe6501b22a10470fb";
 
 const preconfiguredAddresses = {
   hardhat: {
@@ -96,6 +97,10 @@ const preconfiguredAddresses = {
     WBNB: "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
     VBNB_CorePool: "0x2E7222e51c0f6e98610A1543Aa3836E092CDe62c",
     SwapRouter_CorePool: "0x83edf1deE1B730b7e8e13C00ba76027D63a51ac0",
+    XVS: "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
+    ResilientOracle: "0x3cD69251D04A28d887Ac14cbe2E14c52F3D57823",
+    LzEndpoint: "0x6Fcb97553D41516Cb228ac03FdC8B9a0a9df04A1",
+    LzVirtualChainIdL: "10102",
   },
   bscmainnet: {
     VTreasury: "0xF322942f644A996A617BD29c16bd7d231d9F35E9",
@@ -108,6 +113,95 @@ const preconfiguredAddresses = {
     WBNB: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
     VBNB_CorePool: "0xA07c5b74C9B40447a954e1466938b865b6BBea36",
     SwapRouter_CorePool: "0x8938E6dA30b59c1E27d5f70a94688A89F7c815a4",
+    XVS: "0xcF6BB5389c92Bdda8a3747Ddb454cB7a64626C63",
+    ResilientOracle: "0x6592b5DE802159F3E74B2486b091D11a8256ab8A",
+    LzEndpoint: "0x6592b5DE802159F3E74B2486b091D11a8256ab8A",
+    LzVirtualChainIdL: "102",
+  },
+  sepolia: {
+    VTreasury: "0xFc43c055B9be2Ec3BEe6f8C291Af862d764016a0",
+    NormalTimelock: SEPOLIA_MULTISIG,
+    FastTrackTimelock: SEPOLIA_MULTISIG,
+    CriticalTimelock: SEPOLIA_MULTISIG,
+    GovernorBravo: SEPOLIA_MULTISIG,
+    AccessControlManager: "0x799700ea540f002134C371fB955e2392FD94DbCD",
+    XVS: "0xD657eB80daA42c334B1c70Cb274E83E4163A3dDc",
+    ResilientOracle: "0x1B85FAbE5c0846662F5FB0E3598fC48eF587e9f0",
+    LzEndpoint: "0xae92d5aD7583AD66E49A0c67BAd18F6ba52dDDc1",
+    LzVirtualChainIdL: "10161",
+  },
+  ethereum: {
+    // TODO
+  },
+};
+
+export const xvsBridgeAdminMethods = [
+  "setSendVersion(uint16)",
+  "setReceiveVersion(uint16)",
+  "forceResumeReceive(uint16,bytes)",
+  "setOracle(address)",
+  "setMaxSingleTransactionLimit(uint16,uint256)",
+  "setMaxDailyLimit(uint16,uint256)",
+  "setMaxSingleReceiveTransactionLimit(uint16,uint256)",
+  "setMaxDailyReceiveLimit(uint16,uint256)",
+  "pause()",
+  "unpause()",
+  "setUseCustomAdapterParams(bool)",
+  "setTrustedRemote(uint16,bytes)",
+  "setTrustedRemoteAddress(uint16,bytes)",
+  "getTrustedRemoteAddress(uint16)",
+  "setPrecrime(address)",
+  "setMinDstGas(uint16,uint16,uint256)",
+  "setPayloadSizeLimit(uint16,uint256)",
+  "setWhitelist(address,bool)",
+  "setConfig(uint16,uint16,uint256,bytes)",
+];
+
+export const xvsTokenPermissions = (bridge: string, xvs: string): AccessControlEntry[] => {
+  const methods = ["setMintCap(address,uint256)", "mint(address,uint256)", "burn(address,uint256)"];
+  return methods.map(method => ({
+    caller: bridge,
+    target: xvs,
+    method,
+  }));
+};
+
+interface BridgeConfig {
+  [networkName: string]: {
+    methods: { method: string; args: any[] }[];
+  };
+}
+
+export const bridgeConfig: BridgeConfig = {
+  bsctestnet: {
+    methods: [
+      { method: "setTrustedRemote(uint16,bytes)", args: [10161, ANY_CONTRACT] },
+      { method: "setMinDstGas(uint16,uint16,uint256)", args: [10161, 0, "200000"] },
+      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10161, "10000000000000000000"] },
+      { method: "setMaxDailyLimit(uint16,uint256)", args: [10161, "500000000000000000000"] },
+      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [10161, "10000000000000000000"] },
+      { method: "setMaxDailyReceiveLimit(uint16,uint256)", args: [10161, "50000000000000000000"] },
+    ],
+  },
+  bscmainnet: {
+    methods: [
+      { method: "setTrustedRemote(uint16,bytes)", args: [101, ANY_CONTRACT] },
+      { method: "setMinDstGas(uint16,uint16,uint256)", args: [10161, 0, "200000"] },
+      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
+      { method: "setMaxDailyLimit(uint16,uint256)", args: [101, "500000000000000000000"] },
+      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
+      { method: "setMaxDailyReceiveLimit(uint16,uint256)", args: [101, "50000000000000000000"] },
+    ],
+  },
+  sepolia: {
+    methods: [
+      { method: "setTrustedRemote(uint16,bytes)", args: [10102, ANY_CONTRACT] },
+      { method: "setMinDstGas(uint16,uint16,uint256)", args: [10161, 0, "200000"] },
+      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
+      { method: "setMaxDailyLimit(uint16,uint256)", args: [10102, "500000000000000000000"] },
+      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
+      { method: "setMaxDailyReceiveLimit(uint16,uint256)", args: [10102, "50000000000000000000"] },
+    ],
   },
 };
 

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -157,7 +157,6 @@ export const xvsBridgeAdminMethods = [
   "setMaxDailyReceiveLimit(uint16,uint256)",
   "pause()",
   "unpause()",
-  "setTrustedRemote(uint16,bytes)",
   "setTrustedRemoteAddress(uint16,bytes)",
   "setPrecrime(address)",
   "setMinDstGas(uint16,uint16,uint256)",
@@ -171,7 +170,7 @@ export const xvsTokenPermissions = ["mint(address,uint256)", "burn(address,uint2
 export const bridgeConfig: BridgeConfig = {
   bsctestnet: {
     methods: [
-      { method: "setTrustedRemote(uint16,bytes)", args: [10161, ANY_CONTRACT] },
+      { method: "setTrustedRemoteAddress(uint16,bytes)", args: [10161, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [10161, 0, "200000"] },
       { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10161, "10000000000000000000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [10161, "500000000000000000000"] },
@@ -181,7 +180,7 @@ export const bridgeConfig: BridgeConfig = {
   },
   bscmainnet: {
     methods: [
-      { method: "setTrustedRemote(uint16,bytes)", args: [101, ANY_CONTRACT] },
+      { method: "setTrustedRemoteAddress(uint16,bytes)", args: [101, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [101, 0, "200000"] },
       { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [101, "500000000000000000000"] },
@@ -191,7 +190,7 @@ export const bridgeConfig: BridgeConfig = {
   },
   sepolia: {
     methods: [
-      { method: "setTrustedRemote(uint16,bytes)", args: [10102, ANY_CONTRACT] },
+      { method: "setTrustedRemoteAddress(uint16,bytes)", args: [10102, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [10102, 0, "200000"] },
       { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [10102, "500000000000000000000"] },

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -146,7 +146,7 @@ const preconfiguredAddresses = {
   },
 };
 
-export const xvsBridgeAdminMethods = [
+export const xvsBridgeMethods = [
   "setSendVersion(uint16)",
   "setReceiveVersion(uint16)",
   "forceResumeReceive(uint16,bytes)",
@@ -174,7 +174,6 @@ export const xvsTokenPermissions = ["mint(address,uint256)", "burn(address,uint2
 export const bridgeConfig: BridgeConfig = {
   bsctestnet: {
     methods: [
-      { method: "setTrustedRemoteAddress(uint16,bytes)", args: [10161, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [10161, 0, "200000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [10161, "500000000000000000000"] },
       { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10161, "10000000000000000000"] },
@@ -184,7 +183,6 @@ export const bridgeConfig: BridgeConfig = {
   },
   bscmainnet: {
     methods: [
-      { method: "setTrustedRemoteAddress(uint16,bytes)", args: [101, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [101, 0, "200000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [101, "500000000000000000000"] },
       { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
@@ -194,7 +192,6 @@ export const bridgeConfig: BridgeConfig = {
   },
   sepolia: {
     methods: [
-      { method: "setTrustedRemoteAddress(uint16,bytes)", args: [10102, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [10102, 0, "200000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [10102, "500000000000000000000"] },
       { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -157,13 +157,17 @@ export const xvsBridgeAdminMethods = [
   "setMaxDailyReceiveLimit(uint16,uint256)",
   "pause()",
   "unpause()",
-  "setTrustedRemoteAddress(uint16,bytes)",
+  "removeTrustedRemote(uint16)",
+  "dropFailedMessage(uint16,bytes)",
+  "fallbackWithdraw(address,uint256)",
   "setPrecrime(address)",
   "setMinDstGas(uint16,uint16,uint256)",
   "setPayloadSizeLimit(uint16,uint256)",
   "setWhitelist(address,bool)",
   "setConfig(uint16,uint16,uint256,bytes)",
 ];
+
+export const bridgeAdminMethods = ["setTrustedRemoteAddress(uint16,bytes)", "transferBridgeOwnership(address)"];
 
 export const xvsTokenPermissions = ["mint(address,uint256)", "burn(address,uint256)"];
 
@@ -172,30 +176,30 @@ export const bridgeConfig: BridgeConfig = {
     methods: [
       { method: "setTrustedRemoteAddress(uint16,bytes)", args: [10161, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [10161, 0, "200000"] },
-      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10161, "10000000000000000000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [10161, "500000000000000000000"] },
-      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [10161, "10000000000000000000"] },
+      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10161, "10000000000000000000"] },
       { method: "setMaxDailyReceiveLimit(uint16,uint256)", args: [10161, "50000000000000000000"] },
+      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [10161, "10000000000000000000"] },
     ],
   },
   bscmainnet: {
     methods: [
       { method: "setTrustedRemoteAddress(uint16,bytes)", args: [101, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [101, 0, "200000"] },
-      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [101, "500000000000000000000"] },
-      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
+      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
       { method: "setMaxDailyReceiveLimit(uint16,uint256)", args: [101, "50000000000000000000"] },
+      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [101, "10000000000000000000"] },
     ],
   },
   sepolia: {
     methods: [
       { method: "setTrustedRemoteAddress(uint16,bytes)", args: [10102, ANY_CONTRACT] },
       { method: "setMinDstGas(uint16,uint16,uint256)", args: [10102, 0, "200000"] },
-      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
       { method: "setMaxDailyLimit(uint16,uint256)", args: [10102, "500000000000000000000"] },
-      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
+      { method: "setMaxSingleTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
       { method: "setMaxDailyReceiveLimit(uint16,uint256)", args: [10102, "50000000000000000000"] },
+      { method: "setMaxSingleReceiveTransactionLimit(uint16,uint256)", args: [10102, "10000000000000000000"] },
     ],
   },
 };

--- a/helpers/utils.ts
+++ b/helpers/utils.ts
@@ -22,3 +22,9 @@ export const scaleDownBy = (amount: string | number, decimals: number) => {
 };
 
 export const AddressOne = "0x0000000000000000000000000000000000000001";
+
+// Function to get argument types from method signature
+export const getArgTypesFromSignature = (methodSignature: string): string[] => {
+  const [, argumentString] = methodSignature.split("(")[1].split(")");
+  return argumentString.split(",").map(arg => arg.trim());
+};


### PR DESCRIPTION
## Description

This PR includes two distinct deployment scripts for ethereum and bsc, and each script's functionality is described below.

**bsctestnet and  bscmainnet**
1. Deployments of Bridge and Bridge admin.
2. Transfers ownership to timelock.
3. Consoles VIP commands for configuration.
4. Commands include ACM permissions and configuration of Bridge.

**sepolia and  ethereum**
1. Deployments of Bridge and Bridge admin.
2. Execution of commands for configuratrion of Bridge.
3. Transfers ownership to timelock (multisig).
5. Consoles set of command for the multisig transaction.
6. Commands include ACM permissions and minting caps on XVS token. 

> Note: Since both local and remote bridges need each other's addresses and have a circular dependency, we must set trusted remote after deployments. For bsc, we can do this using VIP, and for ethereum, we can do this using multisig.

Resolves #<!-- issue id -->

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
