### PR TITLE
[VEN-2214] Adjust blocksPerYear for Ethereum

### DIFF
--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -93,7 +93,7 @@ export enum InterestRateModels {
 const ANY_CONTRACT = ethers.constants.AddressZero;
 
 const BSC_BLOCKS_PER_YEAR = 10_512_000; // assuming a block is mined every 3 seconds
-const ETH_BLOCKS_PER_YEAR = 2_252_571; // assuming a block is mined every 14 seconds
+const ETH_BLOCKS_PER_YEAR = 2_628_000; // assuming a block is mined every 12 seconds
 
 export type BlocksPerYear = {
   [key: string]: number;


### PR DESCRIPTION
## Description

This PR adjusts the `blocksPerYear` value for `Ethereum` assuming a block is mined every 12 seconds instead of every 14 seconds.

Resolves #VEN-2214

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
