### PR TITLE
refactor: make "time-based" a property of the network

### DIFF
--- a/deploy/009-deploy-vtokens.ts
+++ b/deploy/009-deploy-vtokens.ts
@@ -23,7 +23,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const networkName = hre.getNetworkName();
   const { tokensConfig, poolConfig, preconfiguredAddresses } = await getConfig(networkName);
 
-  const { isTimeBased, blocksPerYear } = getBlockOrTimestampBasedDeploymentInfo(hre.network.name);
+  const { isTimeBased, blocksPerYear } = getBlockOrTimestampBasedDeploymentInfo(hre.getNetworkName());
   const maxBorrowRateMantissa = getMaxBorrowRateMantissa(hre.network.name);
 
   if (networkName === "bscmainnet" || networkName === "bsctestnet" || networkName === "hardhat") {

--- a/helpers/deploymentConfig.ts
+++ b/helpers/deploymentConfig.ts
@@ -56,10 +56,7 @@ export type DeploymentConfig = {
   preconfiguredAddresses: PreconfiguredAddresses;
 };
 
-export type DeploymentInfo = {
-  isTimeBased: boolean;
-  blocksPerYear: number;
-};
+export type DeploymentInfo = { isTimeBased: true; blocksPerYear: 0 } | { isTimeBased: false; blocksPerYear: number };
 
 type BidderDeploymentValues = {
   waitForFirstBidder: number;
@@ -153,30 +150,28 @@ export const ETH_BLOCKS_PER_YEAR = 2_628_000; // assuming a block is mined every
 export const OPBNB_BLOCKS_PER_YEAR = 63_072_000; // assuming a block is mined every 0.5 seconds
 export const SECONDS_PER_YEAR = 31_536_000; // seconds per year
 
-export type BlocksPerYear = {
-  [key: string]: number;
-};
+export type BlocksPerYear = number | "time-based";
 
-export const blocksPerYear: BlocksPerYear = {
-  hardhat: DEFAULT_BLOCKS_PER_YEAR,
+export const blocksPerYear: Record<string, BlocksPerYear> = {
+  hardhat: process.env.IS_TIME_BASED_DEPLOYMENT === "true" ? "time-based" : DEFAULT_BLOCKS_PER_YEAR,
   bsctestnet: BSC_BLOCKS_PER_YEAR,
   bscmainnet: BSC_BLOCKS_PER_YEAR,
   sepolia: ETH_BLOCKS_PER_YEAR,
   ethereum: ETH_BLOCKS_PER_YEAR,
   opbnbtestnet: OPBNB_BLOCKS_PER_YEAR,
   opbnbmainnet: OPBNB_BLOCKS_PER_YEAR,
-  arbitrumsepolia: 0, // for time based contracts
-  arbitrumone: 0, // for time based contracts
-  zksyncsepolia: 0, // for time based contracts
-  zksyncmainnet: 0, // for time based contracts
-  opsepolia: 0, // for time based contracts
-  opmainnet: 0, // for time based contracts
-  basesepolia: 0, // for time based contracts
-  basemainnet: 0, // for time based contracts
-  unichainsepolia: 0, // for time based contracts
-  unichainmainnet: 0, // for time based contracts
-  berachainbartio: 0, // for time based contracts
-  isTimeBased: 0, // for time based contracts
+  arbitrumsepolia: "time-based",
+  arbitrumone: "time-based",
+  zksyncsepolia: "time-based",
+  zksyncmainnet: "time-based",
+  opsepolia: "time-based",
+  opmainnet: "time-based",
+  basesepolia: "time-based",
+  basemainnet: "time-based",
+  unichainsepolia: "time-based",
+  unichainmainnet: "time-based",
+  berachainbartio: "time-based",
+  isTimeBased: "time-based",
 };
 
 export const SEPOLIA_MULTISIG = "0x94fa6078b6b8a26f0b6edffbe6501b22a10470fb";

--- a/helpers/deploymentUtils.ts
+++ b/helpers/deploymentUtils.ts
@@ -122,11 +122,11 @@ export const getUnregisteredRewardsDistributors = async (poolConfig: PoolConfig[
 };
 
 export const getBlockOrTimestampBasedDeploymentInfo = (network: string): DeploymentInfo => {
-  const isTimeBased = process.env.IS_TIME_BASED_DEPLOYMENT === "true";
-
-  const blocksPerYearKey = isTimeBased ? "isTimeBased" : network;
-
-  return { isTimeBased: isTimeBased, blocksPerYear: blocksPerYear[blocksPerYearKey] };
+  const blocksPerYear_ = blocksPerYear[network];
+  if (blocksPerYear_ === "time-based") {
+    return { isTimeBased: true, blocksPerYear: 0 };
+  }
+  return { isTimeBased: false, blocksPerYear: blocksPerYear_ };
 };
 
 export const skipMainnets = () => async (hre: HardhatRuntimeEnvironment) => {


### PR DESCRIPTION
Problem: Currently whether the deployment is time-based is defined by the environment variable. This is error-prone and requires us to support corner cases like having both `blocksPerYear` configured and `timeBased` flag set to true.

Solution: Make "time-based" a property of a particular network. For hardhat, support both modes based on the environment variable.