### PR TITLE
refactor: stop using BSC_BLOCKS_PER_YEAR in tests

### DIFF
--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -147,6 +147,7 @@ export enum InterestRateModels {
 
 const ANY_CONTRACT = ethers.constants.AddressZero;
 
+export const DEFAULT_BLOCKS_PER_YEAR = 10_512_000; // assuming a block is mined every 3 seconds
 export const BSC_BLOCKS_PER_YEAR = 10_512_000; // assuming a block is mined every 3 seconds
 export const ETH_BLOCKS_PER_YEAR = 2_628_000; // assuming a block is mined every 12 seconds
 export const OPBNB_BLOCKS_PER_YEAR = 31_536_000; // assuming a block is mined every 1 seconds
@@ -157,7 +158,7 @@ export type BlocksPerYear = {
 };
 
 export const blocksPerYear: BlocksPerYear = {
-  hardhat: BSC_BLOCKS_PER_YEAR,
+  hardhat: DEFAULT_BLOCKS_PER_YEAR,
   bsctestnet: BSC_BLOCKS_PER_YEAR,
   bscmainnet: BSC_BLOCKS_PER_YEAR,
   sepolia: ETH_BLOCKS_PER_YEAR,

--- a/tests/hardhat/JumpRateModelV2.ts
+++ b/tests/hardhat/JumpRateModelV2.ts
@@ -4,7 +4,7 @@ import BigNumber from "bignumber.js";
 import chai from "chai";
 import { ethers } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
 import { convertToUnit } from "../../helpers/utils";
 import { AccessControlManager, JumpRateModelV2 } from "../../typechain";
 import { getDescription } from "./util/descriptionHelpers";
@@ -27,7 +27,7 @@ for (const isTimeBased of [false, true]) {
   const jumpMultiplierPerYear = convertToUnit(2, 18);
 
   const description = getDescription(isTimeBased);
-  let slotsPerYear = isTimeBased ? 0 : BSC_BLOCKS_PER_YEAR;
+  let slotsPerYear = isTimeBased ? 0 : DEFAULT_BLOCKS_PER_YEAR;
 
   describe(`${description}Jump rate model tests`, async () => {
     const fixture = async () => {

--- a/tests/hardhat/Lens/PoolLens.ts
+++ b/tests/hardhat/Lens/PoolLens.ts
@@ -5,7 +5,7 @@ import { BigNumberish, Signer } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../../helpers/deploymentConfig";
 import {
   AccessControlManager,
   Beacon,
@@ -48,7 +48,7 @@ const assertVTokenMetadata = (vTokenMetadataActual: any, vTokenMetadataExpected:
 
 for (const isTimeBased of [false, true]) {
   const description = getDescription(isTimeBased);
-  const slotsPerYear = isTimeBased ? 0 : BSC_BLOCKS_PER_YEAR;
+  const slotsPerYear = isTimeBased ? 0 : DEFAULT_BLOCKS_PER_YEAR;
 
   describe(`${description}PoolLens`, async () => {
     let poolRegistry: PoolRegistry;

--- a/tests/hardhat/Lens/RewardsSummary.ts
+++ b/tests/hardhat/Lens/RewardsSummary.ts
@@ -4,7 +4,7 @@ import chai from "chai";
 import { BigNumber, Signer } from "ethers";
 import { ethers } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../../helpers/deploymentConfig";
 import { convertToUnit } from "../../../helpers/utils";
 import { Comptroller, MockToken, PoolLens, PoolLens__factory, RewardsDistributor, VToken } from "../../../typechain";
 import { getDescription } from "../util/descriptionHelpers";
@@ -28,7 +28,7 @@ let poolLens: MockContract<PoolLens>;
 let account: Signer;
 let startBlock: number;
 let isTimeBased = false; // for block based contracts
-let blocksPerYear = BSC_BLOCKS_PER_YEAR; // for block based contracts
+let blocksPerYear = DEFAULT_BLOCKS_PER_YEAR; // for block based contracts
 
 type RewardsFixtire = {
   comptroller: FakeContract<Comptroller>;

--- a/tests/hardhat/Rewards.ts
+++ b/tests/hardhat/Rewards.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
 import { convertToUnit } from "../../helpers/utils";
 import {
   AccessControlManager,
@@ -37,7 +37,7 @@ let xvs: MockToken;
 let fakePriceOracle: FakeContract<ResilientOracleInterface>;
 let fakeAccessControlManager: FakeContract<AccessControlManager>;
 const maxLoopsLimit = 150;
-let blocksPerYear = BSC_BLOCKS_PER_YEAR; // for block based contracts
+let blocksPerYear = DEFAULT_BLOCKS_PER_YEAR; // for block based contracts
 
 async function rewardsFixture(isTimeBased: boolean) {
   [root] = await ethers.getSigners();

--- a/tests/hardhat/Shortfall.ts
+++ b/tests/hardhat/Shortfall.ts
@@ -7,7 +7,7 @@ import { constants } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
 import { AddressOne, convertToUnit } from "../../helpers/utils";
 import {
   AccessControlManager,
@@ -49,7 +49,7 @@ let fakePriceOracle: FakeContract<ResilientOracleInterface>;
 const riskFundBalance = "10000";
 const minimumPoolBadDebt = "10000";
 let isTimeBased = false; // for block based contracts
-let blocksPerYear = BSC_BLOCKS_PER_YEAR; // for block based contracts
+let blocksPerYear = DEFAULT_BLOCKS_PER_YEAR; // for block based contracts
 let waitForFirstBidder = 100; // for block based contracts
 let nextBidderBlockOrTimestampLimit = 100; // for block based contracts
 let poolAddress;

--- a/tests/hardhat/TwoKinksInterestRateModel.ts
+++ b/tests/hardhat/TwoKinksInterestRateModel.ts
@@ -4,7 +4,7 @@ import BigNumber from "bignumber.js";
 import chai from "chai";
 import { ethers } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
 import { convertToUnit } from "../../helpers/utils";
 import { TwoKinksInterestRateModel } from "../../typechain";
 import { getDescription } from "./util/descriptionHelpers";
@@ -30,7 +30,7 @@ for (const isTimeBased of [false, true]) {
   const expScale = convertToUnit(1, 18);
 
   const description = getDescription(isTimeBased);
-  const slotsPerYear = isTimeBased ? 0 : BSC_BLOCKS_PER_YEAR;
+  const slotsPerYear = isTimeBased ? 0 : DEFAULT_BLOCKS_PER_YEAR;
 
   describe(`${description}Two Kinks Interest Rate Model Tests`, async () => {
     const fixture = async () => {

--- a/tests/hardhat/UpgradedVToken.ts
+++ b/tests/hardhat/UpgradedVToken.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
 import { convertToUnit } from "../../helpers/utils";
 import {
   AccessControlManager,
@@ -28,7 +28,7 @@ let fakeAccessControlManager: FakeContract<AccessControlManager>;
 
 for (const isTimeBased of [false, true]) {
   const description = getDescription(isTimeBased);
-  const slotsPerYear = isTimeBased ? 0 : BSC_BLOCKS_PER_YEAR;
+  const slotsPerYear = isTimeBased ? 0 : DEFAULT_BLOCKS_PER_YEAR;
 
   describe(`${description}UpgradedVToken: Tests`, function () {
     /**

--- a/tests/hardhat/WhitePaperInterestRateModel.ts
+++ b/tests/hardhat/WhitePaperInterestRateModel.ts
@@ -4,7 +4,7 @@ import BigNumber from "bignumber.js";
 import chai from "chai";
 import { ethers } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../helpers/deploymentConfig";
 import { convertToUnit } from "../../helpers/utils";
 import { WhitePaperInterestRateModel } from "../../typechain";
 import { getDescription } from "./util/descriptionHelpers";
@@ -22,7 +22,7 @@ for (const isTimeBased of [false, true]) {
   const baseRatePerYear = convertToUnit(2, 12);
   const multiplierPerYear = convertToUnit(4, 14);
   const description: string = getDescription(isTimeBased);
-  let slotsPerYear = isTimeBased ? 0 : BSC_BLOCKS_PER_YEAR;
+  let slotsPerYear = isTimeBased ? 0 : DEFAULT_BLOCKS_PER_YEAR;
 
   describe(`${description}White Paper interest rate model tests`, () => {
     const fixture = async () => {

--- a/tests/hardhat/util/TokenTestHelpers.ts
+++ b/tests/hardhat/util/TokenTestHelpers.ts
@@ -4,7 +4,7 @@ import { BaseContract, BigNumber, BigNumberish, Signer } from "ethers";
 import { parseUnits } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 
-import { BSC_BLOCKS_PER_YEAR } from "../../../helpers/deploymentConfig";
+import { DEFAULT_BLOCKS_PER_YEAR } from "../../../helpers/deploymentConfig";
 import {
   AccessControlManager,
   Comptroller,
@@ -77,7 +77,7 @@ export const deployVTokenBeacon = async <VTokenFactory extends AnyVTokenFactory 
   { kind }: { kind: string } = { kind: "VToken" },
   maxBorrowRateMantissa: BigNumberish = BigNumber.from(0.0005e16),
   isTimeBased: boolean = false,
-  blocksPerYear: BigNumberish = BSC_BLOCKS_PER_YEAR,
+  blocksPerYear: BigNumberish = DEFAULT_BLOCKS_PER_YEAR,
 ): Promise<UpgradeableBeacon> => {
   const VToken = await ethers.getContractFactory<VTokenFactory>(kind);
   const vTokenBeacon = (await upgrades.deployBeacon(VToken, {
@@ -116,10 +116,10 @@ const deployVTokenDependencies = async <VTokenFactory extends AnyVTokenFactory =
         { kind },
         params.maxBorrowRateMantissa || BigNumber.from(0.0005e16),
         params.isTimeBased || false,
-        params.blocksPerYear === undefined ? BSC_BLOCKS_PER_YEAR : params.blocksPerYear,
+        params.blocksPerYear === undefined ? DEFAULT_BLOCKS_PER_YEAR : params.blocksPerYear,
       )),
     isTimeBased: params.isTimeBased || false,
-    blocksPerYear: params.blocksPerYear === undefined ? BSC_BLOCKS_PER_YEAR : params.blocksPerYear,
+    blocksPerYear: params.blocksPerYear === undefined ? DEFAULT_BLOCKS_PER_YEAR : params.blocksPerYear,
   };
 };
 


### PR DESCRIPTION
Problem: Some of the tests rely on BSC_BLOCKS_PER_YEAR to be a constant value, e.g. rewards and interests in tests are computed under this assumption. Adjusting test cases for a different number of blocks per year every time this value is changed is an unnecessary overkill, since the logic itself doesn't depend on a particular value assumed by the test suite.

Solution: Introduce a separate constant, DEFAULT_BLOCKS_PER_YEAR, that should be used in tests going forward.