### PR TITLE
[VPD-151]: added scripts for prime score update

### DIFF
--- a/deploy/023-fetch-prime-users.ts
+++ b/deploy/023-fetch-prime-users.ts
@@ -1,0 +1,70 @@
+import { ethers } from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import fs from "fs";
+
+import { Prime, VToken, VToken__factory } from "../typechain";
+
+interface ScoreUpdate {
+    [key: string]: string[];
+}
+
+const fetchPrimeHolders = async (prime: Prime, fromBlock: number, toBlock: number): Promise<string[]> => {
+    const events = await prime.queryFilter(prime.filters.Mint(), fromBlock, toBlock);
+    const users = [];
+
+    for (const event of events) {
+        const user = event.args[0];
+        users.push(user);
+    }
+
+    return users;
+};
+
+const func: DeployFunction = async function () {
+
+
+    const prime: Prime = await ethers.getContract(`Prime`);
+    const primeHolders: string[] = [];
+    const scoreUpdates: ScoreUpdate = {};
+
+    const fromBlock = 20157699;
+    const toBlock = await ethers.provider.getBlockNumber();
+    const chunkSize = 1000;
+
+    let startBlock = fromBlock;
+
+    while (startBlock <= toBlock) {
+        const endBlock = Math.min(startBlock + chunkSize - 1, toBlock);
+        const users = await fetchPrimeHolders(prime, startBlock, endBlock);
+        primeHolders.push(...users);
+
+        console.log(`Fetched events from block ${startBlock} to ${endBlock}`);
+        startBlock = endBlock + 1;
+    }
+
+    const markets = await prime.getAllMarkets();
+
+    for (const market of markets) {
+
+        const vTokenFactory: VToken__factory = await ethers.getContractFactory("VToken");
+        const marketContract: VToken = await vTokenFactory.attach(market).connect(ethers.provider);
+
+        for (const user of primeHolders) {
+            const balance = await marketContract.balanceOf(user);
+            if (balance.gt(0)) {
+                scoreUpdates[user] = scoreUpdates[user] ? [...scoreUpdates[user], market] : [market];
+            }
+        }
+    }
+
+    console.log("********** Score Updates **********");
+    console.log(scoreUpdates);
+
+    fs.writeFileSync("prime-users.json", JSON.stringify(scoreUpdates, null, 2));
+};
+
+func.tags = ["fetch-prime-users"];
+func.skip = async (hre: HardhatRuntimeEnvironment) => !hre.network.live;
+
+export default func;

