### PR TITLE
fix: delegate borrowing/redemption fixups for VEN-2356

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -98,11 +98,8 @@ contract Comptroller is
     /// @notice Emitted when forced liquidation is enabled or disabled for a market
     event IsForcedLiquidationEnabledUpdated(address indexed vToken, bool enable);
 
-    /// @notice Emitted when the borrowing delegate rights are updated for an account
-    event DelegateUpdated(address indexed borrower, address indexed delegate, bool allowDelegatedBorrows);
-
-    /// @notice Emitted when redeemer approves an account to redeem tokens on his behalf
-    event RedeemApproval(address indexed redeemer, address indexed trustee, uint256 amount);
+    /// @notice Emitted when the delegate rights are updated for an account
+    event DelegateUpdated(address indexed user, address indexed delegate, bool allowDelegate);
 
     /// @notice Thrown when collateral factor exceeds the upper bound
     error InvalidCollateralFactor();
@@ -218,17 +215,6 @@ contract Comptroller is
     function updateDelegate(address delegate, bool allowBorrows) external {
         approvedDelegates[msg.sender][delegate] = allowBorrows;
         emit DelegateUpdated(msg.sender, delegate, allowBorrows);
-    }
-
-    /**
-     * @notice Gives allowance to an account to redeem vTokens or underlying on behalf of the approver
-     * @param trustee The address of the trustee being approved for redemption.
-     * @param amount The amount of tokens approved for redemption.
-     * @custom:event RedeemApproval emits on success
-     */
-    function approveRedeem(address trustee, uint256 amount) external {
-        redeemAllowance[msg.sender][trustee] = amount;
-        emit RedeemApproval(msg.sender, trustee, amount);
     }
 
     /**

--- a/contracts/ComptrollerInterface.sol
+++ b/contracts/ComptrollerInterface.sol
@@ -118,6 +118,4 @@ interface ComptrollerViewInterface {
     function supplyCaps(address) external view returns (uint256);
 
     function approvedDelegates(address borrower, address receiver) external view returns (bool);
-
-    function redeemAllowance(address borrower, address receiver) external view returns (uint256);
 }

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -125,18 +125,14 @@ contract ComptrollerStorage {
     /// Prime token address
     IPrime public prime;
 
-    /// @notice Whether the delegate is allowed to borrow on behalf of the borrower
-    //mapping(address borrower => mapping (address delegate => bool approved)) public approvedDelegates;
+    /// @notice Whether the delegate is allowed to borrow or redeem on behalf of the user
+    //mapping(address user => mapping (address delegate => bool approved)) public approvedDelegates;
     mapping(address => mapping(address => bool)) public approvedDelegates;
-
-    /// @notice Whether the user is allowed to redeem on behalf of the redeemer
-    //mapping(address redeemer => mapping (address user => uint256 vTokenAmount)) public redeemAllowance;
-    mapping(address => mapping(address => uint256)) public redeemAllowance;
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[46] private __gap;
+    uint256[47] private __gap;
 }

--- a/contracts/ErrorReporter.sol
+++ b/contracts/ErrorReporter.sol
@@ -15,7 +15,6 @@ contract TokenErrorReporter {
 
     error RedeemFreshnessCheck();
     error RedeemTransferOutNotPossible();
-    error InsufficientRedeemApproval();
 
     error BorrowFreshnessCheck();
     error BorrowCashNotAvailable();

--- a/tests/hardhat/Tokens/borrowAndRepayTest.ts
+++ b/tests/hardhat/Tokens/borrowAndRepayTest.ts
@@ -231,7 +231,7 @@ describe("VToken", function () {
       );
     });
 
-    it("returns success from borrowFresh and transfers the correct amount", async () => {
+    it("returns success from borrowBehalf and transfers the correct amount", async () => {
       const beforeAccountCash = await underlying.balanceOf(trustee.address);
       comptroller.approvedDelegates.returns(true);
       await vToken.connect(trustee).borrowBehalf(borrower.address, borrowAmount);


### PR DESCRIPTION
This PR:

  - removes support for redemption allowances in favor of deletate (operator) contracts
  - adds tests for delegate redemptions
  - updates some natspecs so that they correspond with the declarations
