### PR TITLE
[VEN-2353]: Use addresses from npm packages for Ethereum

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "@venusprotocol/governance-contracts": "1.4.0",
-    "@venusprotocol/oracle": "1.8.0",
+    "@venusprotocol/oracle": "1.9.0",
     "@venusprotocol/protocol-reserve": "1.4.0",
     "@venusprotocol/venus-protocol": "7.1.0",
     "bignumber.js": "9.0.0",

--- a/tests/hardhat/Fork/constants.ts
+++ b/tests/hardhat/Fork/constants.ts
@@ -1,16 +1,18 @@
 import GovernanceBscMainnet from "@venusprotocol/governance-contracts/deployments/bscmainnet.json";
 import GovernanceBscTestnet from "@venusprotocol/governance-contracts/deployments/bsctestnet.json";
+import GovernanceEthMainnet from "@venusprotocol/governance-contracts/deployments/ethereum.json";
 import OracleBscMainnet from "@venusprotocol/oracle/deployments/bscmainnet.json";
 import OracleBscTestnet from "@venusprotocol/oracle/deployments/bsctestnet.json";
+import OracleEthMainnet from "@venusprotocol/oracle/deployments/ethereum.json";
 import PsrBscMainnet from "@venusprotocol/protocol-reserve/deployments/bscmainnet.json";
 import PsrBscTestnet from "@venusprotocol/protocol-reserve/deployments/bsctestnet.json";
 import CoreBscMainnet from "@venusprotocol/venus-protocol/deployments/bscmainnet.json";
 import CoreBscTestnet from "@venusprotocol/venus-protocol/deployments/bsctestnet.json";
+import CoreEthMainnet from "@venusprotocol/venus-protocol/deployments/ethereum.json";
 
-// TESTNET DEPLOYED CONTRACTS
 import { contracts as MainnetContracts } from "../../../deployments/bscmainnet.json";
-// MAINNET DEPLOYED CONTRACTS
 import { contracts as TestnetContracts } from "../../../deployments/bsctestnet.json";
