### PR TITLE
feat: migrate to 0.8.20

### DIFF
--- a/contracts/BaseJumpRateModelV2.sol
+++ b/contracts/BaseJumpRateModelV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IAccessControlManagerV8 } from "@venusprotocol/governance-contracts/contracts/Governance/IAccessControlManagerV8.sol";
 

--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { ResilientOracleInterface } from "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";

--- a/contracts/ComptrollerInterface.sol
+++ b/contracts/ComptrollerInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 import { ResilientOracleInterface } from "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";
 

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { ResilientOracleInterface } from "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";
 

--- a/contracts/ErrorReporter.sol
+++ b/contracts/ErrorReporter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /**
  * @title TokenErrorReporter

--- a/contracts/ExponentialNoError.sol
+++ b/contracts/ExponentialNoError.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { EXP_SCALE as EXP_SCALE_, MANTISSA_ONE as MANTISSA_ONE_ } from "./lib/constants.sol";
 

--- a/contracts/Gateway/INativeTokenGateway.sol
+++ b/contracts/Gateway/INativeTokenGateway.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/contracts/Gateway/Interfaces/IVToken.sol
+++ b/contracts/Gateway/Interfaces/IVToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 interface IVToken {
     function mintBehalf(address receiver, uint256 mintAmount) external returns (uint256);

--- a/contracts/Gateway/Interfaces/IWrappedNative.sol
+++ b/contracts/Gateway/Interfaces/IWrappedNative.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 interface IWrappedNative {
     function deposit() external payable;

--- a/contracts/IPancakeswapV2Router.sol
+++ b/contracts/IPancakeswapV2Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 interface IPancakeswapV2Router {
     function swapExactTokensForTokens(

--- a/contracts/InterestRateModel.sol
+++ b/contracts/InterestRateModel.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /**
  * @title Compound's InterestRateModel Interface

--- a/contracts/JumpRateModelV2.sol
+++ b/contracts/JumpRateModelV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IAccessControlManagerV8 } from "@venusprotocol/governance-contracts/contracts/Governance/IAccessControlManagerV8.sol";
 

--- a/contracts/Lens/PoolLens.sol
+++ b/contracts/Lens/PoolLens.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/MaxLoopsLimitHelper.sol
+++ b/contracts/MaxLoopsLimitHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /**
  * @title MaxLoopsLimitHelper

--- a/contracts/Pool/PoolRegistry.sol
+++ b/contracts/Pool/PoolRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/Pool/PoolRegistryInterface.sol
+++ b/contracts/Pool/PoolRegistryInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 /**
  * @title PoolRegistryInterface

--- a/contracts/Rewards/RewardsDistributor.sol
+++ b/contracts/Rewards/RewardsDistributor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/RiskFund/IRiskFund.sol
+++ b/contracts/RiskFund/IRiskFund.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 /**
  * @title IRiskFund

--- a/contracts/RiskFund/ReserveHelpers.sol
+++ b/contracts/RiskFund/ReserveHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/RiskFund/RiskFund.sol
+++ b/contracts/RiskFund/RiskFund.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/Shortfall/Shortfall.sol
+++ b/contracts/Shortfall/Shortfall.sol
@@ -1,5 +1,5 @@
 /// @notice  SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/VToken.sol
+++ b/contracts/VToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/VTokenInterfaces.sol
+++ b/contracts/VTokenInterfaces.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { ResilientOracleInterface } from "@venusprotocol/oracle/contracts/interfaces/OracleInterface.sol";

--- a/contracts/WhitePaperInterestRateModel.sol
+++ b/contracts/WhitePaperInterestRateModel.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { InterestRateModel } from "./InterestRateModel.sol";
 import { EXP_SCALE, MANTISSA_ONE } from "./lib/constants.sol";

--- a/contracts/lib/ApproveOrRevert.sol
+++ b/contracts/lib/ApproveOrRevert.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 

--- a/contracts/lib/TokenDebtTracker.sol
+++ b/contracts/lib/TokenDebtTracker.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/lib/constants.sol
+++ b/contracts/lib/constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity ^0.8.20;
 
 /// @dev Base unit for computations, usually used in scaling (multiplications, divisions)
 uint256 constant EXP_SCALE = 1e18;

--- a/contracts/lib/imports.sol
+++ b/contracts/lib/imports.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 // This file is needed to make hardhat and typechain generate artifacts for
 // contracts we depend on (e.g. in tests or deployments) but not use directly.

--- a/contracts/lib/validators.sol
+++ b/contracts/lib/validators.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 /// @notice Thrown if the supplied address is a zero address where it is not allowed
 error ZeroAddressNotAllowed();

--- a/contracts/test/HarnessMaxLoopsLimitHelper.sol
+++ b/contracts/test/HarnessMaxLoopsLimitHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { MaxLoopsLimitHelper } from "../MaxLoopsLimitHelper.sol";
 

--- a/contracts/test/MockDeflationaryToken.sol
+++ b/contracts/test/MockDeflationaryToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 contract MockDeflatingToken {
     string public constant NAME = "Deflating Test Token";

--- a/contracts/test/PrimeLiquidityProviderScenario.sol
+++ b/contracts/test/PrimeLiquidityProviderScenario.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { PrimeLiquidityProvider } from "@venusprotocol/venus-protocol/contracts/Tokens/Prime/PrimeLiquidityProvider.sol";
 

--- a/contracts/test/PrimeScenario.sol
+++ b/contracts/test/PrimeScenario.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { Prime } from "@venusprotocol/venus-protocol/contracts/Tokens/Prime/Prime.sol";
 import { IPrimeLiquidityProvider } from "@venusprotocol/venus-protocol/contracts/Tokens/Prime/Interfaces/IPrimeLiquidityProvider.sol";

--- a/contracts/test/lib/ApproveOrRevertHarness.sol
+++ b/contracts/test/lib/ApproveOrRevertHarness.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { ApproveOrRevert } from "../../lib/ApproveOrRevert.sol";

--- a/contracts/test/lib/ProtocolShareReserve.sol
+++ b/contracts/test/lib/ProtocolShareReserve.sol
@@ -1,2 +1,2 @@
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 import { ProtocolShareReserve } from "@venusprotocol/protocol-reserve/contracts/ProtocolReserve/ProtocolShareReserve.sol";

--- a/contracts/test/lib/TokenDebtTrackerHarness.sol
+++ b/contracts/test/lib/TokenDebtTrackerHarness.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.13;
+pragma solidity 0.8.20;
 
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { TokenDebtTracker } from "../../lib/TokenDebtTracker.sol";

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -146,7 +146,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.13",
+        version: "0.8.20",
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
This PR updates the pragma to:

* `^0.8.20` for interfaces, constants, etc.
* `0.8.20` for anything that contains code

Before merging, the dependencies have to be updated after https://github.com/VenusProtocol/solidity-utilities/pull/17, https://github.com/VenusProtocol/governance-contracts/pull/61, https://github.com/VenusProtocol/oracle/pull/173, and https://github.com/VenusProtocol/protocol-reserve/pull/78 are merged.