--- a/deploy/023-fetch-prime-users.ts
+++ b/deploy/023-fetch-prime-users.ts
@@ -2,8 +2,7 @@ import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import fs from "fs";
-
-import { Prime, VToken, VToken__factory } from "../typechain";
+import { Prime } from "../typechain";
 
 interface ScoreUpdate {
     [key: string]: string[];
@@ -22,18 +21,17 @@ const fetchPrimeHolders = async (prime: Prime, fromBlock: number, toBlock: numbe
 };
 
 const func: DeployFunction = async function () {
-
-
     const prime: Prime = await ethers.getContract(`Prime`);
     const primeHolders: string[] = [];
     const scoreUpdates: ScoreUpdate = {};
 
     const fromBlock = 20157699;
     const toBlock = await ethers.provider.getBlockNumber();
-    const chunkSize = 1000;
+    const chunkSize = 50_000; // nodereal support up to 50k block at 1 time 
 
     let startBlock = fromBlock;
 
+    // step 1: fetch all user who have minted prime token before 
     while (startBlock <= toBlock) {
         const endBlock = Math.min(startBlock + chunkSize - 1, toBlock);
         const users = await fetchPrimeHolders(prime, startBlock, endBlock);
@@ -42,26 +40,21 @@ const func: DeployFunction = async function () {
         console.log(`Fetched events from block ${startBlock} to ${endBlock}`);
         startBlock = endBlock + 1;
     }
+    console.log("Step 1: no. of prime holders with mint event", primeHolders.length);
 
-    const markets = await prime.getAllMarkets();
-
-    for (const market of markets) {
-
-        const vTokenFactory: VToken__factory = await ethers.getContractFactory("VToken");
-        const marketContract: VToken = await vTokenFactory.attach(market).connect(ethers.provider);
-
-        for (const user of primeHolders) {
-            const balance = await marketContract.balanceOf(user);
-            if (balance.gt(0)) {
-                scoreUpdates[user] = scoreUpdates[user] ? [...scoreUpdates[user], market] : [market];
-            }
+    // step 2: iterate through the list to filter if user is still prime 
+    const finalPrimeHolders: string[] = [];
+    for (const user of primeHolders) {
+        const isPrme = await prime.isUserPrimeHolder(user);
+        console.log(`is ${user} still prime? ${isPrme}`);
+        if (isPrme) {
+            finalPrimeHolders.push(user);
         }
     }
+    console.log("Step 2: no. of prime holders", finalPrimeHolders.length);
 
-    console.log("********** Score Updates **********");
-    console.log(scoreUpdates);
-
-    fs.writeFileSync("prime-users.json", JSON.stringify(scoreUpdates, null, 2));
+    // step 3: write to file 
+    fs.writeFileSync("prime-users.json", JSON.stringify(finalPrimeHolders, null, 2));
 };
 
 func.tags = ["fetch-prime-users"];

--- a/deploy/024-prime-update-scores.ts
+++ b/deploy/024-prime-update-scores.ts
@@ -1,0 +1,32 @@
+import { ethers } from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import fs from "fs";
+
+import { Prime } from "../typechain";
+
+
+const func: DeployFunction = async function () {
+    const prime: Prime = await ethers.getContract(`Prime`);
+
+    const ScoreUpdate = JSON.parse(fs.readFileSync("prime-users.json", "utf8"));
+    const primeUsers = Object.keys(ScoreUpdate);
+
+
+    // update every batchSize users
+    const batchSize = 50;
+    for (let i = 0; i < primeUsers.length; i += batchSize) {
+        const batch = primeUsers.slice(i, i + batchSize);
+
+        console.log(`Updating ${batch} users`);
+        const tx = await prime.updateScores(batch);
+        await tx.wait();
+        console.log(`Updated ${batch.length} users`);
+        console.log(`TX: ${tx.hash}`);
+    }
+};
+
+func.tags = ["prime-update-scores"];
+func.skip = async (hre: HardhatRuntimeEnvironment) => !hre.network.live;
+
+export default func;

--- a/deploy/024-prime-update-scores.ts
+++ b/deploy/024-prime-update-scores.ts
@@ -5,13 +5,11 @@ import fs from "fs";
 
 import { Prime } from "../typechain";
 
-
 const func: DeployFunction = async function () {
     const prime: Prime = await ethers.getContract(`Prime`);
 
-    const ScoreUpdate = JSON.parse(fs.readFileSync("prime-users.json", "utf8"));
-    const primeUsers = Object.keys(ScoreUpdate);
-
+    const primeUsers = JSON.parse(fs.readFileSync("prime-users.json", "utf8"));
+    console.log('prime users', primeUsers);
 
     // update every batchSize users
     const batchSize = 50;


### PR DESCRIPTION
## Description

This is the script for updating prime score as required after executing https://github.com/VenusProtocol/vips/pull/617/files
  
I've split it into 2 steps:
1. get all prime users
    - deploy/023-fetch-prime-users.ts (ref from https://github.com/VenusProtocol/isolated-pools/pull/421)
3. call `updateScores` for all those users
    - deploy/024-prime-update-scores.ts



## Steps
1. npx hardhat deploy --tags fetch-prime-users --network bscmainnet > output.log
2. npx hardhat deploy --tags prime-update-scores --network bscmainnet 