+import { contracts as EthereumContracts } from "../../../deployments/ethereum.json";
 
 export const contractAddreseses = {
   sepolia: {
@@ -29,8 +31,8 @@ export const contractAddreseses = {
     CHAINLINK_ORACLE: "0xEdaB2b65fD3413d89b6D2a3AeB61E0c9eECA6A76",
     RESILIENT_ORACLE: "0xd44B364a28386a2aa4Df1C54EA32deF3B2b98EeC",
     SWAP_ROUTER_CORE_POOL: "0x83edf1deE1B730b7e8e13C00ba76027D63a51ac0", // picked from bscmainnet
-    TOKEN2_HOLDER: "0x02EB950C215D12d723b44a18CfF098C6E166C531",
     TOKEN1_HOLDER: "0x02EB950C215D12d723b44a18CfF098C6E166C531",
+    TOKEN2_HOLDER: "0x02EB950C215D12d723b44a18CfF098C6E166C531",
     ACC1: "0x3Ac99C7853b58f4AA38b309D372562a5A88bB9C1",
     ACC2: "0xA4a04C2D661bB514bB8B478CaCB61145894563ef",
     ACC3: "0x394d1d517e8269596a7E4Cd1DdaC1C928B3bD8b3",
@@ -38,26 +40,26 @@ export const contractAddreseses = {
   },
   ethereum: {
     ADMIN: "0x285960C5B22fD66A736C7136967A3eB15e93CC67",
-    ACM: "0x230058da2D23eb8836EC5DB7037ef7250c56E25E",
-    TOKEN1: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    TOKEN2: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-    VTOKEN1: "0x17C07e0c232f2f80DfDbd7a95b942D893A4C5ACb",
-    VTOKEN2: "0x8C3e3821259B82fFb32B2450A95d2dcbf161C24E",
-    COMPTROLLER: "0x687a01ecF6d3907658f7A7c714749fAC32336D1B",
-    PSR: "",
+    ACM: GovernanceEthMainnet.contracts.AccessControlManager.address,
+    TOKEN1: "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E", // crvUSD
+    TOKEN2: "0xD533a949740bb3306d119CC777fa900bA034cd52", // CRV
+    VTOKEN1: EthereumContracts.VToken_vcrvUSD_Curve.address,
+    VTOKEN2: EthereumContracts.VToken_vCRV_Curve.address,
+    COMPTROLLER: EthereumContracts.Comptroller_Curve.address,
+    PSR: CoreEthMainnet.contracts.VTreasuryV8.address, // treasury
     SHORTFALL: "",
     RISKFUND: "",
     REWARD_DISTRIBUTOR1: "",
-    POOL_REGISTRY: "0x61CAff113CCaf05FFc6540302c37adcf077C5179",
-    CHAINLINK_ORACLE: "0x94c3A2d6B7B2c051aDa041282aec5B0752F8A1F2",
-    RESILIENT_ORACLE: "0xd2ce3fb018805ef92b8C5976cb31F84b4E295F94",
+    POOL_REGISTRY: EthereumContracts.PoolRegistry.address,
+    CHAINLINK_ORACLE: OracleEthMainnet.contracts.ChainlinkOracle.address,
+    RESILIENT_ORACLE: OracleEthMainnet.contracts.ResilientOracle.address,
     SWAP_ROUTER_CORE_POOL: "",
-    TOKEN2_HOLDER: "0x9696f59E4d72E237BE84fFD425DCaD154Bf96976",
-    TOKEN1_HOLDER: "0xDFd5293D8e347dFe59E90eFd55b2956a1343963d",
+    TOKEN1_HOLDER: "0xCD9054a152b817C0098fF57c7a407a66736Ef812",
+    TOKEN2_HOLDER: "0x28C6c06298d514Db089934071355E5743bf21d60",
     ACC1: "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5",
     ACC2: "0x29182006a4967e9a50C0A66076dA514993D3B4D4",
     ACC3: "0xa27CEF8aF2B6575903b676e5644657FAe96F491F",
-    BLOCK_NUMBER: 19112731,
+    BLOCK_NUMBER: 19117880,
   },
   bsctestnet: {
     ADMIN: GovernanceBscTestnet.contracts.NormalTimelock.address,

--- a/tests/hardhat/Fork/liquidation.ts
+++ b/tests/hardhat/Fork/liquidation.ts
@@ -355,6 +355,8 @@ if (FORK) {
         if (FORKED_NETWORK == "bsctestnet") repayAmount = 1000000047610436;
         else if (FORKED_NETWORK == "sepolia") repayAmount = 1000000019818620;
         else if (FORKED_NETWORK == "bscmainnet") repayAmount = 1000000034788981;
+        else if (FORKED_NETWORK == "ethereum") repayAmount = 1000000076103691;
+
         const seizeTokens = ratio * repayAmount;
         const param = {
           vTokenCollateral: vTOKEN1.address,
@@ -374,7 +376,7 @@ if (FORK) {
         const protocolSeizeTokens = Math.floor((seizeTokens * 5) / 100);
         const reserveIncrease = (protocolSeizeTokens * exchangeRateCollateralNew) / 1e18;
 
-        expect(vTOKEN1BalAcc2Prev - vTOKEN1BalAcc2New).to.closeTo(Math.floor(seizeTokens), 99);
+        expect(vTOKEN1BalAcc2Prev - vTOKEN1BalAcc2New).to.closeTo(Math.floor(seizeTokens), 100);
         expect(vTOKEN1BalAcc1New - vTOKEN1BalAcc1Prev).to.closeTo(liquidatorSeizeTokens, 1);
         expect(totalReservesToken1New - totalReservesToken1Prev).to.closeTo(
           Math.round(reserveIncrease),

--- a/tests/hardhat/Fork/reduceReservesTest.ts
+++ b/tests/hardhat/Fork/reduceReservesTest.ts
@@ -80,8 +80,6 @@ if (FORK) {
       vTOKEN1 = await configureVToken(VTOKEN1);
       comptroller = Comptroller__factory.connect(COMPTROLLER, impersonatedTimelock);
 
-      await vTOKEN1.connect(impersonatedTimelock).setProtocolShareReserve(PSR);
-
       await grantPermissions();
 
       await comptroller.connect(acc1Signer).enterMarkets([vTOKEN1.address]);

--- a/tests/hardhat/Fork/supply.ts
+++ b/tests/hardhat/Fork/supply.ts
@@ -62,7 +62,7 @@ let resilientOracle: MockPriceOracle;
 let priceOracle: ChainlinkOracle;
 let accessControlManager: AccessControlManager;
 
-const blocksToMine: number = 300000;
+const blocksToMine: number = 30000;
 const TOKEN2BorrowAmount = convertToUnit("1", 17);
 
 async function configureTimelock() {
@@ -134,9 +134,7 @@ if (FORK) {
       await resilientOracle.setTokenConfig(tupleForToken2);
       await resilientOracle.setTokenConfig(tupleForToken1);
 
-      if (FORKED_NETWORK == "bscmainnet") {
-        await priceOracle.setDirectPrice(token1.address, convertToUnit("1", 18));
-      }
+      await priceOracle.setDirectPrice(token1.address, convertToUnit("1", 18));
 
       await grantPermissions();
 
@@ -206,7 +204,7 @@ if (FORK) {
       await token2.connect(acc1Signer).approve(vTOKEN2.address, convertToUnit(2, 18));
       await expect(vTOKEN2.connect(acc1Signer).mint(convertToUnit(1, 18))).to.emit(vTOKEN2, "Mint");
 
-      // Mining  3,00,000 blocks
+      // Mining  300,000 blocks
       await mine(300000);
 
       // Assert current exchange rate
@@ -225,7 +223,7 @@ if (FORK) {
       // Borrow TOKEN2 with second account(ACC2)
       await expect(vTOKEN2.connect(acc2Signer).borrow(TOKEN2BorrowAmount)).to.be.emit(vTOKEN2, "Borrow");
 
-      // Mine 300,000 blocks
+      // Mine 30,000 blocks
       await mine(blocksToMine);
 
       // Accural all the interest till latest block
@@ -238,7 +236,7 @@ if (FORK) {
 
       await vTOKEN2.connect(acc2Signer).repayBorrow(TOKEN2BorrowAmount);
 
-      // Mine 300,000 blocks
+      // Mine 30,000 blocks
       await mine(blocksToMine);
 
       // Accural all the interest till latest block
@@ -277,7 +275,7 @@ if (FORK) {
       let result = vTOKEN2.connect(acc1Signer).liquidateBorrow(ACC2, maxClose, vTOKEN1.address);
       await expect(result).to.emit(vTOKEN2, "LiquidateBorrow");
 
-      // Mine 300,000 blocks
+      // Mine 30,000 blocks
       await mine(blocksToMine);
 
       // Accural all the interest till latest block
@@ -309,7 +307,7 @@ if (FORK) {
       const totalBal = await vTOKEN2.balanceOf(ACC1);
       await expect(vTOKEN2.connect(acc1Signer).redeem(totalBal)).to.emit(vTOKEN2, "Redeem");
 
-      // Mine 300,000 blocks
+      // Mine 30,000 blocks
       await mine(blocksToMine);
 
       // Accural all the interest till latest block
@@ -339,7 +337,7 @@ if (FORK) {
       // Borrow TOKEN2 with third account(ACC3)
       await expect(vTOKEN2.connect(acc3Signer).borrow(TOKEN2BorrowAmount)).to.be.emit(vTOKEN2, "Borrow");
 
-      // Mine 300,000 blocks
+      // Mine 30,000 blocks
       await mine(blocksToMine);
 
       // Partial redeem for first account(ACC1)
@@ -349,7 +347,7 @@ if (FORK) {
       // Assert undelying after partial redeem
       await assertRedeemAmount(convertToUnit(5, 7), balanceBefore);
 
-      // Mine 300,000 blocks
+      // Mine 30,000 blocks
       await mine(blocksToMine);
 
       // Complete redeem for first account(ACC1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,7 +3081,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@venusprotocol/governance-contracts@npm:1.4.0, @venusprotocol/governance-contracts@npm:^1.4.0, @venusprotocol/governance-contracts@npm:^1.4.0-dev.1, @venusprotocol/governance-contracts@npm:^1.4.0-dev.9":
+"@venusprotocol/governance-contracts@npm:1.4.0, @venusprotocol/governance-contracts@npm:^1.4.0, @venusprotocol/governance-contracts@npm:^1.4.0-dev.1":
   version: 1.4.0
   resolution: "@venusprotocol/governance-contracts@npm:1.4.0"
   dependencies:
@@ -3121,7 +3121,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.27.1
     "@typescript-eslint/parser": ^5.27.1
     "@venusprotocol/governance-contracts": 1.4.0
-    "@venusprotocol/oracle": 1.8.0
+    "@venusprotocol/oracle": 1.9.0
     "@venusprotocol/protocol-reserve": 1.4.0
     "@venusprotocol/venus-protocol": 7.1.0
     bignumber.js: 9.0.0
@@ -3169,23 +3169,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@venusprotocol/oracle@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@venusprotocol/oracle@npm:1.8.0"
+"@venusprotocol/oracle@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@venusprotocol/oracle@npm:1.9.0"
   dependencies:
     "@chainlink/contracts": ^0.5.1
     "@defi-wonderland/smock": ^2.3.4
     "@nomicfoundation/hardhat-network-helpers": ^1.0.8
     "@openzeppelin/contracts": ^4.6.0
     "@openzeppelin/contracts-upgradeable": ^4.7.3
-    "@venusprotocol/governance-contracts": ^1.4.0-dev.9
+    "@venusprotocol/governance-contracts": ^1.4.0
+    "@venusprotocol/solidity-utilities": 1.3.0
     "@venusprotocol/venus-protocol": ^6.0.0
     ethers: ^5.6.8
     hardhat: ^2.16.1
     hardhat-deploy: ^0.11.14
     module-alias: ^2.2.2
     solidity-docgen: ^0.6.0-beta.29
-  checksum: 3ea02a9686e80ce0b378aa5197fd46b2c02b089bd5512afe673d6d45e3091e280dbf04788400ea47bee4151182b4b39c981207e1d42fbe2b970161b29abcfee1
+  checksum: 60995054e5cb3e970e940afa04e49cc06a8150584be5b777dc559766fef5e4e9ab1acbff1b9158c8e4241f45080dc576050373d1de57768868d1d16710f7469a
   languageName: node
   linkType: hard
 
@@ -3207,7 +3208,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@venusprotocol/solidity-utilities@npm:^1.1.0, @venusprotocol/solidity-utilities@npm:^1.2.0, @venusprotocol/solidity-utilities@npm:^1.3.0":
+"@venusprotocol/solidity-utilities@npm:1.3.0, @venusprotocol/solidity-utilities@npm:^1.1.0, @venusprotocol/solidity-utilities@npm:^1.2.0, @venusprotocol/solidity-utilities@npm:^1.3.0":
   version: 1.3.0
   resolution: "@venusprotocol/solidity-utilities@npm:1.3.0"
   checksum: d1109365a5e01959c47b25fb129373db93792e60bf1bc0ed324b63c2a64f6e4a7878ebf016cfade94bc41a2c1245d3e861fdc6b8c5844ac210ed1d73e7307e72


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

Resolves #VEN-2353
This PR enables fork tests for Ethereum network.

Currently the fork for Ethereum do not work for the following as these contracts are not deployed yet:

- RewardsForkTest
- RiskFund
- Shortfall

## Checklist

<!--
  Any non-WIP PR should have all the checkmarks set.
  If a checkmark is not applicable to your PR, mark it as done
-->

- [ ] I have updated the documentation to account for the changes in the code.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a test preventing this bug from silently reappearing again.
- [ ] My contribution follows [Venus contribution guidelines](docs/CONTRIBUTING.md